### PR TITLE
[MISC][RL] Fix unintended undefined function return types

### DIFF
--- a/src/card/types.ts
+++ b/src/card/types.ts
@@ -1,3 +1,3 @@
 export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
-    "data-testid"?: string;
+    "data-testid"?: string | undefined;
 }

--- a/src/color/types.ts
+++ b/src/color/types.ts
@@ -22,7 +22,7 @@ export interface ColorSet {
         6: string;
     };
     Primary: string;
-    PrimaryDark?: string;
+    PrimaryDark?: string | undefined;
     Secondary: string;
     Accent: {
         Dark: {

--- a/src/date-input/date-input.tsx
+++ b/src/date-input/date-input.tsx
@@ -22,6 +22,7 @@ export const DateInput = ({
     onChangeRaw,
     onBlurRaw,
     readOnly,
+    id,
     ...otherProps
 }: DateInputProps) => {
     // =============================================================================
@@ -314,6 +315,7 @@ export const DateInput = ({
             onClick={handleNodeClick}
             disabled={disabled}
             $error={error}
+            id={id}
             data-testid={otherProps["data-testid"]}
             $readOnly={readOnly}
         >

--- a/src/date-input/types.ts
+++ b/src/date-input/types.ts
@@ -1,31 +1,15 @@
-export interface DateInputTarget {
-    value: string;
-    type?: string | undefined; // input type
-    name?: string | undefined;
-    id?: string | undefined;
-}
-
-/* This mimics the React.SyntheticEvent */
-export interface DateInputEvent {
-    bubbles: boolean;
-    target: DateInputTarget;
-}
-
 export interface DateInputProps extends React.AriaAttributes {
     // Standard HTML Attributes
     className?: string | undefined;
     id?: string | undefined;
-    style?: React.CSSProperties | undefined;
-    tabIndex?: number | undefined;
-    "data-testid"?: string | undefined;
     readOnly?: boolean | undefined;
 
     // WAI-ARIA
     role?: string | undefined;
 
     // Input-specific Attributes
+    "data-testid"?: string | undefined;
     value?: string | undefined;
-    name?: string | undefined;
     error?: boolean | undefined;
     disabled?: boolean | undefined;
     onChange?: ((value: string) => void) | undefined;

--- a/src/date-input/types.ts
+++ b/src/date-input/types.ts
@@ -5,7 +5,7 @@ export interface DateInputProps extends React.AriaAttributes {
     readOnly?: boolean | undefined;
 
     // WAI-ARIA
-    role?: string | undefined;
+    role?: React.AriaRole | undefined;
 
     // Input-specific Attributes
     "data-testid"?: string | undefined;

--- a/src/date-input/types.ts
+++ b/src/date-input/types.ts
@@ -21,7 +21,7 @@ export interface DateInputProps extends React.AriaAttributes {
     readOnly?: boolean | undefined;
 
     // WAI-ARIA
-    role?: string;
+    role?: string | undefined;
 
     // Input-specific Attributes
     value?: string | undefined;

--- a/src/date-input/types.ts
+++ b/src/date-input/types.ts
@@ -18,7 +18,7 @@ export interface DateInputProps extends React.AriaAttributes {
     style?: React.CSSProperties | undefined;
     tabIndex?: number | undefined;
     "data-testid"?: string | undefined;
-    readOnly?: boolean;
+    readOnly?: boolean | undefined;
 
     // WAI-ARIA
     role?: string;
@@ -28,16 +28,16 @@ export interface DateInputProps extends React.AriaAttributes {
     name?: string | undefined;
     error?: boolean | undefined;
     disabled?: boolean | undefined;
-    onChange?: (value: string) => void | undefined;
+    onChange?: ((value: string) => void) | undefined;
     /**
      * Function that returns the raw values in the DateInput on change in an array format
      * as such [day, month, year]
      */
-    onChangeRaw?: (value: string[]) => void | undefined;
-    onBlur?: (value: string) => void | undefined;
+    onChangeRaw?: ((value: string[]) => void) | undefined;
+    onBlur?: ((value: string) => void) | undefined;
     /**
      * Function that returns the raw values in the DateInput on blur in an array format
      * as such [day, month, year]
      */
-    onBlurRaw?: (value: string[]) => void | undefined;
+    onBlurRaw?: ((value: string[]) => void) | undefined;
 }

--- a/src/footer/footer.tsx
+++ b/src/footer/footer.tsx
@@ -95,12 +95,12 @@ export const Footer = <T,>({
                             data-testid="logo"
                         />
                     </LogoSection>
-                    {links[0] && (
+                    {links?.[0] && (
                         <LinkSection key="link-col-1" data-testid="link-col-1">
                             {renderFooterLinks(links[0])}
                         </LinkSection>
                     )}
-                    {links[1] && (
+                    {links?.[1] && (
                         <LinkSection key="link-col-2" data-testid="link-col-2">
                             {renderFooterLinks(links[1])}
                         </LinkSection>

--- a/src/footer/types.ts
+++ b/src/footer/types.ts
@@ -22,7 +22,7 @@ export interface FooterProps<T = void> {
     /** Custom component. This overrides the logo, links and download section */
     children?: JSX.Element | JSX.Element[] | undefined;
     /** Custom disclaimer link attributes */
-    disclaimerLinks?: DisclaimerLinks;
+    disclaimerLinks?: DisclaimerLinks | undefined;
     /** A custom copyright text */
     copyrightInfo?: string | undefined;
     /** Custom logo source */

--- a/src/footer/types.ts
+++ b/src/footer/types.ts
@@ -29,7 +29,7 @@ export interface FooterProps<T = void> {
     logoSrc?: string | undefined;
     /** Last updated date value that is displayed in the bottom of the Footer */
     lastUpdated?: Date | undefined;
-    onFooterLinkClick?: (link: FooterLinkProps<T>) => void | undefined;
+    onFooterLinkClick?: ((link: FooterLinkProps<T>) => void) | undefined;
 }
 
 // TODO: Update component and migration

--- a/src/form/types.ts
+++ b/src/form/types.ts
@@ -30,7 +30,7 @@ export interface FormLabelProps
     extends React.LabelHTMLAttributes<HTMLLabelElement> {
     addon?: FormLabelAddonProps | undefined;
     disabled?: boolean | undefined;
-    subtitle?: string | JSX.Element;
+    subtitle?: string | JSX.Element | undefined;
     "data-testid"?: string | undefined;
 }
 

--- a/src/input-group/types.ts
+++ b/src/input-group/types.ts
@@ -21,13 +21,13 @@ export interface ListAddon<T, V>
         DropdownSearchProps<T> {
     value?: T | undefined;
     placeholder?: string | undefined;
-    displayValueExtractor?: (item: T) => string | undefined;
+    displayValueExtractor?: ((item: T) => string) | undefined;
     "data-selector-testid"?: string | undefined;
 
     // Dropdown props (unable to inherit directly)
     options?: T[] | undefined;
     selectedOption?: T | undefined;
-    onSelectOption?: (option: T, extractedValue: T | V) => void | undefined;
+    onSelectOption?: ((option: T, extractedValue: T | V) => void) | undefined;
     /**
      * Used when items are loaded from an api call.
      * Values: "loading" | "fail" | "success"
@@ -36,9 +36,9 @@ export interface ListAddon<T, V>
     /** Specifies the truncation type. Truncated text will be replaced with ellipsis. Values: "middle" | "end" */
     optionTruncationType?: TruncateType | undefined;
 
-    onRetry?: () => void | undefined;
-    onHideOptions?: () => void | undefined;
-    onShowOptions?: () => void | undefined;
+    onRetry?: (() => void) | undefined;
+    onHideOptions?: (() => void) | undefined;
+    onShowOptions?: (() => void) | undefined;
 }
 
 export interface AddonProps<T, V> {
@@ -48,7 +48,7 @@ export interface AddonProps<T, V> {
 }
 
 export interface InputGroupProps<T, V> extends InputProps {
-    addon?: AddonProps<T, V>;
+    addon?: AddonProps<T, V> | undefined;
 }
 
 /** To be exposed for Form component inheritance */

--- a/src/input-select/types.ts
+++ b/src/input-select/types.ts
@@ -10,7 +10,7 @@ import {
 // SHARED PROPS
 // =============================================================================
 export interface InputSelectOptionsProps<T> {
-    options: T[] | undefined;
+    options: T[];
     /**
      * Used when options are loaded from an api call.
      * Values: "loading" | "fail" | "success"
@@ -19,9 +19,9 @@ export interface InputSelectOptionsProps<T> {
     /** Specifies the truncation type. Truncated text will be replaced with ellipsis. Values: "middle" | "end" */
     optionTruncationType?: TruncateType | undefined;
 
-    onShowOptions?: () => void | undefined;
-    onHideOptions?: () => void | undefined;
-    onRetry?: () => void | undefined;
+    onShowOptions?: (() => void) | undefined;
+    onHideOptions?: (() => void) | undefined;
+    onRetry?: (() => void) | undefined;
 }
 
 export interface InputSelectSharedProps<T> {
@@ -55,13 +55,13 @@ export interface InputSelectProps<T, V>
         DropdownSearchProps<T>,
         DropdownStyleProps {
     selectedOption?: T | undefined;
-    onSelectOption?: (option: T, extractedValue: V) => void | undefined;
+    onSelectOption?: ((option: T, extractedValue: V) => void) | undefined;
     /** Function to derive display value for selected option */
-    displayValueExtractor?: (option: T) => string | undefined;
+    displayValueExtractor?: ((option: T) => string) | undefined;
     /** Function to convert value into a string */
-    valueToStringFunction?: (value: V) => string | undefined;
+    valueToStringFunction?: ((value: V) => string) | undefined;
     /** Function to render selected custom component */
-    renderCustomSelectedOption?: (option: T) => JSX.Element | undefined;
+    renderCustomSelectedOption?: ((option: T) => JSX.Element) | undefined;
 }
 
 /** To be exposed for Form component inheritance */
@@ -81,7 +81,7 @@ export interface InputMultiSelectProps<T, V>
         DropdownSearchProps<T>,
         DropdownStyleProps {
     selectedOptions?: T[] | undefined;
-    onSelectOptions?: (options: T[]) => void | undefined;
+    onSelectOptions?: ((options: T[]) => void) | undefined;
 }
 
 /** To be exposed for Form component inheritance */

--- a/src/input-textarea/types.ts
+++ b/src/input-textarea/types.ts
@@ -4,10 +4,9 @@ export interface TextareaProps
     extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
     error?: boolean | undefined;
     "data-testid"?: string | undefined;
-    renderCustomCounter?: (
-        maxLength: number,
-        currentValueLength: number
-    ) => JSX.Element;
+    renderCustomCounter?:
+        | ((maxLength: number, currentValueLength: number) => JSX.Element)
+        | undefined;
 }
 
 /** To be exposed for Form component inheritance */

--- a/src/link-list/types.ts
+++ b/src/link-list/types.ts
@@ -18,8 +18,10 @@ export interface LinkListProps<T> {
     className?: string | undefined;
     "data-testid"?: string | undefined;
     /** Captures item clicks on a component level */
-    onItemClick?: (
-        item: LinkListItemProps<T>,
-        event: React.MouseEvent<HTMLAnchorElement>
-    ) => void | undefined;
+    onItemClick?:
+        | ((
+              item: LinkListItemProps<T>,
+              event: React.MouseEvent<HTMLAnchorElement>
+          ) => void)
+        | undefined;
 }

--- a/src/modal/types.ts
+++ b/src/modal/types.ts
@@ -11,7 +11,7 @@ export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
     /** The identifier of the element to inject the Modal into */
     rootComponentId?: string | undefined;
     zIndex?: number | undefined;
-    onOverlayClick?: () => void | undefined;
+    onOverlayClick?: (() => void) | undefined;
     /** Dismiss keyboard to keep modal in fullscreen */
     dismissKeyboardOnShow?: boolean;
 }
@@ -19,5 +19,5 @@ export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
 export interface ModalBoxProps extends React.HTMLAttributes<HTMLDivElement> {
     children: JSX.Element | JSX.Element[];
     showCloseButton?: boolean | undefined;
-    onClose?: () => void | undefined;
+    onClose?: (() => void) | undefined;
 }

--- a/src/modal/types.ts
+++ b/src/modal/types.ts
@@ -13,7 +13,7 @@ export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
     zIndex?: number | undefined;
     onOverlayClick?: (() => void) | undefined;
     /** Dismiss keyboard to keep modal in fullscreen */
-    dismissKeyboardOnShow?: boolean;
+    dismissKeyboardOnShow?: boolean | undefined;
 }
 
 export interface ModalBoxProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/src/navbar/brand.tsx
+++ b/src/navbar/brand.tsx
@@ -6,7 +6,9 @@ interface Props {
     resources: NavbarResourcesProps;
     compress?: boolean | undefined;
     "data-testid"?: string | undefined;
-    onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void | undefined;
+    onClick?:
+        | ((event: React.MouseEvent<HTMLAnchorElement>) => void)
+        | undefined;
 }
 
 export const Brand = ({

--- a/src/navbar/types.ts
+++ b/src/navbar/types.ts
@@ -47,9 +47,9 @@ export interface NavbarSharedProps {
     resources?: NavbarResourcesProps | undefined;
     actionButtons?: NavbarActionButtonsProps | undefined;
     /** Triggered when the brand icon is being clicked */
-    onBrandClick?: (
-        event: React.MouseEvent<HTMLAnchorElement>
-    ) => void | undefined;
+    onBrandClick?:
+        | ((event: React.MouseEvent<HTMLAnchorElement>) => void)
+        | undefined;
 }
 
 export type DrawerDismissalMethod =
@@ -60,7 +60,7 @@ export type DrawerDismissalMethod =
 export interface NavbarDrawerProps extends NavbarSharedProps {
     show: boolean;
     children: JSX.Element | JSX.Element[];
-    onClose?: () => void | undefined;
+    onClose?: (() => void) | undefined;
 }
 
 export interface NavbarProps<T = void> extends NavbarSharedProps {
@@ -76,7 +76,7 @@ export interface NavbarProps<T = void> extends NavbarSharedProps {
     drawerDismissalExclusions?: DrawerDismissalMethod[] | undefined;
     hideNavElements?: boolean | undefined;
 
-    onBrandClick?: () => void | undefined; // override
-    onItemClick?: (item: NavItemProps<T>) => void | undefined;
+    onBrandClick?: (() => void) | undefined; // override
+    onItemClick?: ((item: NavItemProps<T>) => void) | undefined;
     onActionButtonClick?: (actionButton: NavbarButtonProps) => void;
 }

--- a/src/navbar/types.ts
+++ b/src/navbar/types.ts
@@ -78,5 +78,7 @@ export interface NavbarProps<T = void> extends NavbarSharedProps {
 
     onBrandClick?: (() => void) | undefined; // override
     onItemClick?: ((item: NavItemProps<T>) => void) | undefined;
-    onActionButtonClick?: (actionButton: NavbarButtonProps) => void;
+    onActionButtonClick?:
+        | ((actionButton: NavbarButtonProps) => void)
+        | undefined;
 }

--- a/src/notification-banner/types.ts
+++ b/src/notification-banner/types.ts
@@ -6,7 +6,7 @@ export interface NotificationBannerProps
     dismissible?: boolean | undefined;
     visible?: boolean | undefined;
     sticky?: boolean | undefined;
-    onDismiss?: () => void | undefined;
+    onDismiss?: (() => void) | undefined;
 }
 
 export interface NotificationBannerWithForwardedRefProps

--- a/src/overlay/types.ts
+++ b/src/overlay/types.ts
@@ -9,7 +9,7 @@ export interface OverlayProps {
     disableTransition?: boolean | undefined;
     enableOverlayClick?: boolean | undefined;
     zIndex?: number | undefined;
-    onOverlayClick?: () => void | undefined;
+    onOverlayClick?: (() => void) | undefined;
     id?: string | undefined;
 }
 

--- a/src/popover/types.ts
+++ b/src/popover/types.ts
@@ -4,12 +4,12 @@ export interface PopoverProps {
     id?: string | undefined;
     className?: string | undefined;
     "data-testid"?: string | undefined;
-    onMobileClose?: () => void | undefined;
+    onMobileClose?: (() => void) | undefined;
 }
 
 export interface PopoverHOCProps {
-    onPopoverAppear?: () => void | undefined;
-    onPopoverDismiss?: () => void | undefined;
+    onPopoverAppear?: (() => void) | undefined;
+    onPopoverDismiss?: (() => void) | undefined;
 }
 
 export interface PopoverHOCOptionsProps {

--- a/src/progress-indicator/types.ts
+++ b/src/progress-indicator/types.ts
@@ -5,5 +5,5 @@ export interface ProgressIndicatorProps<T> {
     currentIndex: number;
     fadeColor?: string[] | undefined;
     fadePosition?: FadePosition | undefined;
-    displayExtractor?: (item: T) => string | undefined;
+    displayExtractor?: ((item: T) => string) | undefined;
 }

--- a/src/shared/dropdown-list/types.ts
+++ b/src/shared/dropdown-list/types.ts
@@ -7,14 +7,13 @@ export interface ListItemRenderArgs {
 
 export interface DropdownDisplayProps<T, V> {
     /** Function to derive value from an item */
-    valueExtractor?: (item: T) => V | undefined;
+    valueExtractor?: ((item: T) => V) | undefined;
     /** Function to derive options display value from an item */
-    listExtractor?: (item: T) => string | undefined;
+    listExtractor?: ((item: T) => string) | undefined;
     /** Function to render custom component */
-    renderListItem?: (
-        item: T,
-        args: ListItemRenderArgs
-    ) => JSX.Element | undefined;
+    renderListItem?:
+        | ((item: T, args: ListItemRenderArgs) => JSX.Element)
+        | undefined;
 }
 
 export interface DropdownStyleProps {
@@ -22,8 +21,8 @@ export interface DropdownStyleProps {
 }
 
 export interface DropdownEventHandlerProps<T, V> {
-    onSelectItem?: (item: T, extractedValue: V) => void | undefined;
-    onSelectItems?: (items: T[]) => void | undefined;
+    onSelectItem?: ((item: T, extractedValue: V) => void) | undefined;
+    onSelectItems?: ((items: T[]) => void) | undefined;
 }
 
 export interface DropdownSearchProps<T> {
@@ -31,8 +30,8 @@ export interface DropdownSearchProps<T> {
     enableSearch?: boolean | undefined;
     searchPlaceholder?: string | undefined;
     /** Custom function to perform search when a user keys in a value in the search input */
-    searchFunction?: (searchValue: string) => T[] | undefined;
-    onSearch?: () => void | undefined;
+    searchFunction?: ((searchValue: string) => T[]) | undefined;
+    onSearch?: (() => void) | undefined;
 }
 
 export interface DropdownListProps<T, V>
@@ -53,11 +52,11 @@ export interface DropdownListProps<T, V>
     /** Specifies the truncation type. Truncated text will be replaced with ellipsis. Values: "middle" | "end" */
     itemTruncationType?: TruncateType | undefined;
 
-    onDismiss?: () => void | undefined;
-    onSelectAll?: () => void | undefined;
-    onRetry?: () => void | undefined;
+    onDismiss?: (() => void) | undefined;
+    onSelectAll?: (() => void) | undefined;
+    onRetry?: (() => void) | undefined;
 }
 
 export interface ListItemSelectorProps {
-    onClick?: () => void | undefined;
+    onClick?: (() => void) | undefined;
 }

--- a/src/smart-app-banner/types.ts
+++ b/src/smart-app-banner/types.ts
@@ -7,7 +7,7 @@ export interface SmartAppBannerProps {
     animated?: boolean | undefined;
     className?: string | undefined;
     onDismiss: () => void;
-    onClick?: () => void | undefined;
+    onClick?: (() => void) | undefined;
 }
 
 export interface SmartAppBannerContentProps {

--- a/src/timepicker/types.ts
+++ b/src/timepicker/types.ts
@@ -16,7 +16,7 @@ export interface TimepickerProps extends React.AriaAttributes {
     format?: TimepickerFormat | undefined;
     disabled?: boolean | undefined;
     error?: boolean | undefined;
-    onChange?: (value: string) => void | undefined;
-    onBlur?: () => void | undefined;
-    onSelectionCancel?: () => void | undefined;
+    onChange?: ((value: string) => void) | undefined;
+    onBlur?: (() => void) | undefined;
+    onSelectionCancel?: (() => void) | undefined;
 }

--- a/src/unit-number/types.ts
+++ b/src/unit-number/types.ts
@@ -16,16 +16,16 @@ export interface UnitNumberInputProps extends React.AriaAttributes {
     name?: string | undefined;
     error?: boolean | undefined;
     disabled?: boolean | undefined;
-    onChange?: (value: string) => void | undefined;
+    onChange?: ((value: string) => void) | undefined;
     /**
      * Function that returns the raw values in the UnitNumberInput on change in an array format
      * as such [floor, unit]
      */
-    onChangeRaw?: (value: string[]) => void | undefined;
-    onBlur?: (value: string) => void | undefined;
+    onChangeRaw?: ((value: string[]) => void) | undefined;
+    onBlur?: ((value: string) => void) | undefined;
     /**
      * Function that returns the raw values in the UnitNumberInput on blur in an array format
      * as such [floor, unit]
      */
-    onBlurRaw?: (value: string[]) => void | undefined;
+    onBlurRaw?: ((value: string[]) => void) | undefined;
 }

--- a/src/unit-number/types.ts
+++ b/src/unit-number/types.ts
@@ -9,7 +9,7 @@ export interface UnitNumberInputProps extends React.AriaAttributes {
     placeholder?: string | undefined;
 
     // WAI-ARIA
-    role?: string | undefined;
+    role?: React.AriaRole | undefined;
 
     // Input-specific Attributes
     value?: string | undefined;

--- a/stories/form/form-date-input/props-table.tsx
+++ b/stories/form/form-date-input/props-table.tsx
@@ -18,11 +18,6 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["string"],
             },
             {
-                name: "name",
-                description: "The name of the component",
-                propTypes: ["string"],
-            },
-            {
                 name: "error",
                 description: (
                     <>
@@ -47,16 +42,6 @@ const DATA: ApiTableSectionProps[] = [
                 description:
                     "Indicates if the component is disabled and entry is not allowed",
                 propTypes: ["boolean"],
-            },
-            {
-                name: "tabIndex",
-                description: "Specifies the tab order of the component",
-                propTypes: ["number"],
-            },
-            {
-                name: "style",
-                description: "Allows for inline styling of the component",
-                propTypes: ["React.CSSProperties"],
             },
             {
                 name: "role",

--- a/stories/form/form-date-input/props-table.tsx
+++ b/stories/form/form-date-input/props-table.tsx
@@ -46,7 +46,7 @@ const DATA: ApiTableSectionProps[] = [
             {
                 name: "role",
                 description: "The aria role of the component",
-                propTypes: ["string"],
+                propTypes: ["React.AriaRole"],
             },
             {
                 name: "data-testid",

--- a/stories/form/form-unit-number-input/props-table.tsx
+++ b/stories/form/form-unit-number-input/props-table.tsx
@@ -80,7 +80,7 @@ const DATA: ApiTableSectionProps[] = [
             {
                 name: "role",
                 description: "The aria role of the component",
-                propTypes: ["string"],
+                propTypes: ["React.AriaRole"],
             },
             {
                 name: "data-testid",


### PR DESCRIPTION
**Changes**
current function typings allow undefined to be returned, which isn't intended

- Update typings
  - Remove undefined return type for functions
  - Add undefined for optional properties that were missed out
  - Remove some unused DateInput props
- Fix error that occurs when Footer links are not specified but `showDownloadAddon` is true
- delete branch

<!-- Remove if not required -->
**Changelog entry**

- Remove undefined return type for functions in component props