### PR TITLE
[MISC][WK] fix the 2px off from children calendar component width

### DIFF
--- a/src/shared/input-wrapper/input-wrapper.tsx
+++ b/src/shared/input-wrapper/input-wrapper.tsx
@@ -21,7 +21,7 @@ export const InputWrapper = styled.div<InputWrapperStyleProps>`
     display: flex;
     align-items: center;
     position: relative;
-    border: 1px solid ${Color.Neutral[5]};
+    outline: 1px solid ${Color.Neutral[5]};
     border-radius: 4px;
     background: ${Color.Neutral[8]};
     height: max-content;
@@ -31,7 +31,7 @@ export const InputWrapper = styled.div<InputWrapperStyleProps>`
         props.$position === "right" ? "row-reverse" : "row"};
 
     :focus-within {
-        border: 1px solid ${Color.Accent.Light[1]};
+        outline: 1px solid ${Color.Accent.Light[1]};
         box-shadow: ${DesignToken.InputBoxShadow};
     }
 
@@ -59,10 +59,10 @@ export const InputWrapper = styled.div<InputWrapperStyleProps>`
             `;
         } else if (props.$error) {
             return css`
-                border: 1px solid ${Color.Validation.Red.Border};
+                outline: 1px solid ${Color.Validation.Red.Border};
 
                 :focus-within {
-                    border: 1px solid ${Color.Validation.Red.Border};
+                    outline: 1px solid ${Color.Validation.Red.Border};
                     box-shadow: ${DesignToken.InputErrorBoxShadow};
                 }
             `;

--- a/src/shared/input-wrapper/input-wrapper.tsx
+++ b/src/shared/input-wrapper/input-wrapper.tsx
@@ -21,7 +21,7 @@ export const InputWrapper = styled.div<InputWrapperStyleProps>`
     display: flex;
     align-items: center;
     position: relative;
-    outline: 1px solid ${Color.Neutral[5]};
+    border: 1px solid ${Color.Neutral[5]};
     border-radius: 4px;
     background: ${Color.Neutral[8]};
     height: max-content;
@@ -31,7 +31,7 @@ export const InputWrapper = styled.div<InputWrapperStyleProps>`
         props.$position === "right" ? "row-reverse" : "row"};
 
     :focus-within {
-        outline: 1px solid ${Color.Accent.Light[1]};
+        border: 1px solid ${Color.Accent.Light[1]};
         box-shadow: ${DesignToken.InputBoxShadow};
     }
 
@@ -59,10 +59,10 @@ export const InputWrapper = styled.div<InputWrapperStyleProps>`
             `;
         } else if (props.$error) {
             return css`
-                outline: 1px solid ${Color.Validation.Red.Border};
+                border: 1px solid ${Color.Validation.Red.Border};
 
                 :focus-within {
-                    outline: 1px solid ${Color.Validation.Red.Border};
+                    border: 1px solid ${Color.Validation.Red.Border};
                     box-shadow: ${DesignToken.InputErrorBoxShadow};
                 }
             `;

--- a/src/shared/internal-calendar/animated-internal-calendar.style.tsx
+++ b/src/shared/internal-calendar/animated-internal-calendar.style.tsx
@@ -6,7 +6,7 @@ export const AnimatedDiv = styled(animated.div)`
     position: absolute;
     top: calc(100% + 0.5rem);
     left: 0;
-    width: 100%;
+    width: calc(100% + 2px);
     max-width: 41rem;
     background: ${Color.Neutral[8]};
     overflow: hidden;

--- a/src/shared/internal-calendar/animated-internal-calendar.style.tsx
+++ b/src/shared/internal-calendar/animated-internal-calendar.style.tsx
@@ -5,7 +5,7 @@ import { Color } from "../../color";
 export const AnimatedDiv = styled(animated.div)`
     position: absolute;
     top: calc(100% + 0.5rem);
-    left: 0;
+    left: -1px;
     width: calc(100% + 2px);
     max-width: 41rem;
     background: ${Color.Neutral[8]};


### PR DESCRIPTION
**Changes**
Description of changes...

* Fix calendar component to extend the exact the parent width.

Can reference this issue in [stackoverflow](https://stackoverflow.com/questions/14706866/css-borders-interfering-with-absolute-positioning)

- [delete] branch

Description of change in `InputWrapper`

**Changelog entry**
1. Replace to outline from border css. 

