### PR TITLE
Filter checkbox group

### DIFF
--- a/src/filter/addons/filter-item-checkbox.styles.tsx
+++ b/src/filter/addons/filter-item-checkbox.styles.tsx
@@ -6,15 +6,19 @@ import { ToggleIcon } from "../../shared/toggle-icon/toggle-icon";
 import { FilterItem } from "../filter-item";
 
 export const StyledFilterItem = styled(FilterItem)`
-    padding: 0.5rem;
+    padding: 0 0 1rem;
+
+    [data-id="content-container"] {
+        position: relative; // to get the item position relative to this parent
+        padding: 0.5rem 0.5rem 0;
+    }
 
     [data-id="minimise-button"] {
-        margin: 0.5rem;
+        margin: 0.5rem 1.25rem 0;
     }
 `;
 
 export const Group = styled.div`
-    position: relative; // to get the item position relative to this parent
     display: flex;
     flex-direction: column;
 
@@ -26,7 +30,7 @@ export const Group = styled.div`
 
 export const Item = styled.label<{ $visible: boolean; $selected: boolean }>`
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     ${(props) => !props.$visible && "display: none;"}
 
     position: relative;
@@ -40,7 +44,6 @@ export const Item = styled.label<{ $visible: boolean; $selected: boolean }>`
         props.$selected &&
         css`
             color: ${Color.Primary};
-            ${TextStyleHelper.getTextStyle("BodySmall", "semibold")}
         `}
 `;
 
@@ -51,6 +54,7 @@ export const Input = styled.input`
 export const Icon = styled(ToggleIcon)`
     height: 1.5rem;
     width: 1.5rem;
+    flex-shrink: 0;
 
     ${Input}:focus-visible + & {
         outline: 2px solid ${Color.Primary};

--- a/src/filter/addons/filter-item-checkbox.styles.tsx
+++ b/src/filter/addons/filter-item-checkbox.styles.tsx
@@ -1,0 +1,12 @@
+import { MediaQuery } from "src/media";
+import styled from "styled-components";
+
+export const Group = styled.div`
+    display: flex;
+    flex-direction: column;
+
+    ${MediaQuery.MaxWidth.mobileL} {
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+`;

--- a/src/filter/addons/filter-item-checkbox.styles.tsx
+++ b/src/filter/addons/filter-item-checkbox.styles.tsx
@@ -61,7 +61,7 @@ export const Input = styled.input`
     appearance: none;
 `;
 
-export const Icon = styled(ToggleIcon)`
+export const StyledToggleIcon = styled(ToggleIcon)`
     height: 1.5rem;
     width: 1.5rem;
     flex-shrink: 0;

--- a/src/filter/addons/filter-item-checkbox.styles.tsx
+++ b/src/filter/addons/filter-item-checkbox.styles.tsx
@@ -2,6 +2,7 @@ import { MediaQuery } from "src/media";
 import styled from "styled-components";
 
 export const Group = styled.div`
+    position: relative; // to get the item position relative to this parent
     display: flex;
     flex-direction: column;
 

--- a/src/filter/addons/filter-item-checkbox.styles.tsx
+++ b/src/filter/addons/filter-item-checkbox.styles.tsx
@@ -4,6 +4,7 @@ import { MediaQuery } from "../../media/media";
 import { TextStyleHelper } from "../../text/helper";
 import { ToggleIcon } from "../../shared/toggle-icon/toggle-icon";
 import { FilterItem } from "../filter-item";
+import { Toggle } from "../../toggle";
 
 export const StyledFilterItem = styled(FilterItem)`
     padding: 0 0 1rem;
@@ -11,10 +12,18 @@ export const StyledFilterItem = styled(FilterItem)`
     [data-id="content-container"] {
         position: relative; // to get the item position relative to this parent
         padding: 0.5rem 0.5rem 0;
+
+        ${MediaQuery.MaxWidth.mobileL} {
+            padding: 1rem 1.25rem 0.5rem;
+        }
     }
 
     [data-id="minimise-button"] {
         margin: 0.5rem 1.25rem 0;
+
+        ${MediaQuery.MaxWidth.mobileL} {
+            margin: 0.5rem 1.25rem 0;
+        }
     }
 `;
 
@@ -25,6 +34,7 @@ export const Group = styled.div`
     ${MediaQuery.MaxWidth.mobileL} {
         flex-direction: row;
         flex-wrap: wrap;
+        gap: 1rem;
     }
 `;
 
@@ -61,4 +71,8 @@ export const Icon = styled(ToggleIcon)`
         outline-offset: -2px;
         border-radius: 4px;
     }
+`;
+
+export const StyledToggle = styled(Toggle)<{ $visible: boolean }>`
+    ${(props) => !props.$visible && "visibility: hidden;"}
 `;

--- a/src/filter/addons/filter-item-checkbox.styles.tsx
+++ b/src/filter/addons/filter-item-checkbox.styles.tsx
@@ -10,3 +10,7 @@ export const Group = styled.div`
         flex-wrap: wrap;
     }
 `;
+
+export const Item = styled.div<{ $visible: boolean }>`
+    ${(props) => !props.$visible && "display: none;"}
+`;

--- a/src/filter/addons/filter-item-checkbox.styles.tsx
+++ b/src/filter/addons/filter-item-checkbox.styles.tsx
@@ -1,5 +1,17 @@
-import { MediaQuery } from "src/media";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
+import { Color } from "../../color/color";
+import { MediaQuery } from "../../media/media";
+import { TextStyleHelper } from "../../text/helper";
+import { ToggleIcon } from "../../shared/toggle-icon/toggle-icon";
+import { FilterItem } from "../filter-item";
+
+export const StyledFilterItem = styled(FilterItem)`
+    padding: 0.5rem;
+
+    [data-id="minimise-button"] {
+        margin: 0.5rem;
+    }
+`;
 
 export const Group = styled.div`
     position: relative; // to get the item position relative to this parent
@@ -12,6 +24,37 @@ export const Group = styled.div`
     }
 `;
 
-export const Item = styled.div<{ $visible: boolean }>`
+export const Item = styled.label<{ $visible: boolean; $selected: boolean }>`
+    display: flex;
+    align-items: center;
     ${(props) => !props.$visible && "display: none;"}
