### PR TITLE
Change className to be assigned to wrapper

### DIFF
--- a/src/input-multi-select/input-multi-select.tsx
+++ b/src/input-multi-select/input-multi-select.tsx
@@ -17,6 +17,7 @@ export const InputMultiSelect = <T, V>({
     selectedOptions,
     placeholder = "Select",
     options,
+    className,
     disabled,
     error,
     "data-testid": testId,
@@ -200,6 +201,7 @@ export const InputMultiSelect = <T, V>({
             error={error && !showOptions}
             disabled={disabled}
             testId={testId}
+            className={className}
             onBlur={handleWrapperBlur}
         >
             <Selector

--- a/src/input-range-select/input-range-select.tsx
+++ b/src/input-range-select/input-range-select.tsx
@@ -19,6 +19,7 @@ export const InputRangeSelect = <T, V>({
     placeholders = { from: "Select", to: "Select" },
     options,
     disabled,
+    className,
     readOnly,
     error,
     "data-testid": testId,
@@ -276,6 +277,7 @@ export const InputRangeSelect = <T, V>({
             readOnly={readOnly}
             testId={testId}
             onBlur={handleWrapperBlur}
+            className={className}
         >
             <Selector
                 type="button"

--- a/src/input-select/input-select.tsx
+++ b/src/input-select/input-select.tsx
@@ -19,6 +19,7 @@ export const InputSelect = <T, V>({
     options,
     disabled,
     error,
+    className,
     "data-testid": testId,
     id,
     enableSearch = false,
@@ -216,6 +217,7 @@ export const InputSelect = <T, V>({
 
     return (
         <DropdownWrapper
+            className={className}
             show={showOptions}
             error={error && !showOptions}
             disabled={disabled}


### PR DESCRIPTION
**Changes**
Currently for the select components, the `className` is wrongly assigned to the selector and it makes it impossible to modify on the wrapper level.

Issue first reported by @Huizz on the FEE.

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Fix `className` property not assigned correctly to the wrapper for `InputSelect`, `InputMultiSelect` and `RangeSelect`
