### PR TITLE
Fix checkbox in overlay not reflecting state changes

### DIFF
--- a/src/overlay/overlay.tsx
+++ b/src/overlay/overlay.tsx
@@ -153,12 +153,11 @@ export const Overlay = ({
     // EVENT HANDLERS
     // =============================================================================
     const handleWrapperClick = (event: React.MouseEvent<HTMLDivElement>) => {
-        event.preventDefault();
-
         const modal = childRef.current?.firstChild;
         if (modal && (modal as any).contains(event.target)) {
             return;
         } else if (onOverlayClick && enableOverlayClick) {
+            event.preventDefault();
             onOverlayClick();
         }
     };


### PR DESCRIPTION

**Changes**

- due to a `preventDefault()` for the click event in `Overlay`
- moved under a condition check so that it does not affect click events on child elements
- explanation of the root cause: https://stackoverflow.com/q/70022781/3932279
- delete branch

<!-- Remove if not required -->
**Changelog entry**

- Fix issue where checkboxes in `Overlay` do not reflect state changes