+
+    position: relative;
+    width: 100%;
+    min-height: 1.5rem;
+    padding: 0.5rem;
+
+    cursor: pointer;
+    ${TextStyleHelper.getTextStyle("BodySmall", "regular")}
+    ${(props) =>
+        props.$selected &&
+        css`
+            color: ${Color.Primary};
+            ${TextStyleHelper.getTextStyle("BodySmall", "semibold")}
+        `}
+`;
+
+export const Input = styled.input`
+    appearance: none;
+`;
+
+export const Icon = styled(ToggleIcon)`
+    height: 1.5rem;
+    width: 1.5rem;
+
+    ${Input}:focus-visible + & {
+        outline: 2px solid ${Color.Primary};
+        outline-offset: -2px;
+        border-radius: 4px;
+    }
 `;

--- a/src/filter/addons/filter-item-checkbox.tsx
+++ b/src/filter/addons/filter-item-checkbox.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { FilterItem } from "../filter-item";
 import { FilterItemCheckboxProps } from "../types";
 import { Group, Item } from "./filter-item-checkbox.styles";
@@ -12,14 +12,29 @@ export const FilterItemCheckbox = ({
     // =============================================================================
     // CONST, STATE, REF
     // =============================================================================
-    const [selected, setSelected] = useState(value || []);
+    const [selected, setSelected] = useState<FilterItemCheckboxProps["value"]>(
+        value || []
+    );
+    const [minimisedHeight, setMinimisedHeight] = useState<number>();
+    const lastVisibleElement = useRef<HTMLDivElement>();
 
     // =============================================================================
     // EFFECTS
     // =============================================================================
     useEffect(() => {
-        setSelected(value || []);
+        if (value !== selected) {
+            setSelected(value || []);
+        }
     }, [value]);
+
+    useEffect(() => {
+        const elementBottom = lastVisibleElement.current
+            ? lastVisibleElement.current.offsetTop +
+              lastVisibleElement.current.clientHeight
+            : undefined;
+
+        setMinimisedHeight(elementBottom);
+    }, [options]);
 
     // =============================================================================
     // EVENT HANDLERS
@@ -33,7 +48,11 @@ export const FilterItemCheckbox = ({
     };
 
     return (
-        <FilterItem minimisable {...filterItemProps}>
+        <FilterItem
+            minimisable={options.length > 5}
+            minimisedHeight={minimisedHeight}
+            {...filterItemProps}
+        >
             {(mode, { minimised }) => (
                 <Group role="group" aria-label={filterItemProps.title}>
                     {options.map(({ label, value: optionValue }, i) => {
@@ -42,6 +61,7 @@ export const FilterItemCheckbox = ({
                             <Item
                                 key={optionValue}
                                 $visible={!minimised || i < 5}
+                                ref={i === 4 ? lastVisibleElement : undefined}
                             >
                                 <label>
                                     <input
@@ -52,7 +72,7 @@ export const FilterItemCheckbox = ({
                                         onChange={handleItemClick(optionValue)}
                                         value={optionValue}
                                     />
-                                    {label} {mode}
+                                    {label}
                                 </label>
                             </Item>
                         );

--- a/src/filter/addons/filter-item-checkbox.tsx
+++ b/src/filter/addons/filter-item-checkbox.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useRef, useState } from "react";
-import { FilterItem } from "../filter-item";
 import { FilterItemCheckboxProps } from "../types";
-import { Group, Item } from "./filter-item-checkbox.styles";
+import {
+    Group,
+    Icon,
+    Input,
+    Item,
+    StyledFilterItem,
+} from "./filter-item-checkbox.styles";
 
 export const FilterItemCheckbox = ({
     value,
@@ -16,7 +21,7 @@ export const FilterItemCheckbox = ({
         value || []
     );
     const [minimisedHeight, setMinimisedHeight] = useState<number>();
-    const lastVisibleElement = useRef<HTMLDivElement>();
+    const lastVisibleElement = useRef<HTMLLabelElement>();
 
     // =============================================================================
     // EFFECTS
@@ -48,7 +53,7 @@ export const FilterItemCheckbox = ({
     };
 
     return (
-        <FilterItem
+        <StyledFilterItem
             minimisable={options.length > 5}
             minimisedHeight={minimisedHeight}
             {...filterItemProps}
@@ -56,29 +61,29 @@ export const FilterItemCheckbox = ({
             {(mode, { minimised }) => (
                 <Group role="group" aria-label={filterItemProps.title}>
                     {options.map(({ label, value: optionValue }, i) => {
+                        const checked = selected.includes(optionValue);
+
                         return (
-                            // TODO: this should be the toggle button
+                            // TODO: this should be the toggle button on mobile
                             <Item
                                 key={optionValue}
                                 $visible={!minimised || i < 5}
+                                $selected={checked}
                                 ref={i === 4 ? lastVisibleElement : undefined}
                             >
-                                <label>
-                                    <input
-                                        type="checkbox"
-                                        id={optionValue}
-                                        name={filterItemProps.title}
-                                        checked={selected.includes(optionValue)}
-                                        onChange={handleItemClick(optionValue)}
-                                        value={optionValue}
-                                    />
-                                    {label}
-                                </label>
+                                <Input
+                                    type="checkbox"
+                                    id={optionValue}
+                                    checked={checked}
+                                    onChange={handleItemClick(optionValue)}
+                                />
+                                <Icon type="checkbox" active={checked} />
+                                {label}
                             </Item>
                         );
                     })}
                 </Group>
             )}
-        </FilterItem>
+        </StyledFilterItem>
     );
 };

--- a/src/filter/addons/filter-item-checkbox.tsx
+++ b/src/filter/addons/filter-item-checkbox.tsx
@@ -4,11 +4,11 @@ import { FilterContext } from "../filter-context";
 import { FilterItemCheckboxProps } from "../types";
 import {
     Group,
-    Icon,
     Input,
     Item,
     StyledFilterItem,
     StyledToggle,
+    StyledToggleIcon,
 } from "./filter-item-checkbox.styles";
 
 export const FilterItemCheckbox = <T,>({
@@ -152,7 +152,7 @@ export const FilterItemCheckbox = <T,>({
                     checked={checked}
                     onChange={handleItemClick(option)}
                 />
-                <Icon type="checkbox" active={checked} />
+                <StyledToggleIcon type="checkbox" active={checked} />
                 {optionLabel}
             </Item>
         );

--- a/src/filter/addons/filter-item-checkbox.tsx
+++ b/src/filter/addons/filter-item-checkbox.tsx
@@ -1,5 +1,5 @@
-import { useContext, useEffect, useRef, useState } from "react";
-import { Toggle } from "../../toggle";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
+import { useResizeDetector } from "react-resize-detector";
 import { FilterContext } from "../filter-context";
 import { FilterItemCheckboxProps } from "../types";
 import {
@@ -31,23 +31,6 @@ export const FilterItemCheckbox = ({
     const lastVisibleElement = useRef<HTMLLabelElement>();
 
     // =============================================================================
-    // EFFECTS
-    // =============================================================================
-    useEffect(() => {
-        if (value !== selected) {
-            setSelected(value || []);
-        }
-    }, [value]);
-
-    useEffect(() => {
-        if (mode === "default") {
-            setVisibleItemsWhenMinimised();
-        } else {
-            setVisibleMobileItemsWhenMinimised();
-        }
-    }, [options, mode]);
-
-    // =============================================================================
     // EVENT HANDLERS
     // =============================================================================
     const handleItemClick = (item: string) => () => {
@@ -70,7 +53,7 @@ export const FilterItemCheckbox = ({
         setMinimisedHeight(elementBottom);
     };
 
-    const setVisibleMobileItemsWhenMinimised = () => {
+    const setVisibleMobileItemsWhenMinimised = useCallback(() => {
         if (!parentRef.current) {
             setMinimisedHeight(undefined);
             return;
@@ -102,7 +85,33 @@ export const FilterItemCheckbox = ({
         } else {
             setMinimisedHeight(undefined);
         }
-    };
+    }, []);
+
+    // =============================================================================
+    // EFFECTS
+    // =============================================================================
+    useEffect(() => {
+        if (value !== selected) {
+            setSelected(value || []);
+        }
+    }, [value]);
+
+    useEffect(() => {
+        if (mode === "default") {
+            setVisibleItemsWhenMinimised();
+        } else {
+            setVisibleMobileItemsWhenMinimised();
+        }
+    }, [options]);
+
+    useResizeDetector({
+        handleWidth: mode === "mobile",
+        handleHeight: false,
+        skipOnMount: true,
+        refreshMode: "throttle",
+        targetRef: parentRef,
+        onResize: setVisibleMobileItemsWhenMinimised,
+    });
 
     // =============================================================================
     // RENDER FUNCTIONS

--- a/src/filter/addons/filter-item-checkbox.tsx
+++ b/src/filter/addons/filter-item-checkbox.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { FilterItem } from "../filter-item";
 import { FilterItemCheckboxProps } from "../types";
-import { Group } from "./filter-item-checkbox.styles";
+import { Group, Item } from "./filter-item-checkbox.styles";
 
 export const FilterItemCheckbox = ({
     value,
@@ -33,26 +33,32 @@ export const FilterItemCheckbox = ({
     };
 
     return (
-        <FilterItem {...filterItemProps}>
-            <Group role="group" aria-label={filterItemProps.title}>
-                {options.map(({ label, value: optionValue }) => {
-                    return (
-                        // TODO: this should be the toggle button
-                        <div key={optionValue}>
-                            <label>
-                                <input
-                                    type="checkbox"
-                                    name={filterItemProps.title}
-                                    checked={selected.includes(optionValue)}
-                                    onChange={handleItemClick(optionValue)}
-                                    value={optionValue}
-                                />
-                                {label}
-                            </label>
-                        </div>
-                    );
-                })}
-            </Group>
+        <FilterItem minimisable {...filterItemProps}>
+            {(mode, { minimised }) => (
+                <Group role="group" aria-label={filterItemProps.title}>
+                    {options.map(({ label, value: optionValue }, i) => {
+                        return (
+                            // TODO: this should be the toggle button
+                            <Item
+                                key={optionValue}
+                                $visible={!minimised || i < 5}
+                            >
+                                <label>
+                                    <input
+                                        type="checkbox"
+                                        id={optionValue}
+                                        name={filterItemProps.title}
+                                        checked={selected.includes(optionValue)}
+                                        onChange={handleItemClick(optionValue)}
+                                        value={optionValue}
+                                    />
+                                    {label} {mode}
+                                </label>
+                            </Item>
+                        );
+                    })}
+                </Group>
+            )}
         </FilterItem>
     );
 };

--- a/src/filter/addons/filter-item-checkbox.tsx
+++ b/src/filter/addons/filter-item-checkbox.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import { FilterItem } from "../filter-item";
+import { FilterItemCheckboxProps } from "../types";
+import { Group } from "./filter-item-checkbox.styles";
+
+export const FilterItemCheckbox = ({
+    value,
+    options,
+    onChange,
+    ...filterItemProps
+}: FilterItemCheckboxProps) => {
+    // =============================================================================
+    // CONST, STATE, REF
+    // =============================================================================
+    const [selected, setSelected] = useState(value || []);
+
+    // =============================================================================
+    // EFFECTS
+    // =============================================================================
+    useEffect(() => {
+        setSelected(value || []);
+    }, [value]);
+
+    // =============================================================================
+    // EVENT HANDLERS
+    // =============================================================================
+    const handleItemClick = (item) => (e) => {
+        const newSelection = e.target.checked
+            ? selected.concat(item)
+            : selected.filter((v) => v !== item);
+        setSelected(newSelection);
+        onChange?.(newSelection);
+    };
+
+    return (
+        <FilterItem {...filterItemProps}>
+            <Group role="group" aria-label={filterItemProps.title}>
+                {options.map(({ label, value: optionValue }) => {
+                    return (
+                        // TODO: this should be the toggle button
+                        <div key={optionValue}>
+                            <label>
+                                <input
+                                    type="checkbox"
+                                    name={filterItemProps.title}
+                                    checked={selected.includes(optionValue)}
+                                    onChange={handleItemClick(optionValue)}
+                                    value={optionValue}
+                                />
+                                {label}
+                            </label>
+                        </div>
+                    );
+                })}
+            </Group>
+        </FilterItem>
+    );
+};

--- a/src/filter/addons/filter-item-checkbox.tsx
+++ b/src/filter/addons/filter-item-checkbox.tsx
@@ -135,6 +135,48 @@ export const FilterItemCheckbox = <T,>({
     // =============================================================================
     // RENDER FUNCTIONS
     // =============================================================================
+    const renderCheckbox = (option: T, index: number, minimised: boolean) => {
+        const optionLabel = getLabel(option);
+        const optionValue = getValue(option);
+        const checked = !!selected.find((s) => getValue(s) === optionValue);
+
+        return (
+            <Item
+                key={optionValue}
+                $visible={!minimised || index < 5}
+                $selected={checked}
+                ref={index === 4 ? lastVisibleElement : undefined}
+            >
+                <Input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={handleItemClick(option)}
+                />
+                <Icon type="checkbox" active={checked} />
+                {optionLabel}
+            </Item>
+        );
+    };
+
+    const renderToggle = (option: T, index: number, minimised: boolean) => {
+        const optionLabel = getLabel(option);
+        const optionValue = getValue(option);
+        const checked = !!selected.find((s) => getValue(s) === optionValue);
+
+        return (
+            <StyledToggle
+                type="checkbox"
+                checked={checked}
+                $visible={
+                    !minimised ||
+                    (minimisedHeight && index <= lastVisibleElementIndex)
+                }
+                onChange={handleItemClick(option)}
+            >
+                {optionLabel}
+            </StyledToggle>
+        );
+    };
 
     return (
         <StyledFilterItem
@@ -148,43 +190,11 @@ export const FilterItemCheckbox = <T,>({
                     aria-label={filterItemProps.title}
                     ref={parentRef}
                 >
-                    {options.map((option, i) => {
-                        const optionLabel = getLabel(option);
-                        const optionValue = getValue(option);
-                        const checked = !!selected.find(
-                            (s) => getValue(s) === optionValue
-                        );
-
-                        return mode === "default" ? (
-                            <Item
-                                key={optionValue}
-                                $visible={!minimised || i < 5}
-                                $selected={checked}
-                                ref={i === 4 ? lastVisibleElement : undefined}
-                            >
-                                <Input
-                                    type="checkbox"
-                                    checked={checked}
-                                    onChange={handleItemClick(option)}
-                                />
-                                <Icon type="checkbox" active={checked} />
-                                {optionLabel}
-                            </Item>
-                        ) : (
-                            <StyledToggle
-                                type="checkbox"
-                                checked={checked}
-                                $visible={
-                                    !minimised ||
-                                    (minimisedHeight &&
-                                        i <= lastVisibleElementIndex)
-                                }
-                                onChange={handleItemClick(option)}
-                            >
-                                {optionLabel}
-                            </StyledToggle>
-                        );
-                    })}
+                    {options.map((option, i) =>
+                        mode === "default"
+                            ? renderCheckbox(option, i, minimised)
+                            : renderToggle(option, i, minimised)
+                    )}
                 </Group>
             )}
         </StyledFilterItem>

--- a/src/filter/filter-item.styles.tsx
+++ b/src/filter/filter-item.styles.tsx
@@ -89,9 +89,8 @@ export const FilterItemTitle = styled(Text.H4)`
 // CONTENT STYLES
 // -----------------------------------------------------------------------------
 
