### PR TITLE
[MOL-11592][EK] Extracted the Bubble used in Popover as a stand-alone component.

### DIFF
--- a/src/card/card.style.tsx
+++ b/src/card/card.style.tsx
@@ -1,0 +1,12 @@
+import { Color } from "src/color";
+import styled from "styled-components";
+
+// =============================================================================
+// STYLING
+// =============================================================================
+export const StyledCard = styled.div`
+    border-radius: 8px;
+    background: ${Color.Neutral[8]};
+    padding: 1rem 2rem;
+    box-shadow: 0 2px 8px 0 rgba(104, 104, 104, 0.24);
+`;

--- a/src/card/card.tsx
+++ b/src/card/card.tsx
@@ -1,0 +1,26 @@
+import { Text } from "../text/text";
+import { StyledCard } from "./card.style";
+import { CardProps } from "./types";
+
+export const Card = ({ children, ...otherProps }: CardProps): JSX.Element => {
+    // =============================================================================
+    // CONST, STATE, REF
+    // =============================================================================
+    const testId = otherProps["data-testid"] || "card";
+
+    // =============================================================================
+    // RENDER FUNCTIONS
+    // =============================================================================
+    const renderContent = () =>
+        typeof children === "string" ? (
+            <Text.Body>{children}</Text.Body>
+        ) : (
+            children
+        );
+
+    return (
+        <StyledCard {...otherProps} data-testid={testId}>
+            {renderContent()}
+        </StyledCard>
+    );
+};

--- a/src/card/index.ts
+++ b/src/card/index.ts
@@ -1,0 +1,1 @@
+export * from "./card";

--- a/src/card/types.ts
+++ b/src/card/types.ts
@@ -1,0 +1,3 @@
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+    "data-testid"?: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from "./animations";
 export * from "./box-container";
 export * from "./breadcrumb";
 export * from "./button";
+export * from "./card";
 export * from "./checkbox";
 export * from "./color";
 export * from "./date-input";

--- a/src/popover/popover.styles.tsx
+++ b/src/popover/popover.styles.tsx
@@ -1,5 +1,4 @@
 import styled, { css } from "styled-components";
-import { Color } from "../color";
 import { MediaQuery } from "../media";
 import { ModalBox } from "../modal/modal-box";
 import { Transition } from "../transition";
@@ -95,11 +94,7 @@ const getBubblePosition = (offset: OffsetPosition) => {
     }
 };
 
-export const Bubble = styled.div<PopoverStyleProps>`
-    border-radius: 8px;
-    background: ${Color.Neutral[8]};
-    padding: 1rem 2rem;
-    box-shadow: 0 2px 8px 0 rgba(104, 104, 104, 0.24);
+export const BubbleWrap = styled.div<PopoverStyleProps>`
     max-width: 30rem;
     pointer-events: auto;
     position: absolute;

--- a/src/popover/popover.tsx
+++ b/src/popover/popover.tsx
@@ -1,10 +1,11 @@
 import debounce from "lodash/debounce";
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useMediaQuery } from "react-responsive";
+import { Card } from "src/card";
 import { Modal } from "../modal/modal";
 import { MediaWidths } from "../spec/media-spec";
 import { Text } from "../text/text";
