### PR TITLE
avoid passing all props to input container

### DIFF
--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -90,7 +90,7 @@ const Component = (
             error={error}
             disabled={disabled}
             readOnly={readOnly}
-            {...otherProps}
+            className={otherProps.className}
         >
             <InputElement
                 data-testid="input"


### PR DESCRIPTION
**Changes**
- Update input container to take in the `className` from props instead of spreading all the props on it. This prevents rendering attributes not meant for the container like id and placeholder.
- delete branch

**Changelog entry**
- Fix rendering of unnecessary attributes in input container

