### PR TITLE
Split input select variants

### DIFF
--- a/src/form/form-multi-select.tsx
+++ b/src/form/form-multi-select.tsx
@@ -1,4 +1,4 @@
-import { InputMultiSelect } from "../input-select/input-multi-select";
+import { InputMultiSelect } from "../input-multi-select/input-multi-select";
 import { FormWrapper } from "./form-wrapper";
 import { FormMultiSelectProps } from "./types";
 

--- a/src/form/form-range-select.tsx
+++ b/src/form/form-range-select.tsx
@@ -1,4 +1,4 @@
-import { InputRangeSelect } from "src/input-select/input-range-select";
+import { InputRangeSelect } from "../input-range-select/input-range-select";
 import { FormWrapper } from "./form-wrapper";
 import { FormInputRangeSelectProps } from "./types";
 

--- a/src/form/types.ts
+++ b/src/form/types.ts
@@ -1,11 +1,9 @@
 import { DateInputProps } from "../date-input/types";
 import { DateRangeInputProps } from "../date-range-input/types";
 import { InputGroupPartialProps } from "../input-group/types";
-import {
-    InputMultiSelectPartialProps,
-    InputRangeSelectPartialProps,
-    InputSelectPartialProps,
-} from "../input-select/types";
+import { InputMultiSelectPartialProps } from "../input-multi-select/types";
+import { InputRangeSelectPartialProps } from "../input-range-select/types";
+import { InputSelectPartialProps } from "../input-select/types";
 import { TextareaPartialProps } from "../input-textarea/types";
 import { InputPartialProps } from "../input/types";
 import { PhoneNumberInputProps } from "../phone-number-input/types";

--- a/src/input-group/input-group-list-addon.style.tsx
+++ b/src/input-group/input-group-list-addon.style.tsx
@@ -5,7 +5,7 @@ import {
     ElementBoundary as InputSelectElemBoundary,
     Selector as InputSelectSelector,
     Wrapper as InputSelectWrapper,
-} from "../input-select/input-select.styles";
+} from "../shared/dropdown-wrapper/dropdown-wrapper.styles";
 import { Text } from "../text/text";
 import { TextStyle } from "../text/text-style";
 import { Transition } from "../transition";

--- a/src/input-group/input-group-list-addon.style.tsx
+++ b/src/input-group/input-group-list-addon.style.tsx
@@ -1,11 +1,7 @@
 import { ChevronDownIcon } from "@lifesg/react-icons/chevron-down";
 import styled, { css } from "styled-components";
 import { Color } from "../color";
-import {
-    ElementBoundary as InputSelectElemBoundary,
-    Selector as InputSelectSelector,
-    Wrapper as InputSelectWrapper,
-} from "../shared/dropdown-wrapper/dropdown-wrapper.styles";
+import { Selector as DropdownSelector } from "../shared/dropdown-wrapper/dropdown-wrapper.styles";
 import { Text } from "../text/text";
 import { TextStyle } from "../text/text-style";
 import { Transition } from "../transition";
@@ -30,9 +26,6 @@ interface DividerStyleProps {
 // =============================================================================
 // STYLING
 // =============================================================================
-export const Wrapper = InputSelectWrapper;
-export const ElementBoundary = styled(InputSelectElemBoundary)``;
-
 export const DisplayContainer = styled.div<StyleProps>`
     position: relative;
     display: flex;
@@ -67,7 +60,7 @@ export const DisplayContainer = styled.div<StyleProps>`
     }}
 `;
 
-export const Selector = styled(InputSelectSelector)`
+export const Selector = styled(DropdownSelector)`
     padding: 0;
     width: auto;
 `;

--- a/src/input-group/input-group-list-addon.tsx
+++ b/src/input-group/input-group-list-addon.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useRef, useState } from "react";
 import { DropdownList } from "../shared/dropdown-list/dropdown-list";