-import { Bubble, MobileModalBox, OffsetPosition } from "./popover.styles";
+import { BubbleWrap, MobileModalBox, OffsetPosition } from "./popover.styles";
 import { PopoverProps } from "./types";
 
 export const Popover = ({
@@ -121,25 +122,24 @@ export const Popover = ({
     // =============================================================================
     // RENDER FUNCTIONS
     // =============================================================================
-    const renderContent = () => {
-        if (typeof children === "string") {
-            return <Text.BodySmall>{children}</Text.BodySmall>;
-        }
-
-        return children;
-    };
+    const renderContent = () =>
+        typeof children === "string" ? (
+            <Text.BodySmall>{children}</Text.BodySmall>
+        ) : (
+            children
+        );
 
     return (
         <>
-            <Bubble
+            <BubbleWrap
                 ref={bubbleRef}
                 data-testid={testId}
                 $visible={visible}
                 $offset={offset}
                 {...otherProps}
             >
-                {renderContent()}
-            </Bubble>
+                <Card>{renderContent()}</Card>
+            </BubbleWrap>
             {isMobile && (
                 <Modal show={visible} onOverlayClick={handleMobileClose}>
                     <MobileModalBox onClose={handleMobileClose}>

--- a/src/tooltip/tooltip.styles.tsx
+++ b/src/tooltip/tooltip.styles.tsx
@@ -1,3 +1,4 @@
+import { Card } from "src/card";
 import styled, { css } from "styled-components";
 import { Color } from "../color";
 import { MediaQuery } from "../media";
@@ -95,16 +96,18 @@ const getBubblePositionStyle = (position: TooltipPosition) => {
     }
 };
 
-export const Bubble = styled.div<TooltipStyleProps>`
+export const BubbleWrap = styled.div<TooltipStyleProps>`
     position: absolute;
-    padding: 1rem 2rem;
-    border-radius: 4px;
-    background: ${Color.Neutral[8]};
-    box-shadow: 3px 2px 10px 1px rgba(91, 91, 91, 0.2);
     max-width: 30rem;
+    pointer-events: auto;
+
     ${(props) => getBubblePositionStyle(props.position)}
     ${(props) => getVisibilityStyle(props.visible)}
-	pointer-events: auto;
+`;
+
+export const Bubble = styled(Card)`
+    border-radius: 4px;
+    box-shadow: 3px 2px 10px 1px rgba(91, 91, 91, 0.2);
 `;
 
 export const Arrow = styled.div<TooltipStyleProps>`

--- a/src/tooltip/tooltip.tsx
+++ b/src/tooltip/tooltip.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import debounce from "lodash/debounce";
 import { Text } from "../text/text";
-import { Arrow, Bubble } from "./tooltip.styles";
+import { Arrow, Bubble, BubbleWrap } from "./tooltip.styles";
 import { TooltipPosition, TooltipProps } from "./types";
 
 export const Tooltip = ({
@@ -82,24 +82,23 @@ export const Tooltip = ({
     // RENDER FUNCTIONS
     // =============================================================================
 
-    const renderContent = () => {
-        if (typeof children === "string") {
-            return <Text.BodySmall>{children}</Text.BodySmall>;
-        }
-
-        return children;
-    };
+    const renderContent = () =>
+        typeof children === "string" ? (
+            <Text.BodySmall>{children}</Text.BodySmall>
+        ) : (
+            children
+        );
 
     return (
-        <Bubble
+        <BubbleWrap
             position={currPosition}
             data-testid={testId}
             visible={visible}
             ref={bubbleRef}
             {...otherProps}
         >
-            {renderContent()}
+            <Bubble>{renderContent()}</Bubble>
             <Arrow position={currPosition} />
-        </Bubble>
+        </BubbleWrap>
     );
 };

--- a/stories/card/card.stories.mdx
+++ b/stories/card/card.stories.mdx
@@ -1,0 +1,77 @@
+import { Canvas, Meta, Preview, Story } from "@storybook/addon-docs";
+import { Heading3, Secondary, Title } from "../storybook-common";
+import { Button } from "src/button";
+import { Card } from "src/card";
+import { Icon } from "src/icon";
+import { IconButton } from "src/icon-button";
+import { Layout } from "src/layout";
+import { Text } from "src/text";
+import { PropsTable } from "./props-table";
+import { StyledIcon } from "../icon/doc-elements";
+
+<Meta title="Modules/Card" component={Card} />
+
+<Title>Card</Title>
+
+<Secondary>Overview</Secondary>
+
+A component that has rounded corners and box shadow and can have any contents.
+Can be used stand-alone or as part of other components (e.g. Popover, Tooltip).
+
+```tsx
+import { Card } from "@lifesg/react-design-system/card";
+```
+
+<Canvas>
+    <Story name="Card">
+        <Card>
+            This is a Card with a string as its children. A default styling of
+            Text.Body is applied to the string.
+        </Card>
+    </Story>
+</Canvas>
+
+<Heading3>Custom Content</Heading3>
+
+Other than a `string`, the `Card` also accepts a `JSX.Element` as its `children`.
+The child `JSX.Element` is unaltered and is simply wrapped by the `Card`.
+
+<Preview>
+    <Story name="Custom content">
+        <Card>
+            <div
+                style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                }}
+            >
+                <StyledIcon type="alert" />
+                <Text.BodySmall>
+                    This is a Card with a JSX.Element as its children.
+                </Text.BodySmall>
+                <Button.Small>Click me</Button.Small>
+            </div>
+        </Card>
+    </Story>
+</Preview>
+
+<Heading3>Customising the style</Heading3>
+
+You can customize/override the style of the `Card` component by extending it:
+
+```tsx
+import { Card } from "@lifesg/react-design-system/card";
+import styled from "styled-components";
+
+export const StyledCard = styled(Card)`
+    border-radius: 4px;
+    padding: 1rem 2rem;
+    max-width: 30rem;
+    /* Other CSS properties... */
+`;
+```
+
+<Secondary>Component API</Secondary>
+
+<PropsTable />

--- a/stories/card/props-table.tsx
+++ b/stories/card/props-table.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { ApiTable } from "../storybook-common/api-table";
+import { ApiTableSectionProps } from "../storybook-common/api-table/types";
+
+const DATA: ApiTableSectionProps[] = [
+    {
+        attributes: [
+            {
+                name: "children",
+                description: "The contents of the bubble",
+                propTypes: ["string", "JSX.Element"],
+            },
+        ],
+    },
+];
+
+export const PropsTable = () => <ApiTable sections={DATA} />;

--- a/stories/popover/popover.stories.mdx
+++ b/stories/popover/popover.stories.mdx
@@ -148,6 +148,6 @@ import { Popover } from "@lifesg/react-design-system/popover";
 withPopover(component: JSX.Element, options: PopoverHOCOptionsProps): (props: PopoverHOCProps) => JSX.Element
 ```
 
-The derived HOC component has it's own set of props that are typed under `PopoverHOCProps`
+The derived HOC component has its own set of props that are typed under `PopoverHOCProps`
 
 <PropsTable />


### PR DESCRIPTION
**Changes**
Extracted the Bubble used in Popover as a stand-alone component, so that it can be reused.
[MOL-11592 requires the addition of a bubble (similar to the one in Popover) in the map modal (location picker) in mol-frontend-engine.]

- delete branch


**Additional information**
Things to consider:
- What should be the default styling (padding, font size, etc.)? Currently following the bubble for the map modal.
- Should the component have a different name (e.g. Card)?
- Any additional functionality needed for this Bubble component?
- Will add a commit to increase the patch version and update the changelog after all changes are finalized.