### PR TITLE
Remove spinner for number inputs

### DIFF
--- a/src/date-input/date-input.style.tsx
+++ b/src/date-input/date-input.style.tsx
@@ -70,17 +70,6 @@ export const InputContainer = styled.div`
     height: 100%;
     display: flex;
     align-items: center;
-
-    // Removal of arrow buttons for Mozilla Firefox
-    input[type="number"]::-webkit-outer-spin-button,
-    input[type="number"]::-webkit-inner-spin-button {
-        -webkit-appearance: none;
-        margin: 0;
-    }
-
-    input[type="number"] {
-        -moz-appearance: textfield;
-    }
 `;
 
 export const BaseInput = styled.input`
@@ -133,7 +122,6 @@ export const Divider = styled(Text.Body)<LabelStyleProps>`
 `;
 
 export const MonthDivider = styled(Divider)`
-    /* margin: 0.1rem 0.2rem 0 0.4rem; */
     ${(props) => {
         if (props.$compress) {
             return css`
@@ -170,27 +158,3 @@ export const MonthPlaceholder = styled(Placeholder)<LabelStyleProps>`
 export const YearPlaceholder = styled(Placeholder)<LabelStyleProps>`
     width: 3.5rem;
 `;
-
-// export const DayPlaceholderDivider = styled(Placeholder)`
-//     margin: 2px 2px 0 2px;
-
-//     ${(props) => {
-// 		if (props.compress) {
-// 			return css`
-//                 margin: 2px 1px 0 2px;
-//             `;
-// 		}
-// 	}}
-// `;
-
-// export const MonthPlaceholderDivider = styled(Placeholder)`
-//     margin: 2px 2px 0 2px;
-
-//     ${(props) => {
-// 		if (props.compress) {
-// 			return css`
-//                 margin: 2px -5px 0 2px;
-//             `;
-// 		}
-// 	}}
-// `;

--- a/src/input/input.style.tsx
+++ b/src/input/input.style.tsx
@@ -8,6 +8,7 @@ import { TextStyleHelper } from "../text/helper";
 interface InputStyleProps {
     error?: boolean;
     readOnly?: boolean;
+    type?: React.HTMLInputTypeAttribute;
 }
 
 // =============================================================================
@@ -36,6 +37,23 @@ export const InputElement = styled.input<InputStyleProps>`
     ::-webkit-input-placeholder {
         color: ${Color.Neutral[3]};
     }
+
+    ${(props) => {
+        // Hiding of spinners for number type input
+        if (props.type === "number") {
+            return css`
+                // Chrome, Safari, Edge, Opera
+                ::-webkit-outer-spin-button,
+                ::-webkit-inner-spin-button {
+                    -webkit-appearance: none;
+                    margin: 0;
+                }
+
+                // Firefox
+                -moz-appearance: textfield;
+            `;
+        }
+    }}
 
     ${(props) => {
         if (props.readOnly) {


### PR DESCRIPTION
- Remove the spinner by default for `number` type input
- Also clean up unused styles on `DateInput`

**Additional Info**
- This was reported as a bug as mentioned in this [ticket](https://jira.ship.gov.sg/browse/MOL-11474)