-export const Expandable = styled(animated.div)<{ $height?: number }>`
+export const ExpandableItem = styled(animated.div)`
     overflow: hidden;
-    ${(props) => props.$height && `height: ${props.$height}px;`}
 `;
 
 export const FilterItemBody = styled.div`
@@ -100,6 +99,14 @@ export const FilterItemBody = styled.div`
     ${MediaQuery.MaxWidth.mobileL} {
         padding: 1.5rem 1.25rem;
     }
+`;
+
+export const MinimisableContent = styled(animated.div)<{
+    $height?: number;
+    $minimisable: boolean;
+}>`
+    ${(props) => props.$minimisable && "overflow: hidden;"}
+    ${(props) => props.$height && `height: ${props.$height}px;`}
 `;
 
 export const FilterItemMinimiseButton = styled(Button.Small)`

--- a/src/filter/filter-item.styles.tsx
+++ b/src/filter/filter-item.styles.tsx
@@ -89,8 +89,9 @@ export const FilterItemTitle = styled(Text.H4)`
 // CONTENT STYLES
 // -----------------------------------------------------------------------------
 
-export const Expandable = styled(animated.div)`
+export const Expandable = styled(animated.div)<{ $height?: number }>`
     overflow: hidden;
+    ${(props) => props.$height && `height: ${props.$height}px;`}
 `;
 
 export const FilterItemBody = styled.div`

