### PR TITLE
Fix unit number input format clash

### DIFF
--- a/src/unit-number/types.ts
+++ b/src/unit-number/types.ts
@@ -5,11 +5,11 @@ export interface UnitNumberInputProps extends React.AriaAttributes {
     style?: React.CSSProperties | undefined;
     tabIndex?: number | undefined;
     "data-testid"?: string | undefined;
-    readOnly?: boolean;
-    placeholder?: string;
+    readOnly?: boolean | undefined;
+    placeholder?: string | undefined;
 
     // WAI-ARIA
-    role?: string;
+    role?: string | undefined;
 
     // Input-specific Attributes
     value?: string | undefined;

--- a/src/unit-number/unit-number-input.tsx
+++ b/src/unit-number/unit-number-input.tsx
@@ -22,7 +22,7 @@ export const UnitNumberInput = ({
     onChangeRaw,
     onBlurRaw,
     readOnly,
-    placeholder,
+    placeholder = "00-8888",
     ...otherProps
 }: UnitNumberInputProps) => {
     // =============================================================================
@@ -191,11 +191,12 @@ export const UnitNumberInput = ({
     const updateValues = (value: string | undefined) => {
         if (value === INVALID_VALUE) {
             return;
-        }
-
-        if (!(value === undefined || value.length === 0)) {
+        } else if (value === undefined || value.length === 0) {
+            setFloorValue("");
+            setUnitValue("");
+        } else {
             const valueArr = value.split("-");
-            if (valueArr.length !== 0) {
+            if (valueArr.length === 2) {
                 // Valid value
                 const floor = valueArr[0];
                 const unit = valueArr[1];
@@ -206,9 +207,6 @@ export const UnitNumberInput = ({
                     currentFocus === "unit" ? unit : formatInput(unit)
                 );
             }
-        } else {
-            setFloorValue("");
-            setUnitValue("");
         }
     };
 
@@ -267,13 +265,8 @@ export const UnitNumberInput = ({
         }
     };
 
-    const getPlaceholder = (value: string | undefined) => {
-        if (value === undefined || value === "") {
-            return ["00", "8888"];
-        } else {
-            const valueArr = value.split("-");
-            return valueArr;
-        }
+    const getPlaceholder = (value: string) => {
+        return value.split("-");
     };
 
     // =============================================================================

--- a/src/unit-number/unit-number-input.tsx
+++ b/src/unit-number/unit-number-input.tsx
@@ -99,7 +99,7 @@ export const UnitNumberInput = ({
     }, [floorValue]);
 
     useEffect(() => {
-        formatDisplayValues(value);
+        updateValues(value);
     }, [value]);
 
     // =============================================================================
@@ -188,69 +188,70 @@ export const UnitNumberInput = ({
             : value.toLocaleUpperCase();
     };
 
-    const formatDisplayValues = (value: string | undefined) => {
-        if (value === undefined || value === "") {
-            setFloorValue("");
-            setUnitValue("");
-        } else {
+    const updateValues = (value: string | undefined) => {
+        if (value === INVALID_VALUE) {
+            return;
+        }
+
+        if (!(value === undefined || value.length === 0)) {
             const valueArr = value.split("-");
             if (valueArr.length !== 0) {
                 // Valid value
                 const floor = valueArr[0];
                 const unit = valueArr[1];
-
-                setFloorValue(formatInput(floor));
-                setUnitValue(formatInput(unit));
+                setFloorValue(
+                    currentFocus === "floor" ? floor : formatInput(floor)
+                );
+                setUnitValue(
+                    currentFocus === "unit" ? unit : formatInput(unit)
+                );
             }
+        } else {
+            setFloorValue("");
+            setUnitValue("");
         }
     };
 
     const performOnChangeHandler = (changeValue: string, field: FieldType) => {
+        if (!onChange && !onChangeRaw) {
+            return;
+        }
+
+        const values: Record<ValueFieldTypes, string> = {
+            floor: floorValueStateRef.current,
+            unit: unitValueStateRef.current,
+        };
+
+        // Update the specific field value
+        values[field] = changeValue;
+
         if (onChange) {
-            const values: Record<ValueFieldTypes, string> = {
-                floor: floorValue,
-                unit: unitValue,
-            };
-
-            // Update the specific field value
-            values[field] = changeValue;
-
             const returnValue = getFormattedValue(values);
             onChange(returnValue);
         }
 
         if (onChangeRaw) {
-            const valuesArr = [
-                ...(field === "floor"
-                    ? [formatInput(changeValue)]
-                    : [floorValue]),
-                ...(field === "unit"
-                    ? [formatInput(changeValue)]
-                    : [unitValue]),
-            ];
-
-            onChangeRaw(valuesArr);
+            onChangeRaw([values.floor, values.unit]);
         }
     };
 
     const performOnBlurHandler = () => {
-        if (onBlur) {
-            const values: Record<ValueFieldTypes, string> = {
-                floor: floorValueStateRef.current,
-                unit: unitValueStateRef.current,
-            };
+        if (!onBlur && !onBlurRaw) {
+            return;
+        }
 
+        const values: Record<ValueFieldTypes, string> = {
+            floor: formatInput(floorValueStateRef.current),
+            unit: formatInput(unitValueStateRef.current),
+        };
+
+        if (onBlur) {
             const returnValue = getFormattedValue(values);
             onBlur(returnValue);
         }
 
         if (onBlurRaw) {
-            const valuesArr = [
-                formatInput(floorValueStateRef.current),
-                formatInput(unitValueStateRef.current),
-            ];
-
-            onBlurRaw(valuesArr);
+            onBlurRaw([values.floor, values.unit]);
         }
     };
 

--- a/stories/form/form-date-input/props-table.tsx
+++ b/stories/form/form-date-input/props-table.tsx
@@ -86,8 +86,9 @@ const DATA: ApiTableSectionProps[] = [
                 description: (
                     <>
                         Called when the user enters a value in the field.
-                        Returns unformatted value in an array format as such [
+                        Returns actual values in an array format as such [
                         <code>day</code>, <code>month</code>, <code>year</code>]
+                        &nbsp;regardless if it is invalid
                     </>
                 ),
                 propTypes: ["(value: string[]) => void"],
@@ -107,9 +108,10 @@ const DATA: ApiTableSectionProps[] = [
                 name: "onBlurRaw",
                 description: (
                     <>
-                        Called when a defocus happens. Returns unformatted value
-                        in an array format as such [<code>day</code>,{" "}
-                        <code>month</code>, <code>year</code>]
+                        Called when a defocus happens. Returns values in an
+                        array format as such [<code>day</code>,{" "}
+                        <code>month</code>, <code>year</code>] &nbsp;regardless
+                        if it is invalid
                     </>
                 ),
                 propTypes: ["(value: string[]) => void"],

--- a/stories/form/form-multi-select/form-multi-select.stories.mdx
+++ b/stories/form/form-multi-select/form-multi-select.stories.mdx
@@ -135,6 +135,7 @@ import { InputMultiSelect } from "@lifesg/react-design-system/input-select";
                     listExtractor={(item) => item.label}
                     placeholder="Default multi select"
                 />
+                <br />
                 <InputMultiSelect
                     options={[
                         { value: "A", label: "Option A" },
@@ -147,6 +148,7 @@ import { InputMultiSelect } from "@lifesg/react-design-system/input-select";
                     placeholder="Searchable multi select"
                     enableSearch
                 />
+                <br />
                 <InputMultiSelect
                     options={[
                         { value: "A", label: "Option A" },

--- a/stories/form/form-select/form-select.stories.mdx
+++ b/stories/form/form-select/form-select.stories.mdx
@@ -120,6 +120,7 @@ import { InputSelect } from "@lifesg/react-design-system/input-select";
                     displayValueExtractor={(item) => item.label}
                     placeholder="Default select"
                 />
+                <br />
                 <InputSelect
                     options={[
                         { value: "A", label: "Option A" },

--- a/stories/form/form-unit-number-input/form-unit-number-input.stories.mdx
+++ b/stories/form/form-unit-number-input/form-unit-number-input.stories.mdx
@@ -1,5 +1,4 @@
 import { Canvas, Meta, Preview, Story } from "@storybook/addon-docs";
-import { useState } from "react";
 import { UnitNumberInput } from "src/unit-number";
 import { Form } from "src/form";
 import {

--- a/stories/form/form-unit-number-input/props-table.tsx
+++ b/stories/form/form-unit-number-input/props-table.tsx
@@ -45,8 +45,15 @@ const DATA: ApiTableSectionProps[] = [
             },
             {
                 name: "placeholder",
-                description: "The placeholder of the component",
+                description: (
+                    <>
+                        The placeholder of the component. We recommend to use
+                        the
+                        <code>{`<floor>-<unit>`}</code> format.
+                    </>
+                ),
                 propTypes: ["string"],
+                defaultValue: "00-8888",
             },
             {
                 name: "disabled",

--- a/stories/form/form-unit-number-input/props-table.tsx
+++ b/stories/form/form-unit-number-input/props-table.tsx
@@ -44,6 +44,11 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["string"],
             },
             {
+                name: "placeholder",
+                description: "The placeholder of the component",
+                propTypes: ["string"],
+            },
+            {
                 name: "disabled",
                 description:
                     "Indicates if the component is disabled and entry is not allowed",
@@ -93,8 +98,9 @@ const DATA: ApiTableSectionProps[] = [
                 description: (
                     <>
                         Called when the user enters a value in the field.
-                        Returns unformatted value in an array format as such [
-                        <code>floor</code>, <code>unit</code>]
+                        Returns values in an array format as such [
+                        <code>floor</code>, <code>unit</code>]&nbsp;regardless
+                        if it is invalid
                     </>
                 ),
                 propTypes: ["(value: string[]) => void"],
@@ -103,9 +109,11 @@ const DATA: ApiTableSectionProps[] = [
                 name: "onBlur",
                 description: (
                     <>
-                        Called when a defocus happens. Returns the existing
+                        Called when a defocus happens. Returns the formatted
                         value in&nbsp;
-                        <code>00-8888</code>&nbsp;format
+                        <code>00-8888</code>&nbsp;format. (E.g.{" "}
+                        <code>11-2</code>
+                        will be returned as <code>11-02</code>)
                     </>
                 ),
                 propTypes: ["(value: string) => void"],
@@ -114,22 +122,12 @@ const DATA: ApiTableSectionProps[] = [
                 name: "onBlurRaw",
                 description: (
                     <>
-                        Called when a defocus happens. Returns unformatted value
+                        Called when a defocus happens. Returns formatted values
                         in an array format as such [<code>floor</code>,{" "}
-                        <code>unit</code>]
+                        <code>unit</code>]&nbsp;regardless if it is invalid
                     </>
                 ),
                 propTypes: ["(value: string[]) => void"],
-            },
-            {
-                name: "placeholder",
-                description: (
-                    <>
-                        The placeholder text of the unit input as such{" "}
-                        <code>floor-unit</code>
-                    </>
-                ),
-                propTypes: ["string"],
             },
         ],
     },


### PR DESCRIPTION
**Changes**
Fix unintended formatting of input value as the user types

Also:

- Standardise the return values for `onChange` and `onChangeRaw` to be unpadded for single digit values
- Also improve some stories' documentation

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- `DateInput`
     - Fix unintended padding of single digit values
     - Standardise the return values for `onChange` and `onChangeRaw` to be unpadded for single digit values
