### PR TITLE
Add resourceScheme key to the theme

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,4 @@
 import { withThemes } from "@react-theming/storybook-addon";
-import { withA11y } from "@storybook/addon-a11y";
 import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport";
 import { addDecorator } from "@storybook/react";
 import pretty from "pretty";
@@ -37,4 +36,3 @@ const themes = [
 ];
 
 addDecorator(withThemes(ThemeProvider, themes));
-addDecorator(withA11y);

--- a/custom-types/styled.d.ts
+++ b/custom-types/styled.d.ts
@@ -1,0 +1,6 @@
+import "styled-components";
+import { ThemeSpec } from "../src/theme/types";
+
+declare module "styled-components" {
+    export interface DefaultTheme extends ThemeSpec {}
+}

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -4,12 +4,14 @@ export const BaseTheme: ThemeSpec = {
     [ThemeContextKeys.colorScheme]: "base",
     [ThemeContextKeys.textStyleScheme]: "base",
     [ThemeContextKeys.designTokenScheme]: "base",
+    [ThemeContextKeys.resourceScheme]: "base",
 };
 
 export const BookingSGTheme: ThemeSpec = {
     [ThemeContextKeys.colorScheme]: "bookingsg",
     [ThemeContextKeys.textStyleScheme]: "base",
     [ThemeContextKeys.designTokenScheme]: "base",
+    [ThemeContextKeys.resourceScheme]: "bookingsg",
 };
 
 export * from "./types";

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -29,6 +29,11 @@ export type DesignTokenCollectionsMap = {
 };
 
 // =============================================================================
+// RESOURCE THEMES
+// =============================================================================
+export type ResourceScheme = "base" | "bookingsg";
+
+// =============================================================================
 // GENERAL
 // =============================================================================
 export enum ThemeContextKeys {
@@ -36,6 +41,7 @@ export enum ThemeContextKeys {
     layout = "layout",
     textStyleScheme = "textStyleScheme",
     designTokenScheme = "designTokenScheme",
+    resourceScheme = "resourceScheme",
 }
 
 export interface ThemeSpecOptions {
@@ -54,6 +60,8 @@ export interface ThemeSpec {
     [ThemeContextKeys.designTokenScheme]: DesignTokenScheme;
     /** Sets the layout scheme of the theme */
     [ThemeContextKeys.layout]?: ThemeLayout | undefined;
+    /** Sets the resource scheme (e.g. images, text) of the theme */
+    [ThemeContextKeys.resourceScheme]: ResourceScheme | undefined;
     /** For specific customisations to any schemes */
     options?: ThemeSpecOptions | undefined;
 }

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -61,7 +61,7 @@ export interface ThemeSpec {
     /** Sets the layout scheme of the theme */
     [ThemeContextKeys.layout]?: ThemeLayout | undefined;
     /** Sets the resource scheme (e.g. images, text) of the theme */
-    [ThemeContextKeys.resourceScheme]: ResourceScheme | undefined;
+    [ThemeContextKeys.resourceScheme]: ResourceScheme;
     /** For specific customisations to any schemes */
     options?: ThemeSpecOptions | undefined;
 }

--- a/stories/getting-started/themes-props-table.tsx
+++ b/stories/getting-started/themes-props-table.tsx
@@ -34,6 +34,17 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: [`"base"`],
             },
             {
+                name: "resourceScheme",
+                mandatory: true,
+                description: (
+                    <>
+                        The resource scheme that will affect certain images or
+                        text values in certain components
+                    </>
+                ),
+                propTypes: [`"base"`, `"bookingsg"`],
+            },
+            {
                 name: "options",
                 description: (
                     <>

--- a/stories/getting-started/themes.stories.mdx
+++ b/stories/getting-started/themes.stories.mdx
@@ -28,6 +28,7 @@ A theme object is composed as such:
 	colorScheme: "base",
 	textStyleScheme: "base",
 	designTokenScheme: "base",
+    resourceScheme: "base"
 }
 ```
 
@@ -52,6 +53,7 @@ const myTheme: ThemeSpec = {
     colorScheme: "base",
     textStyleScheme: "base",
     designTokenScheme: "base",
+    resourceScheme: "base",
 };
 
 const App = () => {


### PR DESCRIPTION
**Changes**
Add `resourceScheme` key to the theme object for use in `ErrorDisplay` in [PR](https://github.com/LifeSG/react-design-system/pull/125)

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Add `resourceScheme` key to the theme object for toggling of image assets and even text content