--- a/src/filter/filter-item.styles.tsx
+++ b/src/filter/filter-item.styles.tsx
@@ -105,4 +105,10 @@ export const FilterItemMinimiseButton = styled(Button.Small)`
     height: fit-content;
     padding: 0;
     margin: 1rem 0 0 0;
+
+    ${MediaQuery.MaxWidth.mobileL} {
+        span {
+            ${TextStyleHelper.getTextStyle("H6", "semibold")}
+        }
+    }
 `;

--- a/src/filter/filter-item.styles.tsx
+++ b/src/filter/filter-item.styles.tsx
@@ -1,16 +1,30 @@
 import { ChevronDownIcon } from "@lifesg/react-icons/chevron-down";
 import { animated } from "react-spring";
 import styled from "styled-components";
+import { Button } from "../button/button";
 import { Color } from "../color/color";
 import { IconButton } from "../icon-button/icon-button";
 import { MediaQuery } from "../media/media";
 import { Text, TextStyleHelper } from "../text";
 
 // =============================================================================
+// STYLES INTERFACE
+// =============================================================================
+interface StyleProps {
+    $collapsible?: boolean;
+    $expanded?: boolean;
+}
+
+interface DividerStyleProps {
+    $showDivider: boolean;
+    $showMobileDivider: boolean;
+}
+
+// =============================================================================
 // FILTER ITEM STYLES
 // =============================================================================
 
-export const FilterItemWrapper = styled.div<{ $collapsible: boolean }>`
+export const FilterItemWrapper = styled.div<StyleProps>`
     background-color: ${(props) =>
         props.$collapsible ? Color.Neutral[7](props) : Color.Neutral[8](props)};
 
@@ -19,10 +33,7 @@ export const FilterItemWrapper = styled.div<{ $collapsible: boolean }>`
     }
 `;
 
-export const Divider = styled.div<{
-    $showDivider: boolean;
-    $showMobileDivider: boolean;
-}>`
+export const Divider = styled.div<DividerStyleProps>`
     display: ${(props) => (props.$showDivider ? "block" : "none")};
     height: 1px;
     background-color: ${Color.Neutral[5]};
@@ -33,13 +44,9 @@ export const Divider = styled.div<{
     }
 `;
 
-export const FilterItemBody = styled.div`
-    padding: 1.5rem 1.25rem;
-
-    ${MediaQuery.MaxWidth.mobileL} {
-        padding: 1rem 1.25rem;
-    }
-`;
+// -----------------------------------------------------------------------------
+// HEADER STYLES
+// -----------------------------------------------------------------------------
 
 export const FilterItemHeader = styled.div`
     display: flex;
