### PR TITLE
V2 date picker min/max props

### DIFF
--- a/src/date-input/date-input.tsx
+++ b/src/date-input/date-input.tsx
@@ -14,7 +14,8 @@ import { DateInputProps } from "./types";
 export type ActionComponent = "calendar" | "input";
 
 export const DateInput = ({
-    between,
+    minDate,
+    maxDate,
     disabled,
     disabledDates,
     error,
@@ -73,7 +74,13 @@ export const DateInput = ({
     }
 
     const handleChange = (val: string) => {
-        if (DateInputHelper.isDateDisabled(val, { disabledDates, between })) {
+        if (
+            DateInputHelper.isDateDisabled(val, {
+                disabledDates,
+                minDate,
+                maxDate,
+            })
+        ) {
             return;
         }
 
@@ -166,8 +173,8 @@ export const DateInput = ({
                 withButton={withButton}
                 value={selectedDate}
                 disabledDates={disabledDates}
-                minDate={between && between[0]} // FIXME: Handle refactoring of between prop to minDate and maxDate
-                maxDate={between && between[1]} // FIXME: Same as above
+                minDate={minDate}
+                maxDate={maxDate}
                 onHover={handleHoverDayCell}
                 onSelect={handleChange}
                 onDismiss={handleCalendarAction}

--- a/src/date-input/types.ts
+++ b/src/date-input/types.ts
@@ -20,10 +20,13 @@ export interface DateInputProps {
      */
     withButton?: boolean | undefined;
     /**
-     * Restrict selection to within this date range, in `YYYY-MM-DD` format.
-     * Example: `["2023-03-15", "2023-04-19"]
+     * The minimum date that can be selected (inclusive) in 'YYYY-MM-DD' format.
      */
-    between?: [string, string] | undefined;
+    minDate?: string | undefined;
+    /**
+     * The maximum date that can be selected (inclusive) in 'YYYY-MM-DD' format.
+     */
+    maxDate?: string | undefined;
     /**
      * Function that returns when a valid selection is made. Returns the start
      * date in "YYYY-MM-DD" string format.

--- a/src/date-range-input/date-range-input.tsx
+++ b/src/date-range-input/date-range-input.tsx
@@ -43,7 +43,8 @@ const INITIAL_STATE: DateRangeInputState = {
 };
 
 export const DateRangeInput = ({
-    between,
+    minDate,
+    maxDate,
     disabled,
     disabledDates,
     error,
@@ -195,7 +196,13 @@ export const DateRangeInput = ({
             return;
         }
 
-        if (DateInputHelper.isDateDisabled(val, { disabledDates, between })) {
+        if (
+            DateInputHelper.isDateDisabled(val, {
+                disabledDates,
+                minDate,
+                maxDate,
+            })
+        ) {
             // date is invalid, remain on this input
             return;
         }
@@ -245,7 +252,13 @@ export const DateRangeInput = ({
             return;
         }
 
-        if (DateInputHelper.isDateDisabled(val, { disabledDates, between })) {
+        if (
+            DateInputHelper.isDateDisabled(val, {
+                disabledDates,
+                minDate,
+                maxDate,
+            })
+        ) {
             // date  is invalid, remain on this input
             return;
         }
@@ -291,7 +304,8 @@ export const DateRangeInput = ({
             !validFormat ||
             DateInputHelper.isDateDisabled(selectedStart, {
                 disabledDates,
-                between,
+                minDate,
+                maxDate,
             })
         ) {
             actions.resetStart();
@@ -304,7 +318,8 @@ export const DateRangeInput = ({
             !validFormat ||
             DateInputHelper.isDateDisabled(selectedEnd, {
                 disabledDates,
-                between,
+                minDate,
+                maxDate,
             })
         ) {
             actions.resetEnd();
@@ -403,8 +418,8 @@ export const DateRangeInput = ({
                 selectWithinRange={isStartDirty || isEndDirty}
                 currentFocus={currentFocus}
                 disabledDates={disabledDates}
-                minDate={between && between[0]} // FIXME: Handle refactoring of between prop to minDate and maxDate
-                maxDate={between && between[1]} // FIXME: Same as above
+                minDate={minDate}
+                maxDate={maxDate}
                 onSelect={handleCalendarSelect}
                 onDismiss={handleCalendarDismiss}
                 onHover={handleCalendarHover}

--- a/src/date-range-input/types.ts
+++ b/src/date-range-input/types.ts
@@ -23,7 +23,14 @@ export interface DateRangeInputProps {
      * Is restricted to `true` on mobile viewports
      */
     withButton?: boolean | undefined;
-    between?: [string, string] | undefined;
+    /**
+     * The minimum date that can be selected (inclusive) in 'YYYY-MM-DD' format.
+     */
+    minDate?: string | undefined;
+    /**
+     * The maximum date that can be selected (inclusive) in 'YYYY-MM-DD' format.
+     */
+    maxDate?: string | undefined;
     /**
      * Function that returns when a valid selection is made. Returns the start and
      * end date in "YYYY-MM-DD" string format.

--- a/src/util/date-input-helper.ts
+++ b/src/util/date-input-helper.ts
@@ -4,13 +4,11 @@ import isBetween from "dayjs/plugin/isBetween";
 dayjs.extend(isBetween);
 
 export namespace DateInputHelper {
-    const dateFormat = /^\d{4}-\d{2}-\d{2}$/; // YYYY-MM-DD
-
     export const isDateDisabled = (
         val: string | undefined,
-        props: { disabledDates?: string[]; between?: [string, string] }
+        props: { disabledDates?: string[]; minDate?: string; maxDate?: string }
     ): boolean => {
-        const { disabledDates, between } = props;
+        const { disabledDates, minDate, maxDate } = props;
         if (
             disabledDates &&
             disabledDates.length &&
@@ -19,129 +17,18 @@ export namespace DateInputHelper {
             return true;
         }
 
-        if (between && between.length === 2) {
-            const [min, max] = between;
-            if (!min || !max) {
-                console.warn('"between" prop is invalid');
+        if (minDate) {
+            if (dayjs(val).isBefore(minDate)) {
                 return true;
             }
+        }
 
-            if (!dayjs(val).isBetween(min, max, "day", "[]")) {
+        if (maxDate) {
+            if (dayjs(val).isAfter(maxDate)) {
                 return true;
             }
         }
 
         return false;
     };
-
-    export const validate = (
-        startDate: string | undefined,
-        endDate: string | undefined,
-        disabledDates?: string[] | undefined,
-        between?: string[] | undefined
-    ): boolean => {
-        if (!startDate || !endDate) {
-            return false;
-        }
-
-        if (dayjs(startDate).isAfter(endDate)) {
-            return false;
-        }
-
-        if (
-            disabledDates &&
-            disabledDates.length &&
-            disabledDates.some((value) => [startDate, endDate].includes(value))
-        ) {
-            return false;
-        }
-
-        if (between && between.length) {
-            if (
-                ![startDate, endDate].every((selectedDate) =>
-                    dayjs(selectedDate).isBetween(
-                        between[0],
-                        between[1],
-                        "day",
-                        "[]"
-                    )
-                )
-            ) {
-                return false;
-            }
-
-            if (!between.every((value) => dateFormat.test(value))) {
-                return false;
-            }
-        }
-
-        return true;
-    };
-
-    export const validateSingle = (
-        value: string,
-        disabledDates?: string[] | undefined,
-        between?: string[] | undefined
-    ) => {
-        if (value.length === 0) {
-            return false;
-        }
-
-        if (
-            disabledDates &&
-            disabledDates.length &&
-            disabledDates.some((disabledDate) => value === disabledDate)
-        ) {
-            return false;
-        }
-
-        if (
-            between &&
-            between.length &&
-            !dayjs(value).isBetween(between[0], between[1], "day", "[]")
-        ) {
-            if (!dayjs(value).isBetween(between[0], between[1], "day", "[]")) {
-                return false;
-            }
-
-            if (!between.every((value) => dateFormat.test(value))) {
-                return false;
-            }
-        }
-
-        return true;
-    };
-
-    export const getFormattedRawValue = (
-        startValue: string,
-        endValue?: string
-    ): {
-        start: string[];
-        end: string[] | undefined;
-    } => {
-        const delimiter = "-";
-        const [year, month, day] = startValue.split(delimiter);
-
-        const start = [day, month, year];
-
-        let end = undefined;
-        if (endValue) {
-            const [endYear, endMonth, endDay] = endValue.split(delimiter);
-            end = [endDay, endMonth, endYear];
-        }
-
-        return {
-            start,
-            end,
-        };
-    };
-
-    export const sleep = (ms: number, controller: AbortController) =>
-        new Promise((resolve) => {
-            const timeoutId = setTimeout(resolve, ms);
-
-            controller.signal.addEventListener("abort", () => {
-                clearTimeout(timeoutId);
-            });
-        });
 }

--- a/stories/form/form-date-input/form-date-input.stories.mdx
+++ b/stories/form/form-date-input/form-date-input.stories.mdx
@@ -69,23 +69,24 @@ You can use `disabledDates` to specify dates that are not available for selectio
     </Story>
 </Canvas>
 
-<Heading3>Within date range</Heading3>
+<Heading3>Within minimum and maximum dates</Heading3>
 
-You can restrict selection to a date range using `between`.
+You can specify the `minDate` and/or `maxDate` to control the selection range.
 
 <Canvas>
-    <Story name="Within date range">
+    <Story name="Min and max dates">
         {() => {
-            const [between] = useState([
-                dayjs().date(7).format("YYYY-MM-DD"),
-                dayjs().date(21).format("YYYY-MM-DD"),
-            ]);
             return (
                 <StoryContainer>
                     <Container>
                         <Form.DateInput
                             label="This date input has restricted selection"
-                            between={between}
+                            minDate={dayjs()
+                                .subtract(2, "days")
+                                .format("YYYY-MM-DD")}
+                            maxDate={dayjs()
+                                .add(20, "days")
+                                .format("YYYY-MM-DD")}
                         />
                     </Container>
                 </StoryContainer>

--- a/stories/form/form-date-input/props-table.tsx
+++ b/stories/form/form-date-input/props-table.tsx
@@ -14,23 +14,6 @@ const DATA: ApiTableSectionProps[] = [
         name: "DateInput specific props",
         attributes: [
             {
-                name: "between",
-                description: (
-                    <>
-                        Specifies the selection between a given date range. To
-                        specify in an array where&nbsp;
-                        <code>[startDate, endDate]</code> using the{" "}
-                        {STRING_FORMAT} for the dates.
-                        <br />
-                        E.g.{" "}
-                        <code>
-                            [{quote("2023-01-01")}, {quote("2023-02-01")}]
-                        </code>
-                    </>
-                ),
-                propTypes: ["[string, string]"],
-            },
-            {
                 name: "className",
                 description: "The class selector of the component",
                 propTypes: ["string"],
@@ -78,6 +61,26 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["string"],
             },
             {
+                name: "maxDate",
+                description: (
+                    <>
+                        Specifies the maximum date allowed for selection in
+                        the&nbsp;{STRING_FORMAT}&nbsp;{`(Inclusive)`}
+                    </>
+                ),
+                propTypes: ["string"],
+            },
+            {
+                name: "minDate",
+                description: (
+                    <>
+                        Specifies the minimum date allowed for selection in
+                        the&nbsp;{STRING_FORMAT}&nbsp;{`(Inclusive)`}
+                    </>
+                ),
+                propTypes: ["string"],
+            },
+            {
                 name: "readOnly",
                 description:
                     "Indicates if the component has a read only state and selection or input is not allowed",
@@ -118,12 +121,7 @@ const DATA: ApiTableSectionProps[] = [
             },
             {
                 name: "onBlur",
-                description: (
-                    <>
-                        Called when a defocus on the field is made. Returns the
-                        start and end date in the {STRING_FORMAT}
-                    </>
-                ),
+                description: "Called when a defocus on the field is made.",
                 propTypes: ["() => void"],
             },
         ],

--- a/stories/form/form-date-range-input/form-date-range-input.stories.mdx
+++ b/stories/form/form-date-range-input/form-date-range-input.stories.mdx
@@ -102,22 +102,21 @@ _(In this example, 2 days before today and 2 days after today are disabled)_
     </Story>
 </Canvas>
 
-<Heading3>Within date range</Heading3>
+<Heading3>Within minimum and maximum dates</Heading3>
 
-You can restrict selection to a date range using `between`.
+You can specify the `minDate` and/or `maxDate` to control the selection range.
 
 <Canvas>
-    <Story name="Within date range">
+    <Story name="Min and max dates">
         {() => {
-            const [between] = useState([
-                dayjs().subtract(2, "days").format("YYYY-MM-DD"),
-                dayjs().add(20, "days").format("YYYY-MM-DD"),
-            ]);
             return (
                 <StoryContainer>
                     <Form.DateRangeInput
                         label="This has restricted selection"
-                        between={between}
+                        minDate={dayjs()
+                            .subtract(2, "days")
+                            .format("YYYY-MM-DD")}
+                        maxDate={dayjs().add(20, "days").format("YYYY-MM-DD")}
                     />
                 </StoryContainer>
             );

--- a/stories/form/form-date-range-input/props-table.tsx
+++ b/stories/form/form-date-range-input/props-table.tsx
@@ -14,23 +14,6 @@ const DATA: ApiTableSectionProps[] = [
         name: "DateRangeInput specific props",
         attributes: [
             {
-                name: "between",
-                description: (
-                    <>
-                        Specifies the selection between a given date range. To
-                        specify in an array where&nbsp;
-                        <code>[startDate, endDate]</code> using the{" "}
-                        {STRING_FORMAT} for the dates.
-                        <br />
-                        E.g.{" "}
-                        <code>
-                            [{quote("2023-01-01")}, {quote("2023-02-01")}]
-                        </code>
-                    </>
-                ),
-                propTypes: ["[string, string]"],
-            },
-            {
                 name: "className",
                 description: "The class selector of the component",
                 propTypes: ["string"],
@@ -75,6 +58,26 @@ const DATA: ApiTableSectionProps[] = [
             {
                 name: "id",
                 description: "The unique identifier of the component",
+                propTypes: ["string"],
+            },
+            {
+                name: "maxDate",
+                description: (
+                    <>
+                        Specifies the maximum date allowed for selection in
+                        the&nbsp;{STRING_FORMAT}&nbsp;{`(Inclusive)`}
+                    </>
+                ),
+                propTypes: ["string"],
+            },
+            {
+                name: "minDate",
+                description: (
+                    <>
+                        Specifies the minimum date allowed for selection in
+                        the&nbsp;{STRING_FORMAT}&nbsp;{`(Inclusive)`}
+                    </>
+                ),
                 propTypes: ["string"],
             },
             {

--- a/tests/utils/date-input-helper.spec.ts
+++ b/tests/utils/date-input-helper.spec.ts
@@ -1,261 +1,91 @@
 import { DateInputHelper } from "../../src/util/date-input-helper";
 
 describe("DateInputHelper", () => {
-    describe("range validation", () => {
-        describe("validate value", () => {
-            it("should return true for valid date range", () => {
-                const startDate = "2023-04-01";
-                const endDate = "2023-04-25";
+    describe("isDateDisabled", () => {
+        it("should return false when no dates are disabled", () => {
+            const date = "2023-04-01";
 
-                const result = DateInputHelper.validate(startDate, endDate);
+            const result = DateInputHelper.isDateDisabled(date, {});
 
-                expect(result).toBe(true);
-            });
-
-            it("should return false if only one date is selected", () => {
-                const startDate = "2023-04-01";
-                const endDate = "";
-
-                const result = DateInputHelper.validate(startDate, endDate);
-
-                expect(result).toBe(false);
-            });
-
-            it("should return false if start date is after end date", () => {
-                const startDate = "2023-04-01";
-                const endDate = "2023-04-25";
-
-                const result = DateInputHelper.validate(endDate, startDate);
-
-                expect(result).toBe(false);
-            });
+            expect(result).toBe(false);
         });
 
-        describe("disabled dates", () => {
-            it("should return true for valid date range", () => {
-                const startDate = "2023-04-01";
-                const endDate = "2023-04-25";
-                const disabledDates = ["2023-04-15"];
+        it("should return false when date is not disabled", () => {
+            const date = "2023-04-01";
+            const disabledDates = ["2023-03-31", "2023-04-02"];
 
-                const result = DateInputHelper.validate(
-                    startDate,
-                    endDate,
-                    disabledDates
-                );
-
-                expect(result).toBe(true);
+            const result = DateInputHelper.isDateDisabled(date, {
+                disabledDates,
             });
 
-            it("should return false if a disabled date is selected", () => {
-                const startDate = "2023-04-01";
-                const endDate = "2023-04-15";
-                const disabledDates = ["2023-04-15"];
-
-                const result = DateInputHelper.validate(
-                    startDate,
-                    endDate,
-                    disabledDates
-                );
-
-                expect(result).toBe(false);
-            });
+            expect(result).toBe(false);
         });
 
-        describe("between range", () => {
-            it("should return true if selected dates are within restricted range", () => {
-                const startDate = "2023-04-01";
-                const endDate = "2023-04-15";
-                const disabledDates = undefined;
-                const between = ["2023-03-25", "2023-04-23"];
+        it("should return true when date is disabled", () => {
+            const date = "2023-04-01";
+            const disabledDates = ["2023-04-01"];
 
-                const result = DateInputHelper.validate(
-                    startDate,
-                    endDate,
-                    disabledDates,
-                    between
-                );
-
-                expect(result).toBe(true);
+            const result = DateInputHelper.isDateDisabled(date, {
+                disabledDates,
             });
 
-            it("should return false if start date is outside of restricted range", () => {
-                const startDate = "2023-03-22";
-                const endDate = "2023-04-15";
-                const disabledDates = undefined;
-                const between = ["2023-03-25", "2023-04-23"];
-
-                const result = DateInputHelper.validate(
-                    startDate,
-                    endDate,
-                    disabledDates,
-                    between
-                );
-
-                expect(result).toBe(false);
-            });
-
-            it("should return false if end date is outside of restricted range", () => {
-                const startDate = "2023-04-01";
-                const endDate = "2023-04-27";
-                const disabledDates = undefined;
-                const between = ["2023-03-25", "2023-04-23"];
-
-                const result = DateInputHelper.validate(
-                    startDate,
-                    endDate,
-                    disabledDates,
-                    between
-                );
-
-                expect(result).toBe(false);
-            });
-
-            it("should return false if between value format is not YYYY-MM-DD", () => {
-                const startDate = "2023-02-12";
-                const endDate = "2023-03-17";
-                const disabledDates = undefined;
-                const between = [undefined, "2023-04-12"];
-
-                const result = DateInputHelper.validate(
-                    startDate,
-                    endDate,
-                    disabledDates,
-                    between
-                );
-
-                expect(result).toBe(false);
-            });
-        });
-    });
-
-    describe("single validation", () => {
-        describe("validate value", () => {
-            it("should return true if only one date is selected", () => {
-                const startDate = "2023-04-01";
-
-                const result = DateInputHelper.validateSingle(startDate);
-
-                expect(result).toBe(true);
-            });
+            expect(result).toBe(true);
         });
 
-        describe("disabled dates", () => {
-            it("should return true for valid date", () => {
-                const startDate = "2023-04-01";
-                const disabledDates = ["2023-04-15"];
+        it("should return false when date is within range (inclusive check)", () => {
+            const minDate = "2023-01-01";
+            const maxDate = "2023-02-01";
 
-                const result = DateInputHelper.validateSingle(
-                    startDate,
-                    disabledDates
-                );
-
-                expect(result).toBe(true);
+            const sameAsMaxCheck = DateInputHelper.isDateDisabled(maxDate, {
+                minDate,
+                maxDate,
+            });
+            const sameAsMinCheck = DateInputHelper.isDateDisabled(minDate, {
+                minDate,
+                maxDate,
             });
 
-            it("should return false for a disabled date is selected", () => {
-                const startDate = "2023-04-15";
-                const disabledDates = ["2023-04-15"];
-
-                const result = DateInputHelper.validateSingle(
-                    startDate,
-                    disabledDates
-                );
-
-                expect(result).toBe(false);
-            });
+            expect(sameAsMaxCheck).toBe(false);
+            expect(sameAsMinCheck).toBe(false);
         });
 
-        describe("between range", () => {
-            it("should return true if selected dates are within restricted range", () => {
-                const startDate = "2023-04-01";
-                const disabledDates = undefined;
-                const between = ["2023-04-25", "2023-04-23"];
+        it("should return true when date is out of range", () => {
+            const minDate = "2023-01-01";
+            const maxDate = "2023-02-01";
 
-                const result = DateInputHelper.validateSingle(
-                    startDate,
-                    disabledDates,
-                    between
-                );
-
-                expect(result).toBe(false);
+            const isBeforeRange = DateInputHelper.isDateDisabled("2022-12-31", {
+                minDate,
+                maxDate,
+            });
+            const isAfterRange = DateInputHelper.isDateDisabled("2023-02-02", {
+                minDate,
+                maxDate,
             });
 
-            it("should return false if start date is outside of restricted range", () => {
-                const startDate = "2023-03-22";
-                const disabledDates = undefined;
-                const between = ["2023-04-25", "2023-04-23"];
+            expect(isBeforeRange).toBe(true);
+            expect(isAfterRange).toBe(true);
+        });
 
-                const result = DateInputHelper.validateSingle(
-                    startDate,
-                    disabledDates,
-                    between
-                );
+        it("should return true when date is before minDate", () => {
+            const date = "2023-03-31";
+            const minDate = "2023-04-01";
 
-                expect(result).toBe(false);
+            const result = DateInputHelper.isDateDisabled(date, {
+                minDate,
             });
 
-            it("should return false if between value format is not YYYY-MM-DD", () => {
-                const startDate = "2023-02-12";
-                const disabledDates = undefined;
-                const between = ["2023-04-12", undefined];
+            expect(result).toBe(true);
+        });
 
-                const result = DateInputHelper.validateSingle(
-                    startDate,
-                    disabledDates,
-                    between
-                );
+        it("should return true when date is after maxRange", () => {
+            const date = "2023-04-02";
+            const maxDate = "2023-04-01";
 
-                expect(result).toBe(false);
+            const result = DateInputHelper.isDateDisabled(date, {
+                maxDate,
             });
-        });
-    });
 
-    describe("getFormattedRawValue", () => {
-        it("should split each value into field object format", () => {
-            const startValue = "2023-03-10";
-            const endValue = "2023-04-05";
-
-            const expected1 = {
-                start: ["10", "03", "2023"],
-                end: undefined,
-            };
-            const expected2 = {
-                start: ["10", "03", "2023"],
-                end: ["05", "04", "2023"],
-            };
-
-            const result1 = DateInputHelper.getFormattedRawValue(startValue);
-            const result2 = DateInputHelper.getFormattedRawValue(
-                startValue,
-                endValue
-            );
-
-            expect(result1).toEqual(expected1);
-            expect(result2).toEqual(expected2);
-        });
-    });
-
-    describe("sleep", () => {
-        beforeEach(() => {
-            jest.useFakeTimers();
-        });
-        afterEach(() => {
-            jest.useRealTimers();
-        });
-
-        it("Promise delay 100ms", async () => {
-            const spy = jest.fn();
-            const controller = new AbortController();
-
-            DateInputHelper.sleep(100, controller).then(spy);
-
-            jest.advanceTimersByTime(20);
-            await Promise.resolve();
-            expect(spy).not.toHaveBeenCalled();
-
-            jest.advanceTimersByTime(100);
-            await Promise.resolve();
-            expect(spy).toHaveBeenCalled();
+            expect(result).toBe(true);
         });
     });
 });


### PR DESCRIPTION
**Changes**
Related to [this calendar PR](https://github.com/LifeSG/react-design-system/pull/173) to separate `between` prop into `minDate` and `maxDate`

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- [BREAKING] Replace `between` prop with `minDate` and `maxDate` in date pickers
