### PR TITLE
Add BookingSG ErrorDisplay assets

### DIFF
--- a/src/error-display/error-display-data.tsx
+++ b/src/error-display/error-display-data.tsx
@@ -358,11 +358,11 @@ export const ERROR_DISPLAY_DATA_BSG = new Map<
 
 export const errorDisplayData = (
     type: ErrorDisplayType,
-    colorScheme: ColorScheme = "base"
+    resourceScheme: ColorScheme = "base"
 ) => {
-    if (colorScheme === "base") {
+    if (resourceScheme === "base") {
         return ERROR_DISPLAY_DATA.get(type);
-    } else if (colorScheme === "bookingsg") {
+    } else if (resourceScheme === "bookingsg") {
         return ERROR_DISPLAY_DATA_BSG.get(type);
     }
 };

--- a/src/error-display/error-display-data.tsx
+++ b/src/error-display/error-display-data.tsx
@@ -1,3 +1,4 @@
+import { ColorScheme } from "src/theme/types";
 import { MediaWidths } from "../spec/media-spec";
 import {
     Error500AdditionalAttributes,
@@ -235,3 +236,133 @@ export const ERROR_DISPLAY_DATA = new Map<
         },
     ],
 ]);
+
+export const ERROR_DISPLAY_DATA_BSG = new Map<
+    ErrorDisplayType,
+    ErrorDisplayDataAttrs
+>([
+    [
+        "400",
+        {
+            img: oldImgAttributeHelper(ImgPaths["400"]),
+            title: "Something went wrong",
+            description: (
+                <>
+                    This could be a temporary problem, so please refresh the
+                    page or try again later.
+                </>
+            ),
+        },
+    ],
+    [
+        "403",
+        {
+            img: oldImgAttributeHelper(ImgPaths["403"]),
+            title: "Error loading page",
+            description: <>You may not have permission to view this page.</>,
+        },
+    ],
+    [
+        "404",
+        {
+            img: oldImgAttributeHelper(ImgPaths["404"]),
+            title: "Page not found",
+            description: (
+                <>
+                    If you entered or pasted the URL, check that it&rsquo;s
+                    correct.
+                </>
+            ),
+        },
+    ],
+    [
+        "408",
+        {
+            img: oldImgAttributeHelper(ImgPaths["400"]),
+            title: "Something went wrong",
+            description: (
+                <>
+                    Please refresh the page or try again later. If it&rsquo;s
+                    still not working, email{" "}
+                    <a href="mailto:helpdesk@life.gov.sg">
+                        helpdesk@life.gov.sg
+                    </a>{" "}
+                    and let us know you received a HTTP 408 error.
+                </>
+            ),
+        },
+    ],
+    [
+        "500",
+        {
+            img: imgAttributeHelper(ImgPaths["500"]),
+            title: "Something went wrong",
+            description: (
+                <>
+                    This could be a temporary problem, so please refresh the
+                    page or try again later.
+                </>
+            ),
+            renderDescription: (attrs: Error500AdditionalAttributes) => (
+                <>
+                    This could be a temporary problem, so please refresh the
+                    page or try again later.
+                </>
+            ),
+        },
+    ],
+    [
+        "503",
+        {
+            img: oldImgAttributeHelper(ImgPaths["503"]),
+            title: "Service under maintenance",
+            description:
+                "This service is currently unavailable. Please try again later.",
+        },
+    ],
+    [
+        "maintenance",
+        {
+            img: oldImgAttributeHelper(ImgPaths["503"]),
+            title: "Service under maintenance",
+            description:
+                "This service is currently unavailable. Please try again later.",
+            renderDescription: (attrs: MaintenanceAdditionalAttributes) => (
+                <>
+                    This service is currently unavailable. Please try again
+                    after&nbsp;
+                    <strong>{attrs.dateString}</strong>.
+                </>
+            ),
+        },
+    ],
+    [
+        "unsupported-browser",
+        {
+            img: imgAttributeHelper(ImgPaths["unsupported-browser"]),
+            title: "Browser not supported",
+            description:
+                "To use BookingSG, download the latest version of Chrome, Edge, Firefox or Safari.",
+        },
+    ],
+    [
+        "partially-supported-browser",
+        {
+            img: imgAttributeHelper(ImgPaths["unsupported-browser"]),
+            title: "Browser not supported",
+            description:
+                "BookingSG works best with the latest version of Chrome, Edge, Firefox or Safari. If you continue with your browser, you may run into problems.",
+        },
+    ],
+]);
+
+export const errorDisplayData = (
+    type: ErrorDisplayType,
+    colorScheme: ColorScheme = "base"
+) => {
+    if (colorScheme === "base") {
+        return ERROR_DISPLAY_DATA.get(type);
+    } else if (colorScheme === "bookingsg") {
+        return ERROR_DISPLAY_DATA_BSG.get(type);
+    }
+};

--- a/src/error-display/error-display.tsx
+++ b/src/error-display/error-display.tsx
@@ -1,5 +1,7 @@
 import React from "react";
