### PR TITLE
Improve breadcrumb fade specification

### DIFF
--- a/src/breadcrumb/breadcrumb.tsx
+++ b/src/breadcrumb/breadcrumb.tsx
@@ -10,7 +10,7 @@ import {
     PreviousLink,
     Wrapper,
 } from "./breadcrumb.style";
-import { BreadcrumbProps } from "./types";
+import { BreadcrumbProps, FadeColorSet } from "./types";
 
 export const Breadcrumb = ({
     links,
@@ -137,13 +137,35 @@ export const Breadcrumb = ({
     };
 
     const renderFade = () => {
+        let fadeColorSet: FadeColorSet;
+
+        if (Array.isArray(fadeColor)) {
+            fadeColorSet = {
+                left: fadeColor,
+                right: fadeColor,
+            };
+        } else if (fadeColor === undefined) {
+            fadeColorSet = {
+                left: undefined,
+                right: undefined,
+            };
+        } else {
+            fadeColorSet = fadeColor;
+        }
+
         return (
             <>
                 {showFadeLeft && (
-                    <Fade $backgroundColor={fadeColor} $position="left" />
+                    <Fade
+                        $backgroundColor={fadeColorSet.left}
+                        $position="left"
+                    />
                 )}
                 {showFadeRight && (
-                    <Fade $backgroundColor={fadeColor} $position="right" />
+                    <Fade
+                        $backgroundColor={fadeColorSet.right}
+                        $position="right"
+                    />
                 )}
             </>
         );

--- a/src/breadcrumb/types.ts
+++ b/src/breadcrumb/types.ts
@@ -1,8 +1,13 @@
 export type FadePosition = "left" | "right" | "both";
 
+export interface FadeColorSet {
+    left?: string[] | undefined;
+    right?: string[] | undefined;
+}
+
 export interface BreadcrumbProps {
     links: React.AnchorHTMLAttributes<HTMLAnchorElement>[];
-    fadeColor?: string[] | undefined;
+    fadeColor?: string[] | FadeColorSet | undefined;
     fadePosition?: FadePosition | undefined;
     itemStyle?: string | undefined;
     id?: string | undefined;

--- a/stories/breadcrumb/breadcrumb.stories.mdx
+++ b/stories/breadcrumb/breadcrumb.stories.mdx
@@ -55,6 +55,58 @@ import { Breadcrumb } from "@lifesg/react-design-system/breadcrumb";
     </Story>
 </Canvas>
 
+<Secondary>Customising the fade color</Secondary>
+
+> Note that the fade effect appears only if the `Breadcrumbs` are compressed and
+> becomes scrollable
+
+<br />
+
+<Heading3>Different fade colors</Heading3>
+
+You can specify different fade colors on both ends of the `Breadcrumb` or even
+on one side.
+
+<Preview>
+    <Story name="Different fade colors">
+        <Breadcrumb
+            links={[
+                {
+                    children: "Home",
+                    href: "https://life.gov.sg",
+                    target: "_blank",
+                    rel: "noreferrer",
+                },
+                {
+                    children: "Breadcrumb without url",
+                },
+                {
+                    children: "Normal breadcrumb",
+                    href: "https://life.gov.sg",
+                    target: "_blank",
+                    rel: "noreferrer",
+                },
+                {
+                    children: "Breadcrumb with a callback function",
+                    href: "https://life.gov.sg",
+                    onClick: (event) => {
+                        event.preventDefault();
+                        alert("I got clicked");
+                    },
+                },
+                {
+                    children: "Last breadcrumb (unclickable)",
+                    href: "https://www.google.com", // Unclickable even if you pass a url
+                },
+            ]}
+            fadeColor={{
+                left: ["red", "orange"],
+                right: ["blue", "green"],
+            }}
+        />
+    </Story>
+</Preview>
+
 <Secondary>Component API</Secondary>
 
 <PropsTable />

--- a/stories/breadcrumb/props-table.tsx
+++ b/stories/breadcrumb/props-table.tsx
@@ -1,18 +1,15 @@
 import React from "react";
-import {
-    DefaultCol,
-    DescriptionCol,
-    NameCol,
-    Section,
-    Table,
-} from "../storybook-common/api-table";
+import { ApiTable } from "../storybook-common/api-table";
+import { ApiTableSectionProps } from "../storybook-common/api-table/types";
 
-export const PropsTable = () => (
-    <Table>
-        <tr>
-            <NameCol mandatory>links</NameCol>
-            <DescriptionCol
-                propTypes={
+const DATA: ApiTableSectionProps[] = [
+    {
+        attributes: [
+            {
+                name: "links",
+                mandatory: true,
+                description: "The links for the breadcrumbs",
+                propTypes: (
                     <a
                         href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement"
                         target="_blank"
@@ -20,80 +17,73 @@ export const PropsTable = () => (
                     >
                         HTMLAnchorElement
                     </a>
-                }
-            >
-                The links for the breadcrumbs
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-        <tr>
-            <NameCol>fadeColor</NameCol>
-            <DescriptionCol propTypes={["string[]"]}>
-                When the breadcrumbs are too long, there will be a fade effect
-                at the ends of the breadcrumb. This will control the color of
-                the fade.
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-        <tr>
-            <NameCol>fadePosition</NameCol>
-            <DescriptionCol propTypes={[`"left"`, `"right"`]}>
-                When the breadcrumbs are too long, there will be a fade effect
-                at the ends of the breadcrumb. This will control the color of
-                the fade.
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-        <tr>
-            <NameCol>itemStyle</NameCol>
-            <DescriptionCol propTypes={["CSS-JS string"]}>
-                Custom style that can be passed to the Breadcrumb items
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-        <tr>
-            <NameCol>id</NameCol>
-            <DescriptionCol propTypes={["string"]}>
-                A unique identifier for each Breadcrumb item
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-        <tr>
-            <NameCol>data-testid</NameCol>
-            <DescriptionCol propTypes={["string"]}>
-                The id used for testing purposes
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-    </Table>
-);
+                ),
+            },
+            {
+                name: "fadeColor",
+                description: (
+                    <>
+                        When the breadcrumbs are too long, there will be a fade
+                        effect at the ends of the breadcrumb. This will control
+                        the color of the fade.
+                    </>
+                ),
+                propTypes: ["string[]", "FadeColorSet"],
+            },
+            {
+                name: "fadePosition",
+                description: (
+                    <>
+                        When the breadcrumbs are too long, there will be a fade
+                        effect at the ends of the breadcrumb. This will control
+                        the color of the fade.
+                    </>
+                ),
+                propTypes: [`"left"`, `"right"`, `"both"`],
+                defaultValue: `"both"`,
+            },
+            {
+                name: "itemStyle",
+                description: (
+                    <>
+                        Custom style that can be passed to the
+                        <code>Breadcrumb</code> items
+                    </>
+                ),
+                propTypes: ["CSS-JS string"],
+            },
+            {
+                name: "id",
+                description: (
+                    <>
+                        A unique identifier for each <code>Breadcrumb</code>
+                        &nbsp;item
+                    </>
+                ),
+                propTypes: ["string"],
+            },
+            {
+                name: "data-testid",
+                description: "The id used for testing purposes",
+                propTypes: ["string"],
+            },
+        ],
+    },
+    {
+        name: "FadeColorSet",
+        attributes: [
+            {
+                name: "left",
+                description: "The color of the left fade",
+                propTypes: ["string[]"],
+            },
+            {
+                name: "right",
+                description: "The color of the right fade",
+                propTypes: ["string[]"],
+            },
+        ],
+    },
+];
 
-export const AccordionItemPropsTable = () => (
-    <Table>
-        <tr>
-            <NameCol mandatory>children</NameCol>
-            <DescriptionCol propTypes={["JSX.Element", "JSX.Element[]"]}>
-                The content of the Accordion.Item
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-        <tr>
-            <NameCol>actionLink</NameCol>
-            <DescriptionCol
-                propTypes={
-                    <a
-                        href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement"
-                        target="_blank"
-                        rel="noreferrer"
-                    >
-                        <code>HTMLAnchorAttributes</code>
-                    </a>
-                }
-            >
-                The attributes of an action link that performs an action on
-                click
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-    </Table>
-);
+export const PropsTable = () => <ApiTable sections={DATA} />;

--- a/stories/text/collection-doc-elements.tsx
+++ b/stories/text/collection-doc-elements.tsx
@@ -167,7 +167,7 @@ const SpecValueLabel = styled(Text.BodySmall)`
 `;
 
 const FontSpecLabelContainer = styled.div`
-    width: 7rem;
+    width: 8rem;
     margin-right: 1rem;
     ${TextStyleHelper.getTextStyle("BodySmall", "semibold")}
 


### PR DESCRIPTION
**Changes**
Improve fade specification by allowing user to specify the left and right colour set. Currently only allow specifying a single colour set that applies to both sides. This is helpful in cases where the background is not a single colour.

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Allow specifying different fade colors for `Breadcrumb`

**Additional information**

- You may refer to this [ticket](https://jira.ship.gov.sg/browse/MOL-11243)
