### PR TITLE
Fix range date input mobile styles

### DIFF
--- a/src/date-input/date-input.style.tsx
+++ b/src/date-input/date-input.style.tsx
@@ -34,7 +34,6 @@ export const Container = styled.div<ContainerStyleProps>`
     background: ${Color.Neutral[8]};
     height: 3rem;
     width: 100%;
-    min-width: 20.75rem;
     padding: 0.1rem 1rem 0;
 
     :focus,

--- a/src/shared/internal-calendar/internal-calendar.style.tsx
+++ b/src/shared/internal-calendar/internal-calendar.style.tsx
@@ -57,7 +57,7 @@ export const IconChevronDown = styled(ChevronDownIcon)`
 // -----------------------------------------------------------------------------
 export const AnimatedDiv = styled(animated.div)`
     position: absolute;
-    top: 3.5rem;
+    top: calc(100% + 0.5rem);
     left: 0;
     width: 100%;
     max-width: 41rem;

--- a/stories/form/form-date-input/form-date-input.stories.mdx
+++ b/stories/form/form-date-input/form-date-input.stories.mdx
@@ -58,11 +58,14 @@ You can use `variant='range'` to specify a range selection.
             const [endValue] = useState(dayjs().day(20).format("YYYY-MM-DD"));
             return (
                 <StoryContainer>
-                    <Container>
+                    <div>
                         <Form.DateInput
                             label="This is the default date range input"
                             variant="range"
                         />
+                    </div>
+                    <br />
+                    <div>
                         <Form.DateInput
                             label="This is the date range input without button"
                             variant="range"
@@ -70,6 +73,9 @@ You can use `variant='range'` to specify a range selection.
                             value={startValue}
                             valueEnd={endValue}
                         />
+                    </div>
+                    <br />
+                    <div>
                         <Form.DateInput
                             label="This is the disabled state"
                             disabled
@@ -77,6 +83,9 @@ You can use `variant='range'` to specify a range selection.
                             value={startValue}
                             valueEnd={endValue}
                         />
+                    </div>
+                    <br />
+                    <div>
                         <Form.DateInput
                             label="This is the readonly state"
                             readOnly
@@ -84,12 +93,15 @@ You can use `variant='range'` to specify a range selection.
                             value={startValue}
                             valueEnd={endValue}
                         />
+                    </div>
+                    <br />
+                    <div>
                         <Form.DateInput
                             label="This is the error state"
                             variant="range"
                             errorMessage="Invalid date"
                         />
-                    </Container>
+                    </div>
                 </StoryContainer>
             );
         }}
@@ -110,17 +122,18 @@ You can use `disabledDates` to specify dates that are not available for selectio
             ]);
             return (
                 <StoryContainer>
-                    <Container>
+                    <div>
                         <Form.DateInput
                             label="This is a date input with disabled dates"
                             disabledDates={disabledDates}
                         />
+                        <br />
                         <Form.DateInput
                             label="This is a date range input with disabled dates"
                             variant="range"
                             disabledDates={disabledDates}
                         />
-                    </Container>
+                    </div>
                 </StoryContainer>
             );
         }}

--- a/stories/form/form-date-input/form-date-input.stories.mdx
+++ b/stories/form/form-date-input/form-date-input.stories.mdx
@@ -30,19 +30,17 @@ import { Form } from "@lifesg/react-design-system/form";
 <Canvas>
     <Story name="DateInput">
         <StoryContainer>
-            <Container>
-                <Form.DateInput label="This is the default date input" />
-                <Form.DateInput
-                    label="This is the date input without buttons"
-                    withButton={false}
-                />
-                <Form.DateInput label="This is the disabled state" disabled />
-                <Form.DateInput label="This is the readonly state" readOnly />
-                <Form.DateInput
-                    label="This is the error state"
-                    errorMessage="Invalid date"
-                />
-            </Container>
+            <Form.DateInput label="This is the default date input" />
+            <Form.DateInput
+                label="This is the date input without buttons"
+                withButton={false}
+            />
+            <Form.DateInput label="This is the disabled state" disabled />
+            <Form.DateInput label="This is the readonly state" readOnly />
+            <Form.DateInput
+                label="This is the error state"
+                errorMessage="Invalid date"
+            />
         </StoryContainer>
     </Story>
 </Canvas>
@@ -58,50 +56,36 @@ You can use `variant='range'` to specify a range selection.
             const [endValue] = useState(dayjs().day(20).format("YYYY-MM-DD"));
             return (
                 <StoryContainer>
-                    <div>
-                        <Form.DateInput
-                            label="This is the default date range input"
-                            variant="range"
-                        />
-                    </div>
-                    <br />
-                    <div>
-                        <Form.DateInput
-                            label="This is the date range input without button"
-                            variant="range"
-                            withButton={false}
-                            value={startValue}
-                            valueEnd={endValue}
-                        />
-                    </div>
-                    <br />
-                    <div>
-                        <Form.DateInput
-                            label="This is the disabled state"
-                            disabled
-                            variant="range"
-                            value={startValue}
-                            valueEnd={endValue}
-                        />
-                    </div>
-                    <br />
-                    <div>
-                        <Form.DateInput
-                            label="This is the readonly state"
-                            readOnly
-                            variant="range"
-                            value={startValue}
-                            valueEnd={endValue}
-                        />
-                    </div>
-                    <br />
-                    <div>
-                        <Form.DateInput
-                            label="This is the error state"
-                            variant="range"
-                            errorMessage="Invalid date"
-                        />
-                    </div>
+                    <Form.DateInput
+                        label="This is the default date range input"
+                        variant="range"
+                    />
+                    <Form.DateInput
+                        label="This is the date range input without button"
+                        variant="range"
+                        withButton={false}
+                        value={startValue}
+                        valueEnd={endValue}
+                    />
+                    <Form.DateInput
+                        label="This is the disabled state"
+                        disabled
+                        variant="range"
+                        value={startValue}
+                        valueEnd={endValue}
+                    />
+                    <Form.DateInput
+                        label="This is the readonly state"
+                        readOnly
+                        variant="range"
+                        value={startValue}
+                        valueEnd={endValue}
+                    />
+                    <Form.DateInput
+                        label="This is the error state"
+                        variant="range"
+                        errorMessage="Invalid date"
+                    />
                 </StoryContainer>
             );
         }}
@@ -122,18 +106,16 @@ You can use `disabledDates` to specify dates that are not available for selectio
             ]);
             return (
                 <StoryContainer>
-                    <div>
-                        <Form.DateInput
-                            label="This is a date input with disabled dates"
-                            disabledDates={disabledDates}
-                        />
-                        <br />
-                        <Form.DateInput
-                            label="This is a date range input with disabled dates"
-                            variant="range"
-                            disabledDates={disabledDates}
-                        />
-                    </div>
+                    <Form.DateInput
+                        label="This is a date input with disabled dates"
+                        disabledDates={disabledDates}
+                    />
+                    <br />
+                    <Form.DateInput
+                        label="This is a date range input with disabled dates"
+                        variant="range"
+                        disabledDates={disabledDates}
+                    />
                 </StoryContainer>
             );
         }}


### PR DESCRIPTION
**Changes**
Description of changes...

1. fix the calendar dropdown position styling in mobile view
2. remove the wrapper container inside the date input story

- delete branch

<!-- Remove if not required -->
**Changelog entry**

- [WARNING] Description of change in `DateInput`