@@ -56,7 +63,7 @@ export const FilterItemExpandButton = styled(IconButton)`
     margin: 0 0 0 auto;
 `;
 
-export const ChevronIcon = styled(ChevronDownIcon)<{ $expanded: boolean }>`
+export const ChevronIcon = styled(ChevronDownIcon)<StyleProps>`
     height: 1.125rem;
     width: 1.125rem;
     color: ${Color.Neutral[3]};
@@ -78,6 +85,24 @@ export const FilterItemTitle = styled(Text.H4)`
     }
 `;
 
+// -----------------------------------------------------------------------------
+// CONTENT STYLES
+// -----------------------------------------------------------------------------
+
 export const Expandable = styled(animated.div)`
     overflow: hidden;
+`;
+
+export const FilterItemBody = styled.div`
+    padding: 1rem 1.25rem;
+
+    ${MediaQuery.MaxWidth.mobileL} {
+        padding: 1.5rem 1.25rem;
+    }
+`;
+
+export const FilterItemMinimiseButton = styled(Button.Small)`
+    height: fit-content;
+    padding: 0;
+    margin: 1rem 0 0 0;
 `;

--- a/src/filter/filter-item.tsx
+++ b/src/filter/filter-item.tsx
@@ -90,6 +90,7 @@ export const FilterItem = ({
                         </Expandable>
                         {minimisable && (
                             <FilterItemMinimiseButton
+                                data-id="minimise-button"
                                 styleType="link"
                                 onClick={() => {
                                     setMinimised(!minimised);

--- a/src/filter/filter-item.tsx
+++ b/src/filter/filter-item.tsx
@@ -41,12 +41,9 @@ export const FilterItem = ({
     const itemAnimationStyles = useSpring({
         height: collapsed ? 0 : itemResizeDetector.height,
     });
-    const contentAnimationStyles = useSpring({
-        height: minimised
-            ? minimisedHeight ??
-              Math.min(contentResizeDetector.height * 0.5, 216)
-            : contentResizeDetector.height,
-    });
+    const contentHeight = minimised
+        ? minimisedHeight ?? Math.min(contentResizeDetector.height * 0.5, 216)
+        : contentResizeDetector.height;
 
     // =============================================================================
     // RENDER
@@ -81,7 +78,7 @@ export const FilterItem = ({
             <Expandable style={isMobile ? undefined : itemAnimationStyles}>
                 <div ref={itemResizeDetector.ref}>
                     <FilterItemBody {...otherProps}>
-                        <Expandable style={contentAnimationStyles}>
+                        <Expandable $height={contentHeight}>
                             <div ref={contentResizeDetector.ref}>
                                 <div data-id="content-container">
                                     {typeof children === "function"

--- a/src/filter/filter-item.tsx
+++ b/src/filter/filter-item.tsx
@@ -18,6 +18,7 @@ import { FilterItemProps } from "./types";
 export const FilterItem = ({
     collapsible: desktopCollapsible = true,
     minimisable = false,
+    minimisedHeight,
     showDivider = true,
     showMobileDivider = true,
     title,
@@ -42,7 +43,8 @@ export const FilterItem = ({
     });
     const contentAnimationStyles = useSpring({
         height: minimised
-            ? Math.min(contentResizeDetector.height * 0.5, 216)
+            ? minimisedHeight ??
+              Math.min(contentResizeDetector.height * 0.5, 216)
             : contentResizeDetector.height,
     });
 

--- a/src/filter/filter-item.tsx
+++ b/src/filter/filter-item.tsx
@@ -5,13 +5,14 @@ import { FilterContext } from "./filter-context";
 import {
     ChevronIcon,
     Divider,
-    Expandable,
+    ExpandableItem,
     FilterItemBody,
     FilterItemExpandButton,
     FilterItemHeader,
     FilterItemMinimiseButton,
     FilterItemTitle,
     FilterItemWrapper,
+    MinimisableContent,
 } from "./filter-item.styles";
 import { FilterItemProps } from "./types";
 
@@ -33,7 +34,7 @@ export const FilterItem = ({
     const [collapsed, setCollapsed] = useState(
         isMobile ? false : desktopCollapsible
     );
-    const [minimised, setMinimised] = useState(minimisable);
+    const [contentMinimised, setContentMinimised] = useState(minimisable);
     const collapsible = !isMobile && desktopCollapsible;
 
     const itemResizeDetector = useResizeDetector();
@@ -41,7 +42,7 @@ export const FilterItem = ({
     const itemAnimationStyles = useSpring({
         height: collapsed ? 0 : itemResizeDetector.height,
     });
-    const contentHeight = minimised
+    const contentHeight = contentMinimised
         ? minimisedHeight ?? Math.min(contentResizeDetector.height * 0.5, 216)
         : contentResizeDetector.height;
 
@@ -75,32 +76,37 @@ export const FilterItem = ({
                     )}
                 </FilterItemHeader>
             )}
-            <Expandable style={isMobile ? undefined : itemAnimationStyles}>
+            <ExpandableItem style={isMobile ? undefined : itemAnimationStyles}>
                 <div ref={itemResizeDetector.ref}>
                     <FilterItemBody {...otherProps}>
-                        <Expandable $height={contentHeight}>
+                        <MinimisableContent
+                            $height={contentHeight}
+                            $minimisable={minimisable}
+                        >
                             <div ref={contentResizeDetector.ref}>
                                 <div data-id="content-container">
                                     {typeof children === "function"
-                                        ? children(mode, { minimised })
+                                        ? children(mode, {
+                                              minimised: contentMinimised,
+                                          })
                                         : children}
                                 </div>
                             </div>
-                        </Expandable>
+                        </MinimisableContent>
                         {minimisable && (
                             <FilterItemMinimiseButton
                                 data-id="minimise-button"
                                 styleType="link"
                                 onClick={() => {
-                                    setMinimised(!minimised);
+                                    setContentMinimised(!contentMinimised);
                                 }}
                             >
-                                View {minimised ? "more" : "less"}
+                                View {contentMinimised ? "more" : "less"}
                             </FilterItemMinimiseButton>
                         )}
                     </FilterItemBody>
                 </div>
-            </Expandable>
+            </ExpandableItem>
         </FilterItemWrapper>
     );
 };

--- a/src/filter/filter-item.tsx
+++ b/src/filter/filter-item.tsx
@@ -83,9 +83,11 @@ export const FilterItem = ({
                     <FilterItemBody {...otherProps}>
                         <Expandable style={contentAnimationStyles}>
                             <div ref={contentResizeDetector.ref}>
-                                {typeof children === "function"
-                                    ? children(mode, { minimised })
-                                    : children}
+                                <div data-id="content-container">
+                                    {typeof children === "function"
+                                        ? children(mode, { minimised })
+                                        : children}
+                                </div>
                             </div>
                         </Expandable>
                         {minimisable && (

--- a/src/filter/filter.tsx
+++ b/src/filter/filter.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { useMediaQuery } from "react-responsive";
 import { Overlay } from "../overlay/overlay";
 import { MediaWidths } from "../spec/media-spec";
+import { FilterItemCheckbox } from "./addons/filter-item-checkbox";
 import { FilterContext } from "./filter-context";
 import { FilterItem } from "./filter-item";
 import { FilterItemPage } from "./filter-item-page";
@@ -161,4 +162,5 @@ const FilterBase = ({
 export const Filter = Object.assign(FilterBase, {
     Item: FilterItem,
     Page: FilterItemPage,
+    Checkbox: FilterItemCheckbox,
 });

--- a/src/filter/types.ts
+++ b/src/filter/types.ts
@@ -41,14 +41,12 @@ export interface FilterPageProps {
     onDone?: (() => void) | undefined;
 }
 
-interface Option {
-    label: string;
-    value: string;
-}
-
-export interface FilterItemCheckboxProps extends FilterItemProps {
-    // TODO: value extractor?
-    options: Option[];
-    value?: string[] | undefined;
-    onChange?: ((value: string[]) => void) | undefined;
+export interface FilterItemCheckboxProps<T> extends FilterItemProps {
+    options: T[];
+    selectedOptions?: T[] | undefined;
+    onSelect?: ((options: T[]) => void) | undefined;
+    /** Function to derive display value from an item. If not set, checks `item.label`. */
+    labelExtractor?: ((item: T) => string) | undefined;
+    /** Function to derive value from an item. If not set, checks `item.value`. */
+    valueExtractor?: ((item: T) => string) | undefined;
 }

--- a/src/filter/types.ts
+++ b/src/filter/types.ts
@@ -36,3 +36,15 @@ export interface FilterPageProps {
     /** Called when done button is pressed */
     onDone?: (() => void) | undefined;
 }
+
+interface Option {
+    label: string;
+    value: string;
+}
+
+export interface FilterItemCheckboxProps extends FilterItemProps {
+    // TODO: value extractor?
+    options: Option[];
+    value?: string[] | undefined;
+    onChange?: ((value: string[]) => void) | undefined;
+}

--- a/src/filter/types.ts
+++ b/src/filter/types.ts
@@ -17,7 +17,9 @@ export interface FilterProps {
 }
 
 export interface FilterItemProps {
-    children: React.ReactNode | ((mode: Mode) => React.ReactNode);
+    children:
+        | React.ReactNode
+        | ((mode: Mode, state: { minimised: boolean }) => React.ReactNode);
     /** Specifies if header divider is visible in default mode */
     showDivider?: boolean | undefined;
     /** Specifies if divider is visible in mobile mode */
@@ -27,6 +29,7 @@ export interface FilterItemProps {
     id?: string | undefined;
     "data-testid"?: string | undefined;
     collapsible?: boolean | undefined;
+    minimisable?: boolean | undefined;
 }
 
 export interface FilterPageProps {

--- a/src/filter/types.ts
+++ b/src/filter/types.ts
@@ -41,7 +41,8 @@ export interface FilterPageProps {
     onDone?: (() => void) | undefined;
 }
 
-export interface FilterItemCheckboxProps<T> extends FilterItemProps {
+export interface FilterItemCheckboxProps<T>
+    extends Omit<FilterItemProps, "children"> {
     options: T[];
     selectedOptions?: T[] | undefined;
     onSelect?: ((options: T[]) => void) | undefined;

--- a/src/filter/types.ts
+++ b/src/filter/types.ts
@@ -30,6 +30,7 @@ export interface FilterItemProps {
     "data-testid"?: string | undefined;
     collapsible?: boolean | undefined;
     minimisable?: boolean | undefined;
+    minimisedHeight?: number | undefined;
 }
 
 export interface FilterPageProps {

--- a/src/shared/toggle-icon/toggle-icon.tsx
+++ b/src/shared/toggle-icon/toggle-icon.tsx
@@ -8,7 +8,7 @@ import { Wrapper } from "./toggle-icon.styles";
 
 export type ToggleIconType = "checkbox" | "radio" | "tick" | "cross";
 
-interface Props {
+export interface Props {
     type: ToggleIconType;
     active?: boolean | undefined;
     disabled?: boolean | undefined;

--- a/src/shared/toggle-icon/toggle-icon.tsx
+++ b/src/shared/toggle-icon/toggle-icon.tsx
@@ -8,7 +8,7 @@ import { Wrapper } from "./toggle-icon.styles";
 
 export type ToggleIconType = "checkbox" | "radio" | "tick" | "cross";
 
-export interface Props {
+export interface ToggleIconProps {
     type: ToggleIconType;
     active?: boolean | undefined;
     disabled?: boolean | undefined;
@@ -20,7 +20,7 @@ export const ToggleIcon = ({
     active = false,
     disabled,
     className,
-}: Props) => {
+}: ToggleIconProps) => {
     let component: JSX.Element;
 
     switch (type) {

--- a/stories/filter/addon-props-table.tsx
+++ b/stories/filter/addon-props-table.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { ApiTable } from "../storybook-common/api-table";
+import { ApiTableSectionProps } from "../storybook-common/api-table/types";
+import { TabAttribute, Tabs } from "../storybook-common/tabs";
+
+const FILTER_CHECKBOX_DATA: ApiTableSectionProps[] = [
+    {
+        attributes: [
+            {
+                name: "",
+                description: (
+                    <>
+                        This component also inherits props from&nbsp;
+                        <a
+                            href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLButtonElement"
+                            rel="noreferrer"
+                            target="_blank"
+                        >
+                            Filter.Item
+                        </a>
+                    </>
+                ),
+            },
+            {
+                name: "selectedOptions",
+                description: "List of selected options",
+                propTypes: ["T[]"],
+            },
+            {
+                name: "options",
+                mandatory: true,
+                description: "List of options",
+                propTypes: ["T[]"],
+            },
+            {
+                name: "onSelect",
+                description: "Called when selection changes",
+                propTypes: ["(options: T[]) => void"],
+            },
+            {
+                name: "labelExtractor",
+                description: (
+                    <>
+                        Function to derive display value from an item. If not
+                        set, checks <code>item.label</code>
+                    </>
+                ),
+                propTypes: ["(item: T) => string"],
+            },
+            {
+                name: "valueExtractor",
+                description: (
+                    <>
+                        Function to derive value from an item. If not set,
+                        checks <code>item.value</code>
+                    </>
+                ),
+                propTypes: ["(item: T) => string"],
+            },
+        ],
+    },
+];
+
+const PROPS_TABLE_DATA: TabAttribute[] = [
+    {
+        title: "Filter.Checkbox",
+        component: <ApiTable sections={FILTER_CHECKBOX_DATA} />,
+    },
+];
+
+export const PropsTable = () => <Tabs tabs={PROPS_TABLE_DATA} />;

--- a/stories/filter/doc-elements.tsx
+++ b/stories/filter/doc-elements.tsx
@@ -2,8 +2,9 @@ import { MagnifierIcon } from "@lifesg/react-icons/magnifier";
 import React, { useState } from "react";
 import styled from "styled-components";
 import { Color } from "../../src/color";
-import { Mode } from "../../src/filter";
+import { Filter, Mode } from "../../src/filter";
 import { Form } from "../../src/form";
+import { Text } from "../../src/text";
 
 interface Props<T> {
     mode: Mode;
@@ -15,23 +16,26 @@ const SearchIcon = styled(MagnifierIcon)`
     color: ${Color.Neutral[3]};
 `;
 
+export const StyledFilterItem = styled(Filter.Item)<{ $mode: Mode }>`
+    padding: ${(props) =>
+        props.$mode === "default" ? "0 1.25rem 1.5rem" : "1.5rem 1.25rem"};
+`;
+
 export const SearchFilter = ({ mode, value, onChange }: Props<string>) => {
     return (
-        <div style={{ marginTop: mode === "default" ? "-1rem" : undefined }}>
-            <Form.InputGroup
-                placeholder="Search with keyword"
-                addon={{
-                    type: "custom",
-                    attributes: {
-                        children: <SearchIcon />,
-                    },
-                }}
-                value={value}
-                onChange={(e) => {
-                    onChange(e.target.value);
-                }}
-            />
-        </div>
+        <Form.InputGroup
+            placeholder="Search with keyword"
+            addon={{
+                type: "custom",
+                attributes: {
+                    children: <SearchIcon />,
+                },
+            }}
+            value={value}
+            onChange={(e) => {
+                onChange(e.target.value);
+            }}
+        />
     );
 };
 
@@ -39,10 +43,27 @@ export const DateFilter = ({ value, onChange }: Props<string>) => {
     return <Form.DateInput value={value} onChange={(date) => onChange(date)} />;
 };
 
+export const TextFilter = () => {
+    return (
+        <Text.BodySmall>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi
+            venenatis neque felis, ac tempor erat iaculis et. Nam elementum at
+            lectus et dapibus. Orci varius natoque penatibus et magnis dis
+            parturient montes, nascetur ridiculus mus. Integer aliquam placerat
+            ullamcorper. Sed ut pulvinar felis. Praesent vulputate ex quis
+            tellus dictum laoreet. Aliquam condimentum libero ut sagittis
+            interdum. Fusce auctor pharetra lorem eu rhoncus. Integer
+            consectetur in odio sed vestibulum. Nunc imperdiet ligula non eros
+            faucibus, non aliquam dui aliquet.
+        </Text.BodySmall>
+    );
+};
+
 export const useFilters = () => {
     const INITIAL_STATE = {
         search: "",
         cat1: "",
+        cat2: [],
     };
 
     const [currentFilters, setCurrentFilters] = useState(INITIAL_STATE);

--- a/stories/filter/doc-elements.tsx
+++ b/stories/filter/doc-elements.tsx
@@ -1,4 +1,5 @@
 import { MagnifierIcon } from "@lifesg/react-icons/magnifier";
+import isEmpty from "lodash/isEmpty";
 import React, { useState } from "react";
 import styled from "styled-components";
 import { Color } from "../../src/color";
@@ -68,8 +69,8 @@ export const useFilters = () => {
 
     const [currentFilters, setCurrentFilters] = useState(INITIAL_STATE);
     const [draftFilters, setDraftFilters] = useState(INITIAL_STATE);
-    const clearButtonDisabled = Object.values(draftFilters).every(
-        (filter) => !filter
+    const clearButtonDisabled = Object.values(draftFilters).every((filter) =>
+        isEmpty(filter)
     );
 
     const updateFilter = (mode: Mode, filterKey: string) => (val) => {

--- a/stories/filter/filter-addons.stories.mdx
+++ b/stories/filter/filter-addons.stories.mdx
@@ -15,9 +15,15 @@ import { PropsTable } from "./addon-props-table";
 
 <Meta title="Modules/Filter/Addons" component={Filter} />
 
-<Title>Filter Checkbox</Title>
+<Title>Filter.Checkbox</Title>
+
+<Secondary>Overview</Secondary>
 
 Widget to select multiple options
+
+```tsx
+import { Filter } from "@lifesg/react-design-system/filter";
+```
 
 <Canvas>
     <Story name="Filter Checkbox">
@@ -44,8 +50,8 @@ Widget to select multiple options
                                 <Filter.Checkbox
                                     showMobileDivider={false}
                                     title="With 5 or less items"
-                                    selectedOptions={draftFilters.cat2}
-                                    onSelect={updateFilter(mode, "cat2")}
+                                    selectedOptions={draftFilters.cat1}
+                                    onSelect={updateFilter(mode, "cat1")}
                                     options={[
                                         {
                                             value: "1",

--- a/stories/filter/filter-addons.stories.mdx
+++ b/stories/filter/filter-addons.stories.mdx
@@ -1,0 +1,112 @@
+import { MagnifierIcon } from "@lifesg/react-icons/magnifier";
+import { Canvas, Meta, Preview, Story } from "@storybook/addon-docs";
+import { useState } from "react";
+import { Filter } from "../../src/filter";
+import { Form } from "../../src/form";
+import { Overlay } from "../../src/overlay";
+import {
+    Heading3,
+    Secondary,
+    StoryContainer,
+    Title,
+} from "../storybook-common";
+import { SearchFilter, TextFilter, useFilters } from "./doc-elements";
+import { PropsTable } from "./addon-props-table";
+
+<Meta title="Modules/Filter/Addons" component={Filter} />
+
+<Title>Filter Checkbox</Title>
+
+Widget to select multiple options
+
+<Canvas>
+    <Story name="Filter Checkbox">
+        {() => {
+            const {
+                currentFilters,
+                draftFilters,
+                clearButtonDisabled,
+                updateFilter,
+                saveFilters,
+                dismissFilters,
+                clearFilters,
+            } = useFilters(); // your custom filter state management here
+            return (
+                <StoryContainer>
+                    <Filter
+                        clearButtonDisabled={clearButtonDisabled}
+                        onClear={clearFilters}
+                        onDismiss={dismissFilters}
+                        onDone={saveFilters}
+                    >
+                        {(mode) => (
+                            <>
+                                <Filter.Checkbox
+                                    showMobileDivider={false}
+                                    title="With 5 or less items"
+                                    selectedOptions={draftFilters.cat2}
+                                    onSelect={updateFilter(mode, "cat2")}
+                                    options={[
+                                        {
+                                            value: "1",
+                                            label: "Sample text",
+                                        },
+                                        {
+                                            value: "2",
+                                            label: "Sample teeext",
+                                        },
+                                        {
+                                            value: "3",
+                                            label: "Sample teeeeeeeeext",
+                                        },
+                                    ]}
+                                />
+                                <Filter.Checkbox
+                                    title="With more than 5 items"
+                                    selectedOptions={draftFilters.cat2}
+                                    onSelect={updateFilter(mode, "cat2")}
+                                    options={[
+                                        {
+                                            value: "1",
+                                            label: "Label 1",
+                                        },
+                                        {
+                                            value: "2",
+                                            label: "Label 2",
+                                        },
+                                        {
+                                            value: "3",
+                                            label: "Label 3",
+                                        },
+                                        {
+                                            value: "4",
+                                            label: "Label 4",
+                                        },
+                                        {
+                                            value: "5",
+                                            label: "Label 5, which is much longer than other labels for some mysterious reason",
+                                        },
+                                        {
+                                            value: "6",
+                                            label: "Label 6",
+                                        },
+                                        {
+                                            value: "7",
+                                            label: "Label 7",
+                                        },
+                                        {
+                                            value: "8",
+                                            label: "Label 8",
+                                        },
+                                    ]}
+                                />
+                            </>
+                        )}
+                    </Filter>
+                </StoryContainer>
+            );
+        }}
+    </Story>
+</Canvas>
+
+<PropsTable />

--- a/stories/filter/filter.stories.mdx
+++ b/stories/filter/filter.stories.mdx
@@ -10,7 +10,13 @@ import {
     StoryContainer,
     Title,
 } from "../storybook-common";
-import { DateFilter, SearchFilter, useFilters } from "./doc-elements";
+import {
+    DateFilter,
+    SearchFilter,
+    StyledFilterItem,
+    TextFilter,
+    useFilters,
+} from "./doc-elements";
 import { PropsTable } from "./props-table";
 
 <Meta title="Modules/Filter" component={Filter} />
@@ -47,8 +53,8 @@ import { Filter } from "@lifesg/react-design-system/filter";
                     >
                         {(mode) => (
                             <>
-                                <Filter.Item
-                                    title=""
+                                <StyledFilterItem
+                                    $mode={mode}
                                     collapsible={false}
                                     showMobileDivider={false}
                                     showDivider={false}
@@ -58,8 +64,8 @@ import { Filter } from "@lifesg/react-design-system/filter";
                                         value={draftFilters.search}
                                         onChange={updateFilter(mode, "search")}
                                     />
-                                </Filter.Item>
-                                <Filter.Item title="Category 1">
+                                </StyledFilterItem>
+                                <Filter.Item title="Date">
                                     <DateFilter
                                         mode={mode}
                                         value={draftFilters.cat1}
@@ -67,20 +73,7 @@ import { Filter } from "@lifesg/react-design-system/filter";
                                     />
                                 </Filter.Item>
                                 <Filter.Item title="Just an example of long content that may wrap to the next line">
-                                    Lorem ipsum dolor sit amet, consectetur
-                                    adipiscing elit. Morbi venenatis neque
-                                    felis, ac tempor erat iaculis et. Nam
-                                    elementum at lectus et dapibus. Orci varius
-                                    natoque penatibus et magnis dis parturient
-                                    montes, nascetur ridiculus mus. Integer
-                                    aliquam placerat ullamcorper. Sed ut
-                                    pulvinar felis. Praesent vulputate ex quis
-                                    tellus dictum laoreet. Aliquam condimentum
-                                    libero ut sagittis interdum. Fusce auctor
-                                    pharetra lorem eu rhoncus. Integer
-                                    consectetur in odio sed vestibulum. Nunc
-                                    imperdiet ligula non eros faucibus, non
-                                    aliquam dui aliquet.
+                                    <TextFilter />
                                 </Filter.Item>
                             </>
                         )}
@@ -114,6 +107,33 @@ Each item can be configured with `collapsible`, `showDivider` and `showMobileDiv
                 </Filter.Item>
                 <Filter.Item title="Not collapsible" collapsible={false}>
                     Always visible
+                </Filter.Item>
+            </Filter>
+        </StoryContainer>
+    </Story>
+</Canvas>
+
+<Heading3>Minimising content</Heading3>
+
+For longer filter items, content can be minimised with the `minimisable` prop.
+
+<Canvas>
+    <Story name="Minimised">
+        <StoryContainer>
+            <Filter>
+                <Filter.Item
+                    title="Minimised"
+                    minimisable
+                    showMobileDivider={false}
+                >
+                    <TextFilter />
+                </Filter.Item>
+                <Filter.Item
+                    title="With custom minimised height"
+                    minimisable
+                    minimisedHeight={100}
+                >
+                    <TextFilter />
                 </Filter.Item>
             </Filter>
         </StoryContainer>


### PR DESCRIPTION
**Changes**
- Add functionality to `Filter.Item` to minimise contents
  - visible height defaults to 50% of content height or 216px, whichever is smaller
  - custom height can also be set
- Allow more granular styling in `Filter.Item`
- Add `Filter.Checkbox` to render list of options in a checkbox group
- delete branch

<!-- Remove if not required -->
**Changelog entry**

- Introduce `Filter.Checkbox` widget to select multiple options from a list

**Additional information**

- You may refer to this [ticket](https://jira.ship.gov.sg/browse/MOL-12517)