+import { DropdownWrapper } from "../shared/dropdown-wrapper";
 import {
     DisplayContainer,
     Divider,
-    ElementBoundary,
     IconContainer,
     LabelContainer,
     PlaceholderLabel,
@@ -11,7 +11,6 @@ import {
     SelectorReadOnly,
     StyledChevronIcon,
     ValueLabel,
-    Wrapper,
 } from "./input-group-list-addon.style";
 import { MainInput } from "./input-group.style";
 import { InputGroupProps, ListAddon } from "./types";
@@ -49,7 +48,6 @@ export const InputGroupListAddon = <T, V>({
     const [selected, setSelected] = useState<T>(selectedOption);
     const [showOptions, setShowOptions] = useState<boolean>(false);
 
-    const nodeRef = useRef();
     const selectorRef = useRef<HTMLButtonElement>();
 
     // =============================================================================
@@ -58,14 +56,6 @@ export const InputGroupListAddon = <T, V>({
     useEffect(() => {
         setSelected(selectedOption);
     }, [selectedOption]);
-
-    useEffect(() => {
-        document.addEventListener("mousedown", handleClick);
-
-        return () => {
-            document.removeEventListener("mousedown", handleClick);
-        };
-    }, []);
 
     // =============================================================================
     // HELPER FUNCTIONS
@@ -95,17 +85,10 @@ export const InputGroupListAddon = <T, V>({
     // =============================================================================
     // EVENT HANDLERS
     // =============================================================================
-    const handleClick = (event: MouseEvent) => {
-        if (!otherProps.disabled) {
-            if (nodeRef && (nodeRef.current as any).contains(event.target)) {
-                // inside click
-                return;
-            }
-            // outside click
-            setShowOptions(false);
-            triggerOptionDisplayCallback(false);
-            handleBlur();
-        }
+    const handleWrapperBlur = () => {
+        setShowOptions(false);
+        triggerOptionDisplayCallback(false);
+        handleBlur();
     };
 
     const handleAddonSelectorClick = (
@@ -238,17 +221,16 @@ export const InputGroupListAddon = <T, V>({
     );
 
     return (
-        <Wrapper className={className}>
-            <ElementBoundary
-                ref={nodeRef}
-                disabled={otherProps.disabled}
-                error={error && !showOptions}
-                expanded={showOptions}
-                $readOnly={readOnly}
-            >
-                {renderDisplay()}
-                {renderOptionList()}
-            </ElementBoundary>
-        </Wrapper>
+        <DropdownWrapper
+            className={className}
+            show={showOptions}
+            error={error && !showOptions}
+            disabled={otherProps.disabled}
+            readOnly={readOnly}
+            onBlur={handleWrapperBlur}
+        >
+            {renderDisplay()}
+            {renderOptionList()}
+        </DropdownWrapper>
     );
 };

--- a/src/input-multi-select/index.ts
+++ b/src/input-multi-select/index.ts
@@ -1,0 +1,2 @@
+export * from "./input-multi-select";
+export * from "./types";

--- a/src/input-multi-select/input-multi-select.tsx
+++ b/src/input-multi-select/input-multi-select.tsx
@@ -1,6 +1,7 @@
 import findIndex from "lodash/findIndex";
 import React, { useEffect, useRef, useState } from "react";
-import { InputSelectWrapper } from "../input-select/input-select-wrapper";
+import { DropdownList } from "../shared/dropdown-list/dropdown-list";
+import { DropdownWrapper } from "../shared/dropdown-wrapper";
 import {
     Divider,
     IconContainer,
@@ -9,8 +10,7 @@ import {
     Selector,
     StyledChevronIcon,
     ValueLabel,
-} from "../input-select/input-select.styles";
-import { DropdownList } from "../shared/dropdown-list/dropdown-list";
+} from "../shared/dropdown-wrapper/dropdown-wrapper.styles";
 import { InputMultiSelectProps } from "./types";
 
 export const InputMultiSelect = <T, V>({
@@ -191,7 +191,7 @@ export const InputMultiSelect = <T, V>({
     };
 
     return (
-        <InputSelectWrapper
+        <DropdownWrapper
             show={showOptions}
             error={error && !showOptions}
             disabled={disabled}
@@ -209,6 +209,6 @@ export const InputMultiSelect = <T, V>({
             </Selector>
             {showOptions && <Divider />}
             {renderOptionList()}
-        </InputSelectWrapper>
+        </DropdownWrapper>
     );
 };

--- a/src/input-multi-select/input-multi-select.tsx
+++ b/src/input-multi-select/input-multi-select.tsx
@@ -85,9 +85,7 @@ export const InputMultiSelect = <T, V>({
             selectorRef.current.focus();
         }
 
-        if (onSelectOptions) {
-            onSelectOptions(selectedCopy);
-        }
+        performOnSelectOptions(selectedCopy);
     };
 
     const handleListDismiss = () => {
@@ -104,10 +102,10 @@ export const InputMultiSelect = <T, V>({
     const handleSelectAllClick = () => {
         if (selected && selected.length > 0) {
             setSelected([]);
-            onSelectOptions([]);
+            performOnSelectOptions([]);
         } else {
             setSelected(options);
-            onSelectOptions(options);
+            performOnSelectOptions(options);
         }
     };
 
@@ -134,6 +132,12 @@ export const InputMultiSelect = <T, V>({
 
         if (show && onShowOptions) {
             onShowOptions();
+        }
+    };
+
+    const performOnSelectOptions = (options: T[]) => {
+        if (onSelectOptions) {
+            onSelectOptions(options);
         }
     };
 

--- a/src/input-multi-select/input-multi-select.tsx
+++ b/src/input-multi-select/input-multi-select.tsx
@@ -1,7 +1,6 @@
 import findIndex from "lodash/findIndex";
 import React, { useEffect, useRef, useState } from "react";
-import { DropdownList } from "../shared/dropdown-list/dropdown-list";
-import { InputSelectWrapper } from "./input-select-wrapper";
+import { InputSelectWrapper } from "../input-select/input-select-wrapper";
 import {
     Divider,
     IconContainer,
@@ -10,7 +9,8 @@ import {
     Selector,
     StyledChevronIcon,
     ValueLabel,
-} from "./input-select.styles";
+} from "../input-select/input-select.styles";
+import { DropdownList } from "../shared/dropdown-list/dropdown-list";
 import { InputMultiSelectProps } from "./types";
 
 export const InputMultiSelect = <T, V>({

--- a/src/input-multi-select/types.ts
+++ b/src/input-multi-select/types.ts
@@ -1,0 +1,26 @@
+import {
+    InputSelectOptionsProps,
+    InputSelectSharedProps,
+} from "../input-select/types";
+import {
+    DropdownDisplayProps,
+    DropdownSearchProps,
+    DropdownStyleProps,
+} from "../shared/dropdown-list/types";
+
+export interface InputMultiSelectProps<T, V>
+    extends React.HTMLAttributes<HTMLElement>,
+        InputSelectOptionsProps<T>,
+        InputSelectSharedProps<T>,
+        DropdownDisplayProps<T, V>,
+        DropdownSearchProps<T>,
+        DropdownStyleProps {
+    selectedOptions?: T[] | undefined;
+    onSelectOptions?: ((options: T[]) => void) | undefined;
+}
+
+/** To be exposed for Form component inheritance */
+export type InputMultiSelectPartialProps<T, V> = Omit<
+    InputMultiSelectProps<T, V>,
+    "error"
+>;

--- a/src/input-range-select/index.ts
+++ b/src/input-range-select/index.ts
@@ -1,0 +1,2 @@
+export * from "./input-range-select";
+export * from "./types";

--- a/src/input-range-select/input-range-select.tsx
+++ b/src/input-range-select/input-range-select.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useRef, useState } from "react";
-import { InputSelectWrapper } from "../input-select/input-select-wrapper";
+import { DropdownList } from "../shared/dropdown-list/dropdown-list";
+import { DropdownWrapper } from "../shared/dropdown-wrapper";
 import {
     Divider,
     LabelContainer,
     PlaceholderLabel,
     Selector,
     ValueLabel,
-} from "../input-select/input-select.styles";
-import { DropdownList } from "../shared/dropdown-list/dropdown-list";
+} from "../shared/dropdown-wrapper/dropdown-wrapper.styles";
 import { RangeInputInnerContainer } from "../shared/range-input-inner-container";
 import { StringHelper } from "../util/string-helper";
 import { InputRangeSelectProps } from "./types";
@@ -268,7 +268,7 @@ export const InputRangeSelect = <T, V>({
         return null;
     };
     return (
-        <InputSelectWrapper
+        <DropdownWrapper
             show={focusedInput !== "none"}
             data-testid={otherProps["data-testid"]}
             error={error && !(focusedInput !== "none")}
@@ -292,6 +292,6 @@ export const InputRangeSelect = <T, V>({
             </Selector>
             {focusedInput !== "none" && <Divider />}
             {renderOptionsList()}
-        </InputSelectWrapper>
+        </DropdownWrapper>
     );
 };

--- a/src/input-range-select/input-range-select.tsx
+++ b/src/input-range-select/input-range-select.tsx
@@ -1,15 +1,15 @@
 import React, { useEffect, useRef, useState } from "react";
-import { DropdownList } from "../shared/dropdown-list/dropdown-list";
-import { RangeInputInnerContainer } from "../shared/range-input-inner-container";
-import { StringHelper } from "../util/string-helper";
-import { InputSelectWrapper } from "./input-select-wrapper";
+import { InputSelectWrapper } from "../input-select/input-select-wrapper";
 import {
     Divider,
     LabelContainer,
     PlaceholderLabel,
     Selector,
     ValueLabel,
-} from "./input-select.styles";
+} from "../input-select/input-select.styles";
+import { DropdownList } from "../shared/dropdown-list/dropdown-list";
+import { RangeInputInnerContainer } from "../shared/range-input-inner-container";
+import { StringHelper } from "../util/string-helper";
 import { InputRangeSelectProps } from "./types";
 
 type RangeType = "from" | "to";

--- a/src/input-range-select/types.ts
+++ b/src/input-range-select/types.ts
@@ -1,0 +1,48 @@
+import {
+    InputSelectOptionsProps,
+    InputSelectSharedProps,
+} from "../input-select/types";
+import {
+    DropdownDisplayProps,
+    DropdownSearchProps,
+    DropdownStyleProps,
+    ItemsLoadStateType,
+} from "../shared/dropdown-list/types";
+
+export interface InputRangeSelectOptionsProps<T>
+    extends Omit<InputSelectOptionsProps<T>, "options" | "optionsLoadState"> {
+    options: InputRangeProp<T[]>;
+    optionsLoadState?: InputRangeProp<ItemsLoadStateType | undefined>;
+}
+
+export interface InputRangeProp<T> {
+    from?: T | undefined;
+    to?: T | undefined;
+}
+
+export interface InputRangeSelectProps<T, V>
+    extends React.HTMLAttributes<HTMLElement>,
+        InputRangeSelectOptionsProps<T>,
+        Omit<InputSelectSharedProps<T>, "options">,
+        DropdownDisplayProps<T, V>,
+        DropdownSearchProps<T>,
+        DropdownStyleProps {
+    readOnly?: boolean | undefined;
+    placeholders?: InputRangeProp<string> | undefined;
+    selectedOptions?: InputRangeProp<T> | undefined;
+    onSelectOption?:
+        | ((option: InputRangeProp<T>, extractedValue: V) => void)
+        | undefined;
+    // /** Function to derive display value for selected option */
+    displayValueExtractor?: ((option: T) => string) | undefined;
+    // /** Function to convert value into a string */
+    valueToStringFunction?: ((value: V) => string) | undefined;
+    // /** Function to render selected custom component */
+    renderCustomSelectedOption?: ((option: T) => JSX.Element) | undefined;
+}
+
+/** To be exposed for Form component inheritance */
+export type InputRangeSelectPartialProps<T, V> = Omit<
+    InputRangeSelectProps<T, V>,
+    "error"
+>;

--- a/src/input-select/index.ts
+++ b/src/input-select/index.ts
@@ -1,4 +1,2 @@
 export * from "./input-select";
-export * from "./input-multi-select";
-export * from "./input-range-select";
 export * from "./types";

--- a/src/input-select/input-select.tsx
+++ b/src/input-select/input-select.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { DropdownList } from "../shared/dropdown-list/dropdown-list";
-import { StringHelper } from "../util/string-helper";
-import { InputSelectWrapper } from "./input-select-wrapper";
+import { DropdownWrapper } from "../shared/dropdown-wrapper";
 import {
     Divider,
     IconContainer,
@@ -10,7 +9,8 @@ import {
     Selector,
     StyledChevronIcon,
     ValueLabel,
-} from "./input-select.styles";
+} from "../shared/dropdown-wrapper/dropdown-wrapper.styles";
+import { StringHelper } from "../util/string-helper";
 import { InputSelectProps } from "./types";
 
 export const InputSelect = <T, V>({
@@ -215,7 +215,7 @@ export const InputSelect = <T, V>({
     };
 
     return (
-        <InputSelectWrapper
+        <DropdownWrapper
             show={showOptions}
             error={error && !showOptions}
             disabled={disabled}
@@ -235,6 +235,6 @@ export const InputSelect = <T, V>({
             </Selector>
             {showOptions && <Divider />}
             {renderOptionList()}
-        </InputSelectWrapper>
+        </DropdownWrapper>
     );
 };

--- a/src/input-select/types.ts
+++ b/src/input-select/types.ts
@@ -35,16 +35,6 @@ export interface InputSelectSharedProps<T> {
     "data-testid"?: string | undefined;
 }
 
-export interface InputSelectWrapperProps {
-    children: JSX.Element[];
-    show: boolean;
-    onBlur: () => void;
-    error?: boolean | undefined;
-    disabled?: boolean | undefined;
-    testId?: string | undefined;
-    readOnly?: boolean | undefined;
-}
-
 // =============================================================================
 // INPUT SELECT PROPS
 // =============================================================================

--- a/src/input-select/types.ts
+++ b/src/input-select/types.ts
@@ -24,12 +24,6 @@ export interface InputSelectOptionsProps<T> {
     onRetry?: (() => void) | undefined;
 }
 
-export interface InputRangeSelectOptionsProps<T>
-    extends Omit<InputSelectOptionsProps<T>, "options" | "optionsLoadState"> {
-    options: InputRangeProp<T[]>;
-    optionsLoadState?: InputRangeProp<ItemsLoadStateType | undefined>;
-}
-
 export interface InputSelectSharedProps<T> {
     /** HTML button props */
     name?: string | undefined;
@@ -75,59 +69,5 @@ export interface InputSelectProps<T, V>
 /** To be exposed for Form component inheritance */
 export type InputSelectPartialProps<T, V> = Omit<
     InputSelectProps<T, V>,
-    "error"
->;
-
-// =============================================================================
-// INPUT RANGE SELECT PROPS
-// =============================================================================
-export interface InputRangeProp<T> {
-    from?: T | undefined;
-    to?: T | undefined;
-}
-
-export interface InputRangeSelectProps<T, V>
-    extends React.HTMLAttributes<HTMLElement>,
-        InputRangeSelectOptionsProps<T>,
-        Omit<InputSelectSharedProps<T>, "options">,
-        DropdownDisplayProps<T, V>,
-        DropdownSearchProps<T>,
-        DropdownStyleProps {
-    readOnly?: boolean | undefined;
-    placeholders?: InputRangeProp<string> | undefined;
-    selectedOptions?: InputRangeProp<T> | undefined;
-    onSelectOption?:
-        | ((option: InputRangeProp<T>, extractedValue: V) => void)
-        | undefined;
-    // /** Function to derive display value for selected option */
-    displayValueExtractor?: ((option: T) => string) | undefined;
-    // /** Function to convert value into a string */
-    valueToStringFunction?: ((value: V) => string) | undefined;
-    // /** Function to render selected custom component */
-    renderCustomSelectedOption?: ((option: T) => JSX.Element) | undefined;
-}
-
-/** To be exposed for Form component inheritance */
-export type InputRangeSelectPartialProps<T, V> = Omit<
-    InputRangeSelectProps<T, V>,
-    "error"
->;
-// =============================================================================
-// INPUT MULTI SELECT PROPS
-// =============================================================================
-export interface InputMultiSelectProps<T, V>
-    extends React.HTMLAttributes<HTMLElement>,
-        InputSelectOptionsProps<T>,
-        InputSelectSharedProps<T>,
-        DropdownDisplayProps<T, V>,
-        DropdownSearchProps<T>,
-        DropdownStyleProps {
-    selectedOptions?: T[] | undefined;
-    onSelectOptions?: ((options: T[]) => void) | undefined;
-}
-
-/** To be exposed for Form component inheritance */
-export type InputMultiSelectPartialProps<T, V> = Omit<
-    InputMultiSelectProps<T, V>,
     "error"
 >;

--- a/src/shared/dropdown-wrapper/dropdown-wrapper.styles.tsx
+++ b/src/shared/dropdown-wrapper/dropdown-wrapper.styles.tsx
@@ -1,16 +1,16 @@
 import { ChevronDownIcon } from "@lifesg/react-icons/chevron-down";
 import styled, { css, keyframes } from "styled-components";
-import { Color } from "../color";
-import { DesignToken } from "../design-token";
-import { MediaQuery } from "../media";
-import { TruncateType } from "../shared/dropdown-list/types";
-import { Text, TextStyle } from "../text";
-import { Transition } from "../transition";
+import { Color } from "../../color";
+import { DesignToken } from "../../design-token";
+import { MediaQuery } from "../../media";
+import { Text, TextStyle } from "../../text";
+import { Transition } from "../../transition";
+import { TruncateType } from "../dropdown-list/types";
 
 // =============================================================================
 // STYLE INTERFACE
 // =============================================================================
-export interface InputSelectStyleProps {
+export interface DropdownWrapperStyleProps {
     disabled?: boolean;
     $readOnly?: boolean;
     error?: boolean;
@@ -76,7 +76,7 @@ const zindexPositionHide = keyframes`
 	}
 `;
 
-export const ElementBoundary = styled.div<InputSelectStyleProps>`
+export const ElementBoundary = styled.div<DropdownWrapperStyleProps>`
     position: relative;
     border: 1px solid ${Color.Neutral[5]};
     border-radius: ${BORDER_RADIUS};
@@ -144,7 +144,7 @@ export const ElementBoundary = styled.div<InputSelectStyleProps>`
     }}
 `;
 
-export const IconContainer = styled.div<InputSelectStyleProps>`
+export const IconContainer = styled.div<DropdownWrapperStyleProps>`
     transform: rotate(${(props) => (props.expanded ? 180 : 0)}deg);
     transition: ${Transition.Base};
     margin-left: 1rem;

--- a/src/shared/dropdown-wrapper/dropdown-wrapper.styles.tsx
+++ b/src/shared/dropdown-wrapper/dropdown-wrapper.styles.tsx
@@ -2,7 +2,6 @@ import { ChevronDownIcon } from "@lifesg/react-icons/chevron-down";
 import styled, { css, keyframes } from "styled-components";
 import { Color } from "../../color";
 import { DesignToken } from "../../design-token";
-import { MediaQuery } from "../../media";
 import { Text, TextStyle } from "../../text";
 import { Transition } from "../../transition";
 import { TruncateType } from "../dropdown-list/types";
@@ -31,10 +30,6 @@ export const Wrapper = styled.div`
     min-height: 3rem;
     height: 3rem; // Need this to persist the height when expanding or collapsing list
     width: 100%;
-
-    ${MediaQuery.MaxWidth.tablet} {
-        height: auto;
-    }
 `;
 
 export const Selector = styled.button`

--- a/src/shared/dropdown-wrapper/dropdown-wrapper.tsx
+++ b/src/shared/dropdown-wrapper/dropdown-wrapper.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useRef } from "react";
-import { ElementBoundary, Wrapper } from "./input-select.styles";
-import { InputSelectWrapperProps } from "./types";
+import { useEffect, useRef } from "react";
+import { ElementBoundary, Wrapper } from "./dropdown-wrapper.styles";
+import { DropdownSelectorProps } from "./types";
 
-export const InputSelectWrapper = ({
+export const DropdownWrapper = ({
     children,
     show,
     error,
@@ -10,7 +10,7 @@ export const InputSelectWrapper = ({
     testId,
     onBlur,
     readOnly,
-}: InputSelectWrapperProps): JSX.Element => {
+}: DropdownSelectorProps): JSX.Element => {
     // =============================================================================
     // CONST, STATE, REFS
     // =============================================================================

--- a/src/shared/dropdown-wrapper/dropdown-wrapper.tsx
+++ b/src/shared/dropdown-wrapper/dropdown-wrapper.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
+import { useEventListener } from "../../util/use-event-listener";
 import { ElementBoundary, Wrapper } from "./dropdown-wrapper.styles";
 import { DropdownSelectorProps } from "./types";
 
@@ -15,38 +16,27 @@ export const DropdownWrapper = ({
     // CONST, STATE, REFS
     // =============================================================================
     const nodeRef = useRef<HTMLDivElement>();
-    const showValueRef = useRef<boolean>(show);
 
     // =============================================================================
     // EFFECTS
     // =============================================================================
-    useEffect(() => {
-        document.addEventListener("mousedown", handleMouseDownEvent);
-
-        return () => {
-            document.removeEventListener("mousedown", handleMouseDownEvent);
-        };
-    }, [onBlur]); // Fixes issue of unable read state values within onBlur Callback.
-
-    useEffect(() => {
-        showValueRef.current = show;
-    }, [show]);
+    useEventListener("mousedown", handleMouseDownEvent, document);
 
     // =============================================================================
     // HELPER FUNCTION
     // =============================================================================
-    const handleMouseDownEvent = (event: MouseEvent) => {
+    function handleMouseDownEvent(event: MouseEvent) {
         if (!disabled) {
             if (nodeRef && (nodeRef.current as any).contains(event.target)) {
                 // inside click
                 return;
             }
             // outside click
-            if (showValueRef.current) {
+            if (show) {
                 onBlur();
             }
         }
-    };
+    }
 
     // =============================================================================
     // RENDER FUNCTIONS

--- a/src/shared/dropdown-wrapper/index.ts
+++ b/src/shared/dropdown-wrapper/index.ts
@@ -1,0 +1,2 @@
+export * from "./dropdown-wrapper";
+export * from "./types";

--- a/src/shared/dropdown-wrapper/types.ts
+++ b/src/shared/dropdown-wrapper/types.ts
@@ -6,4 +6,5 @@ export interface DropdownSelectorProps {
     disabled?: boolean | undefined;
     testId?: string | undefined;
     readOnly?: boolean | undefined;
+    className?: string | undefined;
 }

--- a/src/shared/dropdown-wrapper/types.ts
+++ b/src/shared/dropdown-wrapper/types.ts
@@ -1,0 +1,9 @@
+export interface DropdownSelectorProps {
+    children: JSX.Element[];
+    show: boolean;
+    onBlur: () => void;
+    error?: boolean | undefined;
+    disabled?: boolean | undefined;
+    testId?: string | undefined;
+    readOnly?: boolean | undefined;
+}

--- a/stories/form/form-multi-select/form-multi-select.stories.mdx
+++ b/stories/form/form-multi-select/form-multi-select.stories.mdx
@@ -1,6 +1,6 @@
 import { Canvas, Meta, Preview, Story } from "@storybook/addon-docs";
 import { useState } from "react";
-import { InputMultiSelect } from "src/input-select";
+import { InputMultiSelect } from "src/input-multi-select";
 import { Form } from "src/form";
 import { Text } from "src/text";
 import {

--- a/stories/form/form-multi-select/form-multi-select.stories.mdx
+++ b/stories/form/form-multi-select/form-multi-select.stories.mdx
@@ -117,7 +117,7 @@ import { Form } from "@lifesg/react-design-system/form";
 In the case that you require the multi select field as a standalone, you can do this.
 
 ```tsx
-import { InputMultiSelect } from "@lifesg/react-design-system/input-select";
+import { InputMultiSelect } from "@lifesg/react-design-system/input-multi-select";
 ```
 
 <Preview>

--- a/stories/form/form-range-select/form-range-select.stories.mdx
+++ b/stories/form/form-range-select/form-range-select.stories.mdx
@@ -1,6 +1,6 @@
 import { Canvas, Meta, Preview, Story } from "@storybook/addon-docs";
 import { useState } from "react";
-import { InputRangeSelect } from "src/input-select";
+import { InputRangeSelect } from "src/input-range-select";
 import { Form } from "src/form";
 import { Text } from "src/text";
 import {

--- a/stories/form/form-range-select/form-range-select.stories.mdx
+++ b/stories/form/form-range-select/form-range-select.stories.mdx
@@ -230,7 +230,7 @@ You are able to customise the display of the dropdown list items as well as the 
 In the case that you require the select field as a standalone, you can do this.
 
 ```tsx
-import { InputRangeSelect } from "@lifesg/react-design-system/input-select";
+import { InputRangeSelect } from "@lifesg/react-design-system/input-range-select";
 ```
 
 <Preview>

--- a/tests/input-range-select/input-range-select.spec.tsx
+++ b/tests/input-range-select/input-range-select.spec.tsx
@@ -1,8 +1,8 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FormRangeSelect } from "src/form/form-range-select";
+import { InputRangeSelect } from "src/input-range-select";
 import styled from "styled-components";
-import { Button, InputRangeSelect } from "../../src";
 
 // =============================================================================
 // UNIT TESTS


### PR DESCRIPTION
**Changes**

- extracted InputSelectWrapper, renamed to DropdownWrapper and moved to the shared folder
- moved InputMultiSelect and InputRangeSelect and their types into their own folders
  - for the shared types, I'm still keeping them together with InputSelect
- the same styles are used across these variants so I moved them to the shared folder too
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- [BREAKING] Updated import paths of InputMultiSelect and InputRangeSelect