-import { ERROR_DISPLAY_DATA } from "./error-display-data";
+import { ThemeSpec } from "src/theme";
+import { useTheme } from "styled-components";
+import { errorDisplayData } from "./error-display-data";
 import {
     ActionButton,
     Container,
@@ -26,7 +28,12 @@ export const ErrorDisplay = ({
     // =============================================================================
     // CONST, STATE, REF
     // =============================================================================
-    const defaultAssets = ERROR_DISPLAY_DATA.get(type);
+    const theme = useTheme();
+    console.log(theme);
+    const defaultAssets = errorDisplayData(
+        type,
+        (theme as unknown as ThemeSpec).colorScheme
+    );
     const testId = otherProps["data-testid"] || "error-display";
 
     // =============================================================================

--- a/src/error-display/error-display.tsx
+++ b/src/error-display/error-display.tsx
@@ -29,10 +29,7 @@ export const ErrorDisplay = ({
     // CONST, STATE, REF
     // =============================================================================
     const theme = useTheme();
-    const defaultAssets = errorDisplayData(
-        type,
-        (theme as unknown as ThemeSpec).resourceScheme
-    );
+    const defaultAssets = errorDisplayData(type, theme.resourceScheme);
     const testId = otherProps["data-testid"] || "error-display";
 
     // =============================================================================

--- a/src/error-display/error-display.tsx
+++ b/src/error-display/error-display.tsx
@@ -31,7 +31,7 @@ export const ErrorDisplay = ({
     const theme = useTheme();
     const defaultAssets = errorDisplayData(
         type,
-        (theme as unknown as ThemeSpec).colorScheme
+        (theme as unknown as ThemeSpec).resourceScheme
     );
     const testId = otherProps["data-testid"] || "error-display";
 

--- a/src/error-display/error-display.tsx
+++ b/src/error-display/error-display.tsx
@@ -29,7 +29,6 @@ export const ErrorDisplay = ({
     // CONST, STATE, REF
     // =============================================================================
     const theme = useTheme();
-    console.log(theme);
     const defaultAssets = errorDisplayData(
         type,
         (theme as unknown as ThemeSpec).colorScheme

--- a/stories/error-display/error-display.stories.mdx
+++ b/stories/error-display/error-display.stories.mdx
@@ -74,6 +74,18 @@ The `ErrorDisplay` component is customisable according to your project's needs. 
     </Story>
 </Preview>
 
+<Heading3>Theme</Heading3>
+
+The `ErrorDisplay` component uses the `resourceScheme` key from the theme. Based
+on the `resourceScheme` set in the theme, it will display different title and description.
+Try switching between themes in the Canvas to see the changes.
+
+<Preview>
+    <Story name="Using theme">
+        <ErrorDisplay type="404" />
+    </Story>
+</Preview>
+
 <Heading3>See also</Heading3>
 
 [Variants](#variants) | [Component API](#component-api)

--- a/tests/error-display/error-display.spec.tsx
+++ b/tests/error-display/error-display.spec.tsx
@@ -8,7 +8,7 @@ import { ERROR_DISPLAY_DATA } from "../../src/error-display/error-display-data";
 
 jest.mock("styled-components", () => {
     const actual = jest.requireActual("styled-components");
-    actual.useTheme = () => ({ colorScheme: "base" });
+    actual.useTheme = () => ({ resourceScheme: "base" });
     return actual;
 });
 

--- a/tests/error-display/error-display.spec.tsx
+++ b/tests/error-display/error-display.spec.tsx
@@ -1,11 +1,18 @@
 import { render, screen } from "@testing-library/react";
-
+import * as styledComponents from "styled-components";
 import { ErrorDisplay } from "../../src";
 import { ERROR_DISPLAY_DATA } from "../../src/error-display/error-display-data";
 
 // =============================================================================
 // UNIT TESTS
 // =============================================================================
+
+jest.mock("styled-components", () => {
+    const actual = jest.requireActual("styled-components");
+    actual.useTheme = () => ({ colorScheme: "base" });
+    return actual;
+});
+
 describe("ErrorDisplay", () => {
     beforeEach(() => {
         jest.resetAllMocks();

--- a/tests/error-display/error-display.spec.tsx
+++ b/tests/error-display/error-display.spec.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import * as styledComponents from "styled-components";
 import { ErrorDisplay } from "../../src";
 import { ERROR_DISPLAY_DATA } from "../../src/error-display/error-display-data";
 


### PR DESCRIPTION
**Changes**
- Added error display data for BSG
- Added function to get error display based on theme (e.g. base/bookingsg)
- Updated mock for error display tests

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**
- Added error display data for BSG

**Additional information**

- You may refer to this [BOOKINGSG-3895](https://jira.ship.gov.sg/browse/BOOKINGSG-3895)
- This was a requirement from Michelle so that we have copy and illustrations for BSG directly from DS (Illustrations are not done yet, will raise another PR to update illustrations once its done)
