### PR TITLE
Trigger calendar display change consistently

### DIFF
--- a/src/date-input/date-input.tsx
+++ b/src/date-input/date-input.tsx
@@ -23,6 +23,7 @@ export const DateInput = ({
     value,
     onChange,
     onBlur,
+    onYearMonthDisplayChange,
     withButton: _withButton = true,
     readOnly,
     id,
@@ -175,6 +176,7 @@ export const DateInput = ({
                 onHover={handleHoverDayCell}
                 onSelect={handleChange}
                 onDismiss={handleCalendarAction}
+                onYearMonthDisplayChange={onYearMonthDisplayChange}
             />
         </Container>
     );

--- a/src/date-input/types.ts
+++ b/src/date-input/types.ts
@@ -1,4 +1,7 @@
-import { CommonCalendarProps } from "../shared/internal-calendar/types";
+import {
+    CommonCalendarProps,
+    YearMonthDisplay,
+} from "../shared/internal-calendar/types";
 
 export interface DateInputProps extends CommonCalendarProps {
     // Standard HTML Attributes
@@ -28,4 +31,6 @@ export interface DateInputProps extends CommonCalendarProps {
      * Function that returns when a defocus is made on the field
      */
     onBlur?: (() => void) | undefined;
+    /** Called when there is a change in the current visible month and year */
+    onYearMonthDisplayChange?: ((value: YearMonthDisplay) => void) | undefined;
 }

--- a/src/date-range-input/date-range-input.tsx
+++ b/src/date-range-input/date-range-input.tsx
@@ -52,6 +52,7 @@ export const DateRangeInput = ({
     valueEnd,
     onChange,
     onBlur,
+    onYearMonthDisplayChange,
     withButton: _withButton = true,
     readOnly,
     id,
@@ -423,6 +424,7 @@ export const DateRangeInput = ({
                 onSelect={handleCalendarSelect}
                 onDismiss={handleCalendarDismiss}
                 onHover={handleCalendarHover}
+                onYearMonthDisplayChange={onYearMonthDisplayChange}
             />
         </Container>
     );

--- a/src/date-range-input/types.ts
+++ b/src/date-range-input/types.ts
@@ -1,4 +1,7 @@
-import { CommonCalendarProps } from "../shared/internal-calendar/types";
+import {
+    CommonCalendarProps,
+    YearMonthDisplay,
+} from "../shared/internal-calendar/types";
 
 export interface DateRangeInputProps extends CommonCalendarProps {
     // Standard HTML Attributes
@@ -32,4 +35,6 @@ export interface DateRangeInputProps extends CommonCalendarProps {
      * Function that returns when a defocus is made on the field
      */
     onBlur?: (() => void) | undefined;
+    /** Called when there is a change in the current visible month and year */
+    onYearMonthDisplayChange?: ((value: YearMonthDisplay) => void) | undefined;
 }

--- a/src/shared/internal-calendar/calendar-manager.tsx
+++ b/src/shared/internal-calendar/calendar-manager.tsx
@@ -58,11 +58,11 @@ const Component = (
     // =============================================================================
     // CONST, STATE, REF
     // =============================================================================
-    // the current visible date in all views
+    // the current visible date in month/year views and header
     const [calendarDate, setCalendarDate] = useState<Dayjs>(
         dayjs(initialCalendarDate)
     );
-    // the selected date in month/year views
+    // the selected date in month/year views and the current visible date in day view
     const [viewCalendarDate, setViewCalendarDate] = useState<Dayjs>(
         dayjs(initialCalendarDate)
     );
@@ -84,7 +84,6 @@ const Component = (
                 const date = dayjs(initialCalendarDate);
                 setCalendarDate(date);
                 setViewCalendarDate(date);
-                performOnCalendarDateChange(date);
 
                 setCurrentView("default");
             },
@@ -92,7 +91,6 @@ const Component = (
                 const date = value ? dayjs(value) : dayjs();
                 setCalendarDate(date);
                 setViewCalendarDate(date);
-                performOnCalendarDateChange(date);
             },
         };
     });
@@ -102,6 +100,12 @@ const Component = (
         setCalendarDate(date);
         setViewCalendarDate(date);
     }, [initialCalendarDate]);
+
+    useEffect(() => {
+        performOnCalendarDateChange(viewCalendarDate);
+        // more accurate than calendarDate since it accounts for selection state
+        // in month/year views
+    }, [viewCalendarDate]);
 
     // =============================================================================
     // EVENT HANDLERS
@@ -144,7 +148,6 @@ const Component = (
             case "default":
                 setViewCalendarDate(nextDate);
                 setCalendarDate(nextDate);
-                performOnCalendarDateChange(nextDate);
                 break;
             case "month-options":
                 setCalendarDate((date) => date.subtract(1, "year"));
@@ -167,7 +170,6 @@ const Component = (
             case "default":
                 setViewCalendarDate(nextDate);
                 setCalendarDate(nextDate);
-                performOnCalendarDateChange(nextDate);
                 break;
             case "month-options":
                 setCalendarDate((date) => date.add(1, "year"));
@@ -181,8 +183,6 @@ const Component = (
     const handleMonthYearSelect = (value: Dayjs) => {
         setCalendarDate(value);
         setViewCalendarDate(value);
-
-        performOnCalendarDateChange(value);
     };
 
     const handleCancelButton = () => {
@@ -412,7 +412,7 @@ const Component = (
     const renderViews = () => {
         const defaultView =
             typeof children === "function"
-                ? children({ calendarDate })
+                ? children({ calendarDate: viewCalendarDate })
                 : children;
 
         if (dynamicHeight) {

--- a/src/shared/internal-calendar/internal-calendar.tsx
+++ b/src/shared/internal-calendar/internal-calendar.tsx
@@ -32,6 +32,7 @@ export const Component = (
     // CONST, STATE, REF
     // =============================================================================
     const calendarManagerRef = useRef<CalendarManagerRef>();
+    const previousCalendarDate = useRef<Dayjs>(undefined);
 
     // =============================================================================
     // HOOKS
@@ -76,11 +77,20 @@ export const Component = (
     const handleDateSelect = (value: Dayjs) => {
         const stringValue = value.format("YYYY-MM-DD");
         performOnSelectHandler(stringValue);
-        performDisplayChangeHandler(value);
     };
 
     const handleDateHover = (value: string) => {
         performOnHoverHandler(value);
+    };
+
+    const handleCalendarDateChange = (value: Dayjs) => {
+        if (
+            !previousCalendarDate.current ||
+            !previousCalendarDate.current.isSame(value, "month")
+        ) {
+            performDisplayChangeHandler(value);
+        }
+        previousCalendarDate.current = value;
     };
 
     // =============================================================================
@@ -144,6 +154,7 @@ export const Component = (
                 currentFocus={currentFocus}
                 selectedStartDate={selectedStartDate}
                 selectedEndDate={selectedEndDate}
+                onCalendarDateChange={handleCalendarDateChange}
             >
                 {({ calendarDate }) => (
                     <InternalCalendarDay

--- a/src/time-slot-week-view/time-slot-week-view.tsx
+++ b/src/time-slot-week-view/time-slot-week-view.tsx
@@ -28,6 +28,7 @@ export const TimeSlotWeekView = ({
     // =============================================================================
     const [selectedDate, setSelectedDate] = useState<string>(value); // YYYY-MM-DD
     const calendarManagerRef = useRef<CalendarManagerRef>();
+    const previousCalendarDate = useRef<Dayjs>(undefined);
 
     // =============================================================================
     // EFFECTS
@@ -56,7 +57,21 @@ export const TimeSlotWeekView = ({
         }
     };
 
-    const performOnCalendarDateChange = (value: Dayjs) => {
+    const handleOnCalendarDateChange = (value: Dayjs) => {
+        if (
+            previousCalendarDate.current &&
+            !previousCalendarDate.current.isSame(value, "week")
+        ) {
+            performDisplayChangeHandler(value);
+        }
+        previousCalendarDate.current = value;
+    };
+
+    // =============================================================================
+    // HELPERS
+    // =============================================================================
+
+    const performDisplayChangeHandler = (value: Dayjs) => {
         if (onWeekDisplayChange) {
             const returnValue = {
                 week: {
@@ -97,7 +112,7 @@ export const TimeSlotWeekView = ({
                     maxDate &&
                     dayjs(calendarDate).add(1, "week").isAfter(maxDate, "week")
                 }
-                onCalendarDateChange={performOnCalendarDateChange}
+                onCalendarDateChange={handleOnCalendarDateChange}
                 showNavigationHeader={showNavigationHeader}
                 minDate={minDate}
                 maxDate={maxDate}

--- a/src/util/date-input-helper.ts
+++ b/src/util/date-input-helper.ts
@@ -18,13 +18,13 @@ export namespace DateInputHelper {
         }
 
         if (minDate) {
-            if (dayjs(val).isBefore(minDate)) {
+            if (dayjs(val).isBefore(minDate, "day")) {
                 return true;
             }
         }
 
         if (maxDate) {
-            if (dayjs(val).isAfter(maxDate)) {
+            if (dayjs(val).isAfter(maxDate, "day")) {
                 return true;
             }
         }


### PR DESCRIPTION
**Changes**

- Fix internal logic for firing calendar date change. It wasn't triggering in some places, so the trigger is now based on a single `useEffect` for simplicity
- Invoke Calendar's `onYearMonthDisplayChange` callback prop only when the month/year has indeed changed
- Update TimeSlotWeekView's `onWeekDisplayChange` to match this behaviour
- Expose `onYearMonthDisplayChange` in date pickers as well (needed by BSG)
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Introduce `onYearMonthDisplayChange` to listen to month/year display change in date pickers
