### PR TITLE
Remove publish config to use default

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
         "type": "git",
         "url": "git+https://github.com/LifeSG/react-design-system.git"
     },
-    "publishConfig": {
-        "registry": "https://npm.pkg.github.com"
-    },
     "keywords": [
         "design-system"
     ],


### PR DESCRIPTION
The previous registry specified is incorrect. While it is a legit registry, most people's registry are using the default one. This will result in them not being able to find the package when doing `npm ci`

- Ready to merge
- Delete branch