### PR TITLE
Fix modal height on iOS

### DIFF
--- a/src/modal/modal.styles.tsx
+++ b/src/modal/modal.styles.tsx
@@ -6,6 +6,7 @@ interface Props {
     show: boolean;
     animationFrom?: ModalAnimationDirection;
     verticalHeight?: number;
+    offsetTop?: number;
 }
 
 const visibilityStyle = (
@@ -38,19 +39,14 @@ export const Container = styled.div<Props>`
     overflow: hidden;
     ${(props) => visibilityStyle(props.show, props.animationFrom || "bottom")}
 
-    ${(props) => {
-        if (props.verticalHeight) {
-            return css`
-                ${MediaQuery.MaxWidth.mobileL} {
-                    height: calc(${props.verticalHeight}px * 100);
-                }
-            `;
-        } else {
-            return css`
-                ${MediaQuery.MaxWidth.mobileL} {
-                    height: calc(1vh * 100);
-                }
-            `;
-        }
-    }}
+    ${MediaQuery.MaxWidth.mobileL} {
+        height: calc(
+            ${(props) =>
+                    props.verticalHeight
+                        ? `${props.verticalHeight}px`
+                        : "1vh"} * 100
+        );
+
+        top: ${(props) => props.offsetTop || 0}px;
+    }
 `;

--- a/src/modal/modal.tsx
+++ b/src/modal/modal.tsx
@@ -12,12 +12,14 @@ export const Modal = ({
     rootComponentId,
     zIndex,
     onOverlayClick,
+    dismissKeyboardOnShow = true,
     ...otherProps
 }: ModalProps): JSX.Element => {
     // =============================================================================
     // CONST, STATE, REF
     // =============================================================================
     const [verticalHeight, setVerticalHeight] = useState<number>();
+    const [offsetTop, setOffsetTop] = useState<number>();
 
     // =============================================================================
     // EFFECTS
@@ -48,6 +50,13 @@ export const Modal = ({
         }
     }, []);
 
+    useEffect(() => {
+        if (show && dismissKeyboardOnShow) {
+            // dismiss software keyboard to put modal in fullscreen
+            (document.activeElement as HTMLElement)?.blur?.();
+        }
+    }, [show]);
+
     // =============================================================================
     // EVENT HANDLERS
     // =============================================================================
@@ -59,6 +68,7 @@ export const Modal = ({
     const handleViewportResize = () => {
         const newVerticalHeight = window.visualViewport.height * 0.01;
         setVerticalHeight(newVerticalHeight);
+        setOffsetTop(window.visualViewport.offsetTop);
     };
 
     // =============================================================================
@@ -79,6 +89,7 @@ export const Modal = ({
                 animationFrom={animationFrom}
                 data-testid={id}
                 verticalHeight={verticalHeight}
+                offsetTop={offsetTop}
                 {...otherProps}
             >
                 {children}

--- a/src/modal/modal.tsx
+++ b/src/modal/modal.tsx
@@ -24,19 +24,40 @@ export const Modal = ({
     // =============================================================================
     useEffect(() => {
         //set initial vh
-        setVerticalHeight(window.innerHeight * 0.01);
-        window.addEventListener("resize", handleResize);
 
-        return () => {
-            window.removeEventListener("resize", handleResize);
-        };
+        // use VisualViewport API if available, it gives more accurate dimensions when iOS software keyboard is active
+        if (window.visualViewport) {
+            handleViewportResize();
+            window.visualViewport.addEventListener(
+                "resize",
+                handleViewportResize
+            );
+            return () => {
+                window.visualViewport.removeEventListener(
+                    "resize",
+                    handleViewportResize
+                );
+            };
+        } else {
+            // fallback to Window API
+            handleWindowResize();
+            window.addEventListener("resize", handleWindowResize);
+            return () => {
+                window.removeEventListener("resize", handleWindowResize);
+            };
+        }
     }, []);
 
     // =============================================================================
     // EVENT HANDLERS
     // =============================================================================
-    const handleResize = () => {
+    const handleWindowResize = () => {
         const newVerticalHeight = window.innerHeight * 0.01;
+        setVerticalHeight(newVerticalHeight);
+    };
+
+    const handleViewportResize = () => {
+        const newVerticalHeight = window.visualViewport.height * 0.01;
         setVerticalHeight(newVerticalHeight);
     };
 

--- a/src/modal/types.ts
+++ b/src/modal/types.ts
@@ -12,6 +12,8 @@ export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
     rootComponentId?: string | undefined;
     zIndex?: number | undefined;
     onOverlayClick?: () => void | undefined;
+    /** Dismiss keyboard to keep modal in fullscreen */
+    dismissKeyboardOnShow?: boolean;
 }
 
 export interface ModalBoxProps extends React.HTMLAttributes<HTMLDivElement> {


### PR DESCRIPTION
**Changes**
Description of changes...

- Use the `window.visualViewport` api to calculate the currently visible screen height, as iOS handles it weirdly with the soft keyboard (ref: https://rdavis.io/articles/dealing-with-the-visual-viewport). Falls back to the existing `window.innerHeight` for older browser support.
- Dismiss the keyboard when modal is shown to keep it full screen. This behaviour can be opted out of with the `dismissKeyboardOnShow` prop.
- delete branch

<!-- Remove if not required -->
**Changelog entry**

- Fix modal height calculation on iOS when the software keyboard is visible or dismissed

**Additional information**

- You may refer to this [ticket](https://jira.ship.gov.sg/browse/MOL-11034)
- Ideally we should use the [VirtualKeyboard api](https://caniuse.com/mdn-api_virtualkeyboard) and [new viewport units](https://caniuse.com/viewport-unit-variants), but support is still spotty across major browsers