### PR TITLE
Sort alphabetically. Callback attrs to be at the bottom

### DIFF
--- a/stories/storybook-common/api-table/api-table.tsx
+++ b/stories/storybook-common/api-table/api-table.tsx
@@ -1,38 +1,62 @@
+import orderBy from "lodash/orderBy";
 import React from "react";
-import { DefaultCol, DescriptionCol, NameCol, Section, Table } from "./api-table-components";
+import {
+    DefaultCol,
+    DescriptionCol,
+    NameCol,
+    Section,
+    Table,
+} from "./api-table-components";
 import { ApiTableAttributeRowProps, ApiTableProps } from "./types";
 
 export const ApiTable = (props: ApiTableProps): JSX.Element => {
-	const renderSection = (attributes: ApiTableAttributeRowProps[], sectionIndex: number) => {
-		return attributes.map((attribute, index) => {
-			return (
-				<tr key={`${sectionIndex}-${index}`}>
-					<NameCol mandatory={attribute.mandatory}>
-						{attribute.name}
-					</NameCol>
-					<DescriptionCol propTypes={attribute.propTypes}>
-						{attribute.description}
-					</DescriptionCol>
-					<DefaultCol>{attribute.defaultValue}</DefaultCol>
-				</tr>
-			);
-		});
-	};
+    const renderSection = (
+        attributes: ApiTableAttributeRowProps[],
+        sectionIndex: number
+    ) => {
+        const sortedAttributes = orderBy(attributes, ["name"], ["asc"]);
+        const normalAttributes: ApiTableAttributeRowProps[] = [];
+        const callbackAttributes: ApiTableAttributeRowProps[] = [];
 
-	const renderContents = () => {
-		return props.sections.map((section, index) => {
-			return (
-				<>
-					{section.name && <Section key={`section-${index + 1}`}>{section.name}</Section>}
-					{renderSection(section.attributes, index)}
-				</>
-			);
-		});
-	};
+        sortedAttributes.forEach((attribute) => {
+            if (attribute.name.startsWith("on")) {
+                callbackAttributes.push(attribute);
+            } else {
+                normalAttributes.push(attribute);
+            }
+        });
 
-	return (
-		<Table>
-			{renderContents()}
-		</Table>
-	);
+        const newArr = [...normalAttributes, ...callbackAttributes];
+
+        return newArr.map((attribute, index) => {
+            return (
+                <tr key={`${sectionIndex}-${index}`}>
+                    <NameCol mandatory={attribute.mandatory}>
+                        {attribute.name}
+                    </NameCol>
+                    <DescriptionCol propTypes={attribute.propTypes}>
+                        {attribute.description}
+                    </DescriptionCol>
+                    <DefaultCol>{attribute.defaultValue}</DefaultCol>
+                </tr>
+            );
+        });
+    };
+
+    const renderContents = () => {
+        return props.sections.map((section, index) => {
+            return (
+                <>
+                    {section.name && (
+                        <Section key={`section-${index + 1}`}>
+                            {section.name}
+                        </Section>
+                    )}
+                    {renderSection(section.attributes, index)}
+                </>
+            );
+        });
+    };
+
+    return <Table>{renderContents()}</Table>;
 };


### PR DESCRIPTION
**Changes**
Sorting the prob tables to display the props in alphabetical order with the callback attributes at the bottom. 

- [delete] branch
