### PR TITLE
File upload part 2

### DIFF
--- a/src/file-upload/file-item-edit.styles.tsx
+++ b/src/file-upload/file-item-edit.styles.tsx
@@ -1,0 +1,80 @@
+import styled from "styled-components";
+import { MediaQuery } from "../media/media";
+import { Button } from "../button/button";
+import { Text } from "../text/text";
+
+export const Item = styled.li`
+    display: flex;
+    flex-direction: column;
+    padding: 2rem 0;
+    background: transparent;
+`;
+
+export const ContentSection = styled.div`
+    display: flex;
+    margin-bottom: 1rem;
+    width: 100%;
+`;
+
+export const ContentMain = styled.div`
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+`;
+
+export const NameSection = styled.div`
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+
+    ${MediaQuery.MaxWidth.mobileL} {
+        flex-direction: column;
+        justify-content: flex-start;
+    }
+`;
+
+export const EditableSection = styled.div`
+    display: flex;
+    flex-direction: column;
+    padding-right: 5.3rem;
+
+    ${MediaQuery.MaxWidth.mobileL} {
+        padding-right: 0;
+    }
+`;
+
+export const ActionButtonsSection = styled.div`
+    display: flex;
+
+    ${MediaQuery.MaxWidth.mobileL} {
+        flex-direction: column;
+    }
+`;
+
+export const ActionButton = styled(Button.Small)`
+    width: 7.5rem;
+    :not(:last-of-type) {
+        margin-right: 1rem;
+    }
+
+    ${MediaQuery.MaxWidth.mobileL} {
+        width: 100%;
+        :not(:last-of-type) {
+            margin-bottom: 1rem;
+        }
+    }
+`;
+
+export const FileNameText = styled(Text.BodySmall)`
+    display: flex;
+    flex: 1;
+    margin-right: 1rem;
+
+    ${MediaQuery.MaxWidth.mobileL} {
+        margin-right: 0;
+        margin-bottom: 0.5rem;
+    }
+`;
+
+export const FileSizeText = styled(Text.BodySmall)``;

--- a/src/file-upload/file-item-edit.styles.tsx
+++ b/src/file-upload/file-item-edit.styles.tsx
@@ -2,12 +2,17 @@ import styled from "styled-components";
 import { MediaQuery } from "../media/media";
 import { Button } from "../button/button";
 import { Text } from "../text/text";
+import { Color } from "../color/color";
 
 export const Item = styled.li`
     display: flex;
     flex-direction: column;
     padding: 2rem 0;
     background: transparent;
+
+    :not(:last-child) {
+        border-bottom: 1px solid ${Color.Neutral[5]};
+    }
 `;
 
 export const ContentSection = styled.div`
@@ -37,11 +42,6 @@ export const NameSection = styled.div`
 export const EditableSection = styled.div`
     display: flex;
     flex-direction: column;
-    padding-right: 5.3rem;
-
-    ${MediaQuery.MaxWidth.mobileL} {
-        padding-right: 0;
-    }
 `;
 
 export const ActionButtonsSection = styled.div`

--- a/src/file-upload/file-item-edit.tsx
+++ b/src/file-upload/file-item-edit.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useRef, useState } from "react";
+import { Form } from "../form";
+import {
+    ActionButton,
+    ActionButtonsSection,
+    ContentMain,
+    ContentSection,
+    EditableSection,
+    FileNameText,
+    FileSizeText,
+    Item,
+    NameSection,
+} from "./file-item-edit.styles";
+import { StringHelper } from "../util";
+
+interface Props {
+    id: string;
+    name: string;
+    description: string;
+    fileSize: string;
+    wrapperWidth: number;
+    descriptionMaxLength?: number | undefined;
+    truncateText?: boolean | undefined;
+    onEdit: (description: string) => void;
+    onCancel: () => void;
+}
+
+export const FileItemEdit = ({
+    id,
+    description,
+    name,
+    fileSize,
+    descriptionMaxLength,
+    wrapperWidth,
+    truncateText = true,
+    onEdit,
+    onCancel,
+}: Props) => {
+    // =========================================================================
+    // CONST, STATE, REFS
+    // =========================================================================
+    const [formattedName, setFormattedName] = useState<string>();
+
+    const textareaRef = useRef<HTMLTextAreaElement>();
+    const nameSectionRef = useRef<HTMLDivElement>();
+
+    // =========================================================================
+    // EFFECTS
+    // =========================================================================
+    useEffect(() => {
+        setFormattedName(getTruncatedText(name));
+    }, [wrapperWidth]);
+
+    // =========================================================================
+    // EVENT HANDLERS
+    // =========================================================================
+    const handleSave = () => {
+        if (textareaRef.current) {
+            onEdit(textareaRef.current.value);
+        } else {
+            onEdit(undefined);
+        }
+    };
+
+    // =========================================================================
+    // HELPER FUNCTIONS
+    // =========================================================================
+    const getTruncatedText = (value: string) => {
+        if (!truncateText) return value;
+
+        const widthOfElement =
+            nameSectionRef && nameSectionRef.current
+                ? nameSectionRef.current.getBoundingClientRect().width
+                : 0;
+
+        return StringHelper.truncateOneLine(
+            value,
+            widthOfElement,
+            widthOfElement / 2,
+            widthOfElement / 2 / 8, // Arbitrary
+            16 // Font size
+        );
+    };
+
+    // =========================================================================
+    // RENDER FUNCTIONS
+    // =========================================================================
+    return (
+        <Item>
+            <ContentSection>
+                {/* Thumbnail to be rendered here. */}
+                <ContentMain>
+                    <NameSection ref={nameSectionRef}>
+                        <FileNameText weight="semibold">
+                            {formattedName}
+                        </FileNameText>
+                        <FileSizeText>{fileSize}</FileSizeText>
+                    </NameSection>
+                    <EditableSection>
+                        <Form.Textarea
+                            ref={textareaRef}
+                            id={`${id}-description-textarea`}
+                            value={description}
+                            maxLength={descriptionMaxLength}
+                            rows={3}
+                            label={{
+                                children: "Photo description",
+                                subtitle:
+                                    "Describe this photo to users who may not be able to see the image.",
+                            }}
+                        />
+                    </EditableSection>
+                </ContentMain>
+            </ContentSection>
+            <ActionButtonsSection>
+                <ActionButton type="button" onClick={handleSave}>
+                    Save
+                </ActionButton>
+                <ActionButton
+                    type="button"
+                    styleType="secondary"
+                    onClick={onCancel}
+                >
+                    Cancel
+                </ActionButton>
+            </ActionButtonsSection>
+        </Item>
+    );
+};

--- a/src/file-upload/file-item-edit.tsx
+++ b/src/file-upload/file-item-edit.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Form } from "../form";
+import { StringHelper } from "../util";
 import {
     ActionButton,
     ActionButtonsSection,
@@ -11,9 +12,8 @@ import {
     Item,
     NameSection,
 } from "./file-item-edit.styles";
-import { StringHelper } from "../util";
-import { FileItemProps } from "./types";
 import { FileUploadHelper } from "./helper";
+import { FileItemProps } from "./types";
 
 interface Props {
     fileItem: FileItemProps;

--- a/src/file-upload/file-item-edit.tsx
+++ b/src/file-upload/file-item-edit.tsx
@@ -12,33 +12,29 @@ import {
     NameSection,
 } from "./file-item-edit.styles";
 import { StringHelper } from "../util";
+import { FileItemProps } from "./types";
+import { FileUploadHelper } from "./helper";
 
 interface Props {
-    id: string;
-    name: string;
-    description: string;
-    fileSize: string;
+    fileItem: FileItemProps;
     wrapperWidth: number;
     descriptionMaxLength?: number | undefined;
-    truncateText?: boolean | undefined;
     onEdit: (description: string) => void;
     onCancel: () => void;
 }
 
 export const FileItemEdit = ({
-    id,
-    description,
-    name,
-    fileSize,
+    fileItem,
     descriptionMaxLength,
     wrapperWidth,
-    truncateText = true,
     onEdit,
     onCancel,
 }: Props) => {
     // =========================================================================
     // CONST, STATE, REFS
     // =========================================================================
+    const { id, description, name, size, truncateText = true } = fileItem;
+
     const [formattedName, setFormattedName] = useState<string>();
 
     const textareaRef = useRef<HTMLTextAreaElement>();
@@ -56,10 +52,14 @@ export const FileItemEdit = ({
     // =========================================================================
     const handleSave = () => {
         if (textareaRef.current) {
-            onEdit(textareaRef.current.value);
+            onEdit(textareaRef.current.value || "");
         } else {
             onEdit(undefined);
         }
+    };
+
+    const handleCancel = () => {
+        onCancel();
     };
 
     // =========================================================================
@@ -86,7 +86,7 @@ export const FileItemEdit = ({
     // RENDER FUNCTIONS
     // =========================================================================
     return (
-        <Item>
+        <Item data-testid={`${id}-edit-display`}>
             <ContentSection>
                 {/* Thumbnail to be rendered here. */}
                 <ContentMain>
@@ -94,12 +94,15 @@ export const FileItemEdit = ({
                         <FileNameText weight="semibold">
                             {formattedName}
                         </FileNameText>
-                        <FileSizeText>{fileSize}</FileSizeText>
+                        <FileSizeText>
+                            {FileUploadHelper.formatFileSizeDisplay(size)}
+                        </FileSizeText>
                     </NameSection>
                     <EditableSection>
                         <Form.Textarea
                             ref={textareaRef}
                             id={`${id}-description-textarea`}
+                            data-testid={`${id}-textarea`}
                             value={description}
                             maxLength={descriptionMaxLength}
                             rows={3}
@@ -113,13 +116,18 @@ export const FileItemEdit = ({
                 </ContentMain>
             </ContentSection>
             <ActionButtonsSection>
-                <ActionButton type="button" onClick={handleSave}>
+                <ActionButton
+                    data-testid={`${id}-save-button`}
+                    type="button"
+                    onClick={handleSave}
+                >
                     Save
                 </ActionButton>
                 <ActionButton
                     type="button"
                     styleType="secondary"
-                    onClick={onCancel}
+                    data-testid={`${id}-cancel-button`}
+                    onClick={handleCancel}
                 >
                     Cancel
                 </ActionButton>

--- a/src/file-upload/file-item.styles.tsx
+++ b/src/file-upload/file-item.styles.tsx
@@ -69,6 +69,9 @@ export const Content = styled.div`
 `;
 
 export const ItemText = styled(Text.BodySmall)``;
+export const ItemDescriptionText = styled(ItemText)`
+    margin-top: 0.25rem;
+`;
 export const ItemFileSizeText = styled(ItemText)`
     width: 5rem;
     padding-left: 0.5rem;

--- a/src/file-upload/file-item.styles.tsx
+++ b/src/file-upload/file-item.styles.tsx
@@ -15,7 +15,7 @@ interface ItemStyleProps {
 }
 
 interface ItemActionContainerStyleProps {
-    $hasEditButton?: boolean | undefined;
+    $editable?: boolean | undefined;
 }
 
 // =============================================================================
@@ -101,7 +101,7 @@ export const ItemActionContainer = styled.div<ItemActionContainerStyleProps>`
 
     ${MediaQuery.MaxWidth.mobileL} {
         ${(props) => {
-            if (props.$hasEditButton) {
+            if (props.$editable) {
                 return css`
                     margin-left: 0;
                     margin-top: 1rem;

--- a/src/file-upload/file-item.tsx
+++ b/src/file-upload/file-item.tsx
@@ -1,7 +1,6 @@
 import { BinIcon } from "@lifesg/react-icons/bin";
 import { CrossIcon } from "@lifesg/react-icons/cross";
 import { useEffect, useRef, useState } from "react";
-import { useResizeDetector } from "react-resize-detector";
 import { ProgressBar } from "../shared/progress-bar";
 import { StringHelper } from "../util";
 import {
@@ -46,7 +45,6 @@ export const FileItem = ({
     const isLoading = progress < 1;
 
     const nameSectionRef = useRef<HTMLDivElement>();
-    const { width: wrapperWidth, ref: wrapperRef } = useResizeDetector();
 
     // =========================================================================
     // EFFECTS
@@ -143,7 +141,6 @@ export const FileItem = ({
     return (
         <Item
             id={id}
-            ref={wrapperRef}
             $error={!!errorMessage}
             $loading={isLoading}
             $editable={FileUploadHelper.isSupportedImageType(type)}

--- a/src/file-upload/file-item.tsx
+++ b/src/file-upload/file-item.tsx
@@ -1,5 +1,6 @@
 import { BinIcon } from "@lifesg/react-icons/bin";
 import { CrossIcon } from "@lifesg/react-icons/cross";
+import { PencilIcon } from "@lifesg/react-icons/pencil";
 import { useEffect, useRef, useState } from "react";
 import { ProgressBar } from "../shared/progress-bar";
 import { StringHelper } from "../util";
@@ -19,7 +20,6 @@ import {
 } from "./file-item.styles";
 import { FileUploadHelper } from "./helper";
 import { FileItemProps } from "./types";
-import { PencilIcon } from "@lifesg/react-icons/pencil";
 
 interface Props {
     fileItem: FileItemProps;
@@ -121,16 +121,17 @@ export const FileItem = ({
             );
         } else {
             return (
-                <ItemActionContainer $hasEditButton={editable}>
+                <ItemActionContainer $editable={editable}>
                     {editable && (
                         <IconButton
                             key="edit"
                             data-testid={`${id}-edit-button`}
                             type="button"
                             styleType="light"
+                            aria-label={`edit ${name}`}
                             onClick={handleEdit}
                         >
-                            <PencilIcon />
+                            <PencilIcon aria-hidden />
                         </IconButton>
                     )}
                     <IconButton

--- a/src/file-upload/file-item.tsx
+++ b/src/file-upload/file-item.tsx
@@ -20,39 +20,38 @@ import {
 import { FileUploadHelper } from "./helper";
 import { FileItemProps } from "./types";
 import { PencilIcon } from "@lifesg/react-icons/pencil";
-import { FileItemEdit } from "./file-item-edit";
 
-interface Props extends FileItemProps {
-    wrapperWidth: number;
-    /** Indicates the max length for the file item description */
-    descriptionMaxLength?: number | undefined;
-    /** Indicates if the file item is editable (only for image files) */
+interface Props {
+    fileItem: FileItemProps;
     editable?: boolean | undefined;
+    wrapperWidth: number;
     onDelete: () => void;
-    onDescriptionUpdate: (description: string) => void;
+    onEditClick?: (() => void) | undefined;
 }
 
 export const FileItem = ({
-    id,
-    name,
-    size,
-    type,
-    description,
-    progress = 1,
+    fileItem,
     editable,
-    errorMessage,
     wrapperWidth,
-    thumbnailImageDataUrl,
-    truncateText = true,
-    descriptionMaxLength,
     onDelete,
-    onDescriptionUpdate,
+    onEditClick,
 }: Props) => {
     // =========================================================================
     // CONST, STATE, REFS
     // =========================================================================
+    const {
+        id,
+        name,
+        size,
+        type,
+        description,
+        progress = 1,
+        errorMessage,
+        thumbnailImageDataUrl,
+        truncateText = true,
+    } = fileItem;
+
     const [formattedName, setFormattedName] = useState<string>();
-    const [renderEditMode, setRenderEditMode] = useState<boolean>(false);
     const isLoading = progress < 1;
     const fileSize = FileUploadHelper.formatFileSizeDisplay(size);
 
@@ -63,17 +62,7 @@ export const FileItem = ({
     // =========================================================================
     useEffect(() => {
         setFormattedName(getTruncatedText(name));
-    }, [wrapperWidth, renderEditMode]);
-
-    useEffect(() => {
-        if (
-            editable &&
-            FileUploadHelper.isSupportedImageType(type) &&
-            !description
-        ) {
-            setRenderEditMode(true);
-        }
-    }, [description, type, editable]);
+    }, [wrapperWidth]);
 
     // =========================================================================
     // EVENT HANDLERS
@@ -83,16 +72,9 @@ export const FileItem = ({
     };
 
     const handleEdit = () => {
-        setRenderEditMode(true);
-    };
-
-    const handleDescriptionEdit = (description: string) => {
-        onDescriptionUpdate(description);
-        setRenderEditMode(false);
-    };
-
-    const handleDescriptionEditCancel = () => {
-        setRenderEditMode(false);
+        if (onEditClick) {
+            onEditClick();
+        }
     };
 
     // =========================================================================
@@ -138,12 +120,9 @@ export const FileItem = ({
                 </ItemActionContainer>
             );
         } else {
-            const isEditable =
-                editable && FileUploadHelper.isSupportedImageType(type);
-
             return (
-                <ItemActionContainer $hasEditButton={isEditable}>
-                    {isEditable && (
+                <ItemActionContainer $hasEditButton={editable}>
+                    {editable && (
                         <IconButton
                             key="edit"
                             data-testid={`${id}-edit-button`}
@@ -168,24 +147,6 @@ export const FileItem = ({
             );
         }
     };
-
-    // -------------------------------------------------------------------------
-    // ACTUAL RENDER
-    // -------------------------------------------------------------------------
-    if (renderEditMode) {
-        return (
-            <FileItemEdit
-                id={id}
-                name={name}
-                description={description}
-                descriptionMaxLength={descriptionMaxLength}
-                fileSize={fileSize}
-                wrapperWidth={wrapperWidth}
-                onEdit={handleDescriptionEdit}
-                onCancel={handleDescriptionEditCancel}
-            />
-        );
-    }
 
     return (
         <Item

--- a/src/file-upload/file-list.styles.tsx
+++ b/src/file-upload/file-list.styles.tsx
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+import { Color } from "../color";
+
+export const ListWrapper = styled.ul`
+    list-style-type: none;
+    margin-bottom: 2rem;
+`;
+
+export const EditableItemsContainer = styled.li`
+    border-top: 1px solid ${Color.Neutral[5]};
+    border-bottom: 1px solid ${Color.Neutral[5]};
+
+    :not(:last-child) {
+        margin-bottom: 2rem;
+    }
+
+    :not(:first-child) {
+        margin-top: 2rem;
+    }
+
+    ul {
+        list-style-type: none;
+    }
+`;

--- a/src/file-upload/file-list.tsx
+++ b/src/file-upload/file-list.tsx
@@ -1,0 +1,237 @@
+import findIndex from "lodash/findIndex";
+import isEqual from "lodash/isEqual";
+import { useEffect, useState } from "react";
+import { useResizeDetector } from "react-resize-detector";
+import { FileItem } from "./file-item";
+import { FileItemEdit } from "./file-item-edit";
+import { EditableItemsContainer, ListWrapper } from "./file-list.styles";
+import { FileUploadHelper } from "./helper";
+import { FileItemProps } from "./types";
+import { SimpleIdGenerator } from "../util";
+
+// =============================================================================
+// INTERFACES
+// =============================================================================
+type RenderMode = "cancelled-edit" | "list" | "edit";
+
+interface FileItemRenderProps {
+    fileItem: FileItemProps;
+    renderMode: RenderMode;
+}
+
+type RenderItem = FileItemRenderProps | FileItemRenderProps[];
+
+interface Props {
+    fileItems: FileItemProps[];
+    onItemUpdate: (item: FileItemProps) => void;
+    onItemDelete: (item: FileItemProps) => void;
+    editableFileItems: boolean;
+    descriptionMaxLength?: number | undefined;
+}
+
+// =============================================================================
+// COMPONENT
+// =============================================================================
+
+export const FileList = ({
+    fileItems,
+    editableFileItems,
+    descriptionMaxLength,
+    onItemUpdate,
+    onItemDelete,
+}: Props) => {
+    // =========================================================================
+    // CONST, STATE, REFS
+    // =========================================================================
+    const [arrangedItems, setArrangedItems] = useState<RenderItem[]>([]);
+    const [itemsRenderMode, setItemsRenderMode] = useState<
+        FileItemRenderProps[]
+    >([]);
+
+    const { width: wrapperWidth, ref: wrapperRef } = useResizeDetector();
+
+    // =========================================================================
+    // EFFECTS
+    // =========================================================================
+    useEffect(() => {
+        setItemsRenderMode(getItemsRenderMode(fileItems));
+    }, [fileItems]);
+
+    useEffect(() => {
+        setArrangedItems(getArrangedItemsToRender(itemsRenderMode));
+    }, [itemsRenderMode]);
+
+    // =========================================================================
+    // EVENT HANDLERS
+    // =========================================================================
+    const handleDescriptionUpdate =
+        (item: FileItemProps) => (description: string) => {
+            const updatedItem = { ...item, description };
+            onItemUpdate(updatedItem);
+        };
+
+    const handleCancel = (item: FileItemProps) => () => {
+        setItemsRenderMode((prevState) => {
+            return prevState.map((renderItem) => {
+                if (isEqual(item, renderItem.fileItem)) {
+                    return {
+                        ...renderItem,
+                        renderMode: item.description
+                            ? "list"
+                            : "cancelled-edit",
+                    };
+                }
+
+                return renderItem;
+            });
+        });
+    };
+
+    const handleInitiateEdit = (item: FileItemProps) => () => {
+        setItemsRenderMode((prevState) => {
+            return prevState.map((renderItem) => {
+                if (isEqual(item, renderItem.fileItem)) {
+                    return {
+                        ...renderItem,
+                        renderMode: "edit",
+                    };
+                }
+
+                return renderItem;
+            });
+        });
+    };
+
+    const handleDelete = (item: FileItemProps) => () => {
+        onItemDelete(item);
+    };
+
+    // =========================================================================
+    // HELPER FUNCTIONS
+    // =========================================================================
+    const checkEditable = (item: FileItemProps) => {
+        return (
+            editableFileItems &&
+            FileUploadHelper.isSupportedImageType(item.type)
+        );
+    };
+
+    const shouldRenderEditMode = (item: FileItemProps) => {
+        return checkEditable(item) && item.description === undefined;
+    };
+
+    const getItemsRenderMode = (
+        fileItems: FileItemProps[]
+    ): FileItemRenderProps[] => {
+        if (!fileItems || fileItems.length === 0) return [];
+
+        return fileItems.map((item) => {
+            const existingIndex = findIndex(itemsRenderMode, (renderedItem) => {
+                return isEqual(renderedItem.fileItem, item);
+            });
+
+            if (existingIndex < 0) {
+                // New item
+                return {
+                    fileItem: item,
+                    renderMode: shouldRenderEditMode(item) ? "edit" : "list",
+                };
+            } else {
+                const existingRenderedItem = itemsRenderMode[existingIndex];
+
+                /**
+                 * If an item previously had it's edit cancelled,
+                 * we'll not re-render the edit mode even if the
+                 * description is undefined
+                 */
+                return {
+                    fileItem: item,
+                    renderMode:
+                        shouldRenderEditMode(item) &&
+                        !(existingRenderedItem.renderMode === "cancelled-edit")
+                            ? "edit"
+                            : existingRenderedItem.renderMode,
+                };
+            }
+        });
+    };
+
+    /**
+     * Due to a UI requirement, we will render
+     */
+    const getArrangedItemsToRender = (
+        fileItemRenders: FileItemRenderProps[]
+    ) => {
+        if (!fileItemRenders || fileItemRenders.length === 0) {
+            return [];
+        }
+
+        return fileItemRenders.reduce((accumulator, currentItem) => {
+            const { renderMode } = currentItem;
+
+            if (renderMode === "edit") {
+                const previousElement = accumulator[accumulator.length - 1];
+                if (Array.isArray(previousElement)) {
+                    previousElement.push(currentItem);
+                } else {
+                    accumulator.push([currentItem]);
+                }
+            } else {
+                accumulator.push(currentItem);
+            }
+
+            return accumulator;
+        }, []);
+    };
+
+    // =========================================================================
+    // RENDER FUNCTIONS
+    // =========================================================================
+    const renderItemsInEditMode = (fileItems: FileItemRenderProps[]) => {
+        const itemsToRender = fileItems.map((item) => {
+            const { fileItem } = item;
+            return (
+                <FileItemEdit
+                    key={fileItem.id}
+                    fileItem={fileItem}
+                    wrapperWidth={wrapperWidth}
+                    descriptionMaxLength={descriptionMaxLength}
+                    onEdit={handleDescriptionUpdate(fileItem)}
+                    onCancel={handleCancel(fileItem)}
+                />
+            );
+        });
+
+        return (
+            <EditableItemsContainer
+                key={`editable-items-${SimpleIdGenerator.generate()}`}
+            >
+                <ul>{itemsToRender}</ul>
+            </EditableItemsContainer>
+        );
+    };
+
+    const renderItems = () => {
+        if (arrangedItems.length === 0) return null;
+
+        return arrangedItems.map((item) => {
+            if (Array.isArray(item)) {
+                return renderItemsInEditMode(item);
+            } else {
+                const { fileItem } = item;
+                return (
+                    <FileItem
+                        key={fileItem.id}
+                        fileItem={fileItem}
+                        editable={checkEditable(fileItem)}
+                        wrapperWidth={wrapperWidth}
+                        onDelete={handleDelete(fileItem)}
+                        onEditClick={handleInitiateEdit(fileItem)}
+                    />
+                );
+            }
+        });
+    };
+
+    return <ListWrapper ref={wrapperRef}>{renderItems()}</ListWrapper>;
+};

--- a/src/file-upload/file-upload.styles.tsx
+++ b/src/file-upload/file-upload.styles.tsx
@@ -1,9 +1,9 @@
 import styled from "styled-components";
 import { Alert } from "../alert";
-import { Text, TextStyleHelper } from "../text";
-import { MediaQuery } from "../media";
 import { Button } from "../button";
 import { Color } from "../color";
+import { MediaQuery } from "../media";
+import { Text, TextStyleHelper } from "../text";
 
 // =============================================================================
 // STYLING
@@ -21,11 +21,6 @@ export const Title = styled(Text.H4)`
 export const Description = styled(Text.BodySmall)`
     margin-bottom: 0;
     color: ${Color.Neutral[3]};
-`;
-
-export const ItemsContainer = styled.ul`
-    list-style-type: none;
-    margin-bottom: 2rem;
 `;
 
 export const WarningAlert = styled(Alert)`
@@ -59,22 +54,5 @@ export const UploadButtonLabel = styled.label`
     ${MediaQuery.MaxWidth.mobileL} {
         display: none;
         visibility: hidden;
-    }
-`;
-
-export const EditableItemsContainer = styled.ul`
-    list-style-type: none;
-    border-top: 1px solid ${Color.Neutral[5]};
-    :not(:last-child) {
-        border-bottom: 1px solid ${Color.Neutral[5]};
-        margin-bottom: 2rem;
-    }
-
-    :last-child {
-        margin-bottom: -2rem; // offset as margin already on ItemsContainer
-    }
-
-    :not(:first-child) {
-        margin-top: 2rem;
     }
 `;

--- a/src/file-upload/file-upload.styles.tsx
+++ b/src/file-upload/file-upload.styles.tsx
@@ -61,3 +61,20 @@ export const UploadButtonLabel = styled.label`
         visibility: hidden;
     }
 `;
+
+export const EditableItemsContainer = styled.ul`
+    list-style-type: none;
+    border-top: 1px solid ${Color.Neutral[5]};
+    :not(:last-child) {
+        border-bottom: 1px solid ${Color.Neutral[5]};
+        margin-bottom: 2rem;
+    }
+
+    :last-child {
+        margin-bottom: -2rem; // offset as margin already on ItemsContainer
+    }
+
+    :not(:first-child) {
+        margin-top: 2rem;
+    }
+`;

--- a/src/file-upload/file-upload.tsx
+++ b/src/file-upload/file-upload.tsx
@@ -1,12 +1,8 @@
-import isEqual from "lodash/isEqual";
-import { useEffect, useRef, useState } from "react";
-import { useResizeDetector } from "react-resize-detector";
+import { useRef } from "react";
 import { DropzoneElement, FileUploadDropzone } from "./dropzone";
-import { FileItem } from "./file-item";
+import { FileList } from "./file-list";
 import {
     Description,
-    EditableItemsContainer,
-    ItemsContainer,
     Title,
     TitleContainer,
     UploadButton,
@@ -15,22 +11,7 @@ import {
     WarningAlert,
 } from "./file-upload.styles";
 import { FileItemProps, FileUploadProps } from "./types";
-import { FileUploadHelper } from "./helper";
-import { FileItemEdit } from "./file-item-edit";
 
-// =============================================================================
-// INTERFACES
-// =============================================================================
-interface FileItemRenderProps {
-    fileItem: FileItemProps;
-    renderMode: "default" | "edit";
-}
-
-type RenderItem = FileItemRenderProps | FileItemRenderProps[];
-
-// =============================================================================
-// COMPONENT
-// =============================================================================
 export const FileUpload = ({
     styleType = "bordered",
     fileItems,
@@ -46,7 +27,7 @@ export const FileUpload = ({
     multiple,
     disabled,
     descriptionMaxLength,
-    editableFileItems,
+    editableFileItems = true,
     onChange,
     onDelete,
     onEdit,
@@ -54,24 +35,7 @@ export const FileUpload = ({
     // =========================================================================
     // CONST, STATE, REFS
     // =========================================================================
-    const [arrangedItems, setArrangedItems] = useState<RenderItem[]>([]);
-    const [itemsRenderMode, setItemsRenderMode] = useState<
-        FileItemRenderProps[]
-    >([]);
-
     const dropzoneRef = useRef<DropzoneElement>();
-    const { width: wrapperWidth, ref: wrapperRef } = useResizeDetector();
-
-    // =========================================================================
-    // EFFECTS
-    // =========================================================================
-    useEffect(() => {
-        setItemsRenderMode(getItemsRenderMode(fileItems));
-    }, [fileItems]);
-
-    useEffect(() => {
-        setArrangedItems(getArrangedItemsToRender(itemsRenderMode));
-    }, [itemsRenderMode]);
 
     // =========================================================================
     // EVENT HANDLERS
@@ -82,7 +46,7 @@ export const FileUpload = ({
         }
     };
 
-    const handleItemDelete = (item: FileItemProps) => () => {
+    const handleItemDelete = (item: FileItemProps) => {
         if (onDelete) {
             onDelete(item);
         }
@@ -99,93 +63,15 @@ export const FileUpload = ({
         }
     };
 
-    const handleDescriptionUpdate =
-        (item: FileItemProps) => (description: string) => {
-            if (onEdit) {
-                const updatedItem = { ...item, description };
-                onEdit(updatedItem);
-            }
-        };
-
-    const handleInitiateEdit = (item: FileItemProps) => () => {
-        setItemsRenderMode((prevState) => {
-            return prevState.map((renderItem) => {
-                if (isEqual(item, renderItem.fileItem)) {
-                    return {
-                        ...renderItem,
-                        renderMode: "edit",
-                    };
-                }
-
-                return renderItem;
-            });
-        });
-    };
-
-    const handleCancel = (item: FileItemProps) => () => {
-        setItemsRenderMode((prevState) => {
-            return prevState.map((renderItem) => {
-                if (isEqual(item, renderItem.fileItem)) {
-                    return {
-                        ...renderItem,
-                        renderMode: "default",
-                    };
-                }
-
-                return renderItem;
-            });
-        });
+    const handleItemUpdate = (updatedItem: FileItemProps) => {
+        if (onEdit) {
+            onEdit(updatedItem);
+        }
     };
 
     // =========================================================================
     // HELPER FUNCTIONS
     // =========================================================================
-    const checkEditable = (type: string) => {
-        return editableFileItems && FileUploadHelper.isSupportedImageType(type);
-    };
-
-    const getItemsRenderMode = (
-        fileItems: FileItemProps[]
-    ): FileItemRenderProps[] => {
-        if (!fileItems || fileItems.length === 0) return [];
-
-        return fileItems.map((item) => {
-            return {
-                fileItem: item,
-                renderMode:
-                    FileUploadHelper.isSupportedImageType(item.type) &&
-                    item.description === undefined
-                        ? "edit"
-                        : "default",
-            };
-        });
-    };
-
-    const getArrangedItemsToRender = (
-        fileItemRenders: FileItemRenderProps[]
-    ) => {
-        if (!fileItemRenders || fileItemRenders.length === 0) {
-            return [];
-        }
-
-        return fileItemRenders.reduce((accumulator, currentItem) => {
-            const { renderMode } = currentItem;
-
-            if (renderMode === "edit") {
-                const previousElement = accumulator[accumulator.length - 1];
-                if (Array.isArray(previousElement)) {
-                    previousElement.push(currentItem);
-                } else {
-                    accumulator.push([currentItem]);
-                }
-            } else {
-                accumulator.push(currentItem);
-            }
-
-            return accumulator;
-        }, []);
-    };
-
     const reachedMaxFiles = () => {
         return maxFiles ? fileItems.length >= maxFiles : false;
     };
@@ -193,50 +79,6 @@ export const FileUpload = ({
     // =========================================================================
     // RENDER FUNCTIONS
     // =========================================================================
-    const renderItemsInEditMode = (fileItems: FileItemRenderProps[]) => {
-        const itemsToRender = fileItems.map((item) => {
-            const { fileItem } = item;
-            return (
-                <FileItemEdit
-                    key={fileItem.id}
-                    fileItem={fileItem}
-                    wrapperWidth={wrapperWidth}
-                    descriptionMaxLength={descriptionMaxLength}
-                    onEdit={handleDescriptionUpdate(fileItem)}
-                    onCancel={handleCancel(fileItem)}
-                />
-            );
-        });
-
-        return <EditableItemsContainer>{itemsToRender}</EditableItemsContainer>;
-    };
-
-    const renderItems = () => {
-        if (arrangedItems.length === 0) return null;
-
-        const itemsToRender = arrangedItems.map((item) => {
-            if (Array.isArray(item)) {
-                return renderItemsInEditMode(item);
-            } else {
-                const { fileItem } = item;
-                return (
-                    <FileItem
-                        key={fileItem.id}
-                        fileItem={fileItem}
-                        editable={checkEditable(fileItem.type)}
-                        wrapperWidth={wrapperWidth}
-                        onDelete={handleItemDelete(fileItem)}
-                        onEditClick={handleInitiateEdit(fileItem)}
-                    />
-                );
-            }
-        });
-
-        return (
-            <ItemsContainer ref={wrapperRef}>{itemsToRender}</ItemsContainer>
-        );
-    };
-
     return (
         <FileUploadDropzone
             ref={dropzoneRef}
@@ -261,7 +103,13 @@ export const FileUpload = ({
                 </TitleContainer>
             )}
             {warning && <WarningAlert type="warning">{warning}</WarningAlert>}
-            {renderItems()}
+            <FileList
+                fileItems={fileItems}
+                editableFileItems={editableFileItems}
+                descriptionMaxLength={descriptionMaxLength}
+                onItemDelete={handleItemDelete}
+                onItemUpdate={handleItemUpdate}
+            />
             <UploadButtonContainer>
                 <UploadButton
                     type="button"

--- a/src/file-upload/file-upload.tsx
+++ b/src/file-upload/file-upload.tsx
@@ -1,4 +1,5 @@
 import { useRef } from "react";
+import { useResizeDetector } from "react-resize-detector";
 import { DropzoneElement, FileUploadDropzone } from "./dropzone";
 import { FileItem } from "./file-item";
 import {
@@ -34,6 +35,7 @@ export const FileUpload = ({
     // CONST, STATE, REFS
     // =========================================================================
     const dropzoneRef = useRef<DropzoneElement>();
+    const { width: wrapperWidth, ref: wrapperRef } = useResizeDetector();
 
     // =========================================================================
     // EFFECTS
@@ -81,7 +83,9 @@ export const FileUpload = ({
             );
         });
 
-        return <ItemsContainer>{itemsToRender}</ItemsContainer>;
+        return (
+            <ItemsContainer ref={wrapperRef}>{itemsToRender}</ItemsContainer>
+        );
     };
 
     return (

--- a/src/file-upload/file-upload.tsx
+++ b/src/file-upload/file-upload.tsx
@@ -28,8 +28,11 @@ export const FileUpload = ({
     capture,
     multiple,
     disabled,
+    descriptionMaxLength,
+    editableFileItems,
     onChange,
     onDelete,
+    onEdit,
 }: FileUploadProps) => {
     // =========================================================================
     // CONST, STATE, REFS
@@ -67,6 +70,14 @@ export const FileUpload = ({
         }
     };
 
+    const handleDescriptionUpdate =
+        (item: FileItemProps) => (description: string) => {
+            if (onEdit) {
+                const updatedItem = { ...item, description };
+                onEdit(updatedItem);
+            }
+        };
+
     // =========================================================================
     // RENDER FUNCTIONS
     // =========================================================================
@@ -78,7 +89,11 @@ export const FileUpload = ({
                 <FileItem
                     key={item.id}
                     {...item}
+                    wrapperWidth={wrapperWidth}
+                    descriptionMaxLength={descriptionMaxLength}
+                    editable={editableFileItems}
                     onDelete={handleItemDelete(item)}
+                    onDescriptionUpdate={handleDescriptionUpdate(item)}
                 />
             );
         });

--- a/src/file-upload/types.ts
+++ b/src/file-upload/types.ts
@@ -12,8 +12,6 @@ export interface FileItemProps {
     progress?: number | undefined;
     /** The error message display to indicate file upload error */
     errorMessage?: string | undefined;
-    /** If set, the item will be in editable mode */
-    editableMode?: boolean | undefined;
     /** The thumbnail of the file that will be rendered */
     thumbnailImageDataUrl?: string | undefined;
     /** Indicates if text should be truncated */
@@ -40,7 +38,7 @@ export interface FileUploadProps extends FileInputProps {
     /** Called when an upload happens via drag drop or click */
     onChange?: (files: File[]) => void;
     /** Called when an update to the description happens */
-    onUpdate?: (fileItem: FileItemProps) => void;
+    onEdit?: (fileItem: FileItemProps) => void;
     /** Called when a file item's delete button is clicked */
     onDelete?: (fileItem: FileItemProps) => void;
     title?: string | JSX.Element | undefined;
@@ -52,4 +50,6 @@ export interface FileUploadProps extends FileInputProps {
     fileItems?: FileItemProps[] | undefined;
     /** If set, file items will be editable (only image files) */
     editableFileItems?: boolean | undefined;
+    /** The max length of the description of the file (only image files) */
+    descriptionMaxLength?: number | undefined;
 }

--- a/stories/file-upload/file-upload.stories.mdx
+++ b/stories/file-upload/file-upload.stories.mdx
@@ -190,6 +190,75 @@ uploads. However this will require the user to manage the progress themselves.
     </Story>
 </Canvas>
 
+<Heading3>Editable file items</Heading3>
+
+The component also enables you to add a description to the file item. Note that
+this does not alter the file in any way and is up to the discretion of the user
+of the component to decide what to do with it.
+
+Currently only image file uploads have this feature.
+
+<Canvas>
+    <Story name="Editable file items">
+        {() => {
+            const [fileItems, setFileItems] = useState([]);
+            const handleChange = (files) => {
+                const newFileItems = files.map((file) => {
+                    return {
+                        id: SimpleIdGenerator.generate(),
+                        name: file.name,
+                        size: file.size,
+                        type: file.type,
+                    };
+                });
+                setFileItems((prevItems) => {
+                    return prevItems.concat(newFileItems);
+                });
+            };
+            const handleDelete = (fileItem) => {
+                if (fileItems.length === 1) {
+                    setFileItems([]);
+                } else {
+                    const newArr = [...fileItems];
+                    newArr.splice(newArr.indexOf(fileItem), 1);
+                    setFileItems(newArr);
+                }
+            };
+            const handleEdit = (fileItem) => {
+                setFileItems((prevItems) => {
+                    return prevItems.map((item) => {
+                        if (item.id === fileItem.id) {
+                            return fileItem;
+                        } else {
+                            return item;
+                        }
+                    });
+                });
+            };
+            return (
+                <FileUpload
+                    fileItems={fileItems}
+                    onChange={handleChange}
+                    onDelete={handleDelete}
+                    onEdit={handleEdit}
+                    title="Editable file items"
+                    description="Drag an image file and a textarea will be shown for you to enter a description"
+                    descriptionMaxLength={200}
+                    editableFileItems
+                    maxFiles={6}
+                    warning={
+                        <>
+                            Maximum size per file: 2 MB
+                            <br />
+                            Supported file types: .JPG, .JPEG, .PNG
+                        </>
+                    }
+                />
+            );
+        }}
+    </Story>
+</Canvas>
+
 <Secondary>Component API</Secondary>
 
 To be added at the end

--- a/tests/file-upload/file-upload.spec.tsx
+++ b/tests/file-upload/file-upload.spec.tsx
@@ -73,6 +73,43 @@ describe("FileUpload", () => {
                 rendered.getByTestId("some-edit-display")
             ).toBeInTheDocument();
         });
+
+        it("should render the image files with an edit button if there is a description, or if the user cancelled an edit previously", () => {
+            const fileItems: FileItemProps[] = [
+                { ...MOCK_IMAGE_ITEM, description: "Lorem ipsum" },
+                {
+                    id: "another",
+                    name: "donald-duck.png",
+                    type: "image/png",
+                    size: 4000,
+                    truncateText: false, // Test purposes
+                },
+            ];
+
+            const rendered = render(<FileUpload fileItems={fileItems} />);
+
+            // First image to be in list view but with edit button
+            expect(screen.getByText("bugs-bunny.png")).toBeInTheDocument();
+            expect(screen.getByText("3 KB")).toBeInTheDocument();
+            expect(
+                rendered.getByTestId("some-edit-button")
+            ).toBeInTheDocument();
+
+            // Second image to be in edit view
+            expect(screen.getByText("donald-duck.png")).toBeInTheDocument();
+            expect(screen.getByText("4 KB")).toBeInTheDocument();
+            expect(
+                rendered.getByTestId("another-edit-display")
+            ).toBeInTheDocument();
+
+            // Cancel editing for second image
+            const cancelButton = rendered.getByTestId("another-cancel-button");
+            fireEvent.click(cancelButton);
+
+            expect(
+                rendered.getByTestId("another-edit-button")
+            ).toBeInTheDocument();
+        });
     });
 
     describe("Upload", () => {
@@ -116,6 +153,41 @@ describe("FileUpload", () => {
             expect(onDeleteCallback).toBeCalledWith(MOCK_NON_IMAGE_FILE);
         });
     });
+
+    describe("Edit", () => {
+        it("should render the textarea, save and cancel buttons in edit mode", () => {
+            const fileItems: FileItemProps[] = MOCK_FILE_ITEMS;
+
+            const rendered = render(<FileUpload fileItems={fileItems} />);
+
+            expect(screen.getByText("Photo description")).toBeInTheDocument();
+            expect(rendered.getByTestId("some-textarea")).toBeInTheDocument();
+            expect(
+                rendered.getByTestId("some-save-button")
+            ).toBeInTheDocument();
+            expect(
+                rendered.getByTestId("some-cancel-button")
+            ).toBeInTheDocument();
+        });
+
+        it("should return the file item with the description via onEdit upon entering into the textarea", () => {
+            const fileItems: FileItemProps[] = [MOCK_IMAGE_ITEM];
+            const mockFn = jest.fn();
+
+            const rendered = render(
+                <FileUpload fileItems={fileItems} onEdit={mockFn} />
+            );
+
+            const textarea = rendered.getByTestId("some-textarea");
+            fireEvent.change(textarea, { target: { value: "Hello world" } });
+            fireEvent.click(rendered.getByTestId("some-save-button"));
+
+            expect(mockFn).toBeCalledWith({
+                ...MOCK_IMAGE_ITEM,
+                description: "Hello world",
+            });
+        });
+    });
 });
 
 // =============================================================================
@@ -123,15 +195,15 @@ describe("FileUpload", () => {
 // =============================================================================
 const DEFAULT_TITLE = "File upload component";
 const DEFAULT_DESCRIPTION = "This is a description";
-const MOCK_FILE_ITEMS = [
-    {
-        id: "some",
-        name: "bugs-bunny.png",
-        type: "image/png",
-        size: 3000,
-        truncateText: false, // Test purposes
-    },
-];
+const MOCK_IMAGE_ITEM = {
+    id: "some",
+    name: "bugs-bunny.png",
+    type: "image/png",
+    size: 3000,
+    truncateText: false, // Test purposes
+};
+
+const MOCK_FILE_ITEMS = [MOCK_IMAGE_ITEM];
 const MOCK_NON_IMAGE_FILE = {
     id: "some",
     name: "bugs-bunny.pdf",

--- a/tests/file-upload/file-upload.spec.tsx
+++ b/tests/file-upload/file-upload.spec.tsx
@@ -51,6 +51,18 @@ describe("FileUpload", () => {
         });
 
         it("should render the file items if specified", () => {
+            const fileItems: FileItemProps[] = [MOCK_NON_IMAGE_FILE];
+
+            const rendered = render(<FileUpload fileItems={fileItems} />);
+
+            expect(screen.getByText("bugs-bunny.pdf")).toBeInTheDocument();
+            expect(screen.getByText("3 KB")).toBeInTheDocument();
+            expect(
+                rendered.getByTestId("some-delete-button")
+            ).toBeInTheDocument();
+        });
+
+        it("should render the image files in its edit mode if no description is specified for the image", () => {
             const fileItems: FileItemProps[] = MOCK_FILE_ITEMS;
 
             const rendered = render(<FileUpload fileItems={fileItems} />);
@@ -58,7 +70,7 @@ describe("FileUpload", () => {
             expect(screen.getByText("bugs-bunny.png")).toBeInTheDocument();
             expect(screen.getByText("3 KB")).toBeInTheDocument();
             expect(
-                rendered.getByTestId("some-delete-button")
+                rendered.getByTestId("some-edit-display")
             ).toBeInTheDocument();
         });
     });
@@ -92,7 +104,7 @@ describe("FileUpload", () => {
         it("should fire the onDelete callback when a file item's delete button is clicked", () => {
             const onDeleteCallback = jest.fn();
 
-            const fileItems: FileItemProps[] = MOCK_FILE_ITEMS;
+            const fileItems: FileItemProps[] = [MOCK_NON_IMAGE_FILE];
 
             const rendered = render(
                 <FileUpload fileItems={fileItems} onDelete={onDeleteCallback} />
@@ -101,7 +113,7 @@ describe("FileUpload", () => {
 
             fireEvent.click(deleteButton);
 
-            expect(onDeleteCallback).toBeCalledWith(MOCK_FILE_ITEMS[0]);
+            expect(onDeleteCallback).toBeCalledWith(MOCK_NON_IMAGE_FILE);
         });
     });
 });
@@ -120,3 +132,10 @@ const MOCK_FILE_ITEMS = [
         truncateText: false, // Test purposes
     },
 ];
+const MOCK_NON_IMAGE_FILE = {
+    id: "some",
+    name: "bugs-bunny.pdf",
+    type: "application/pdf",
+    size: 3000,
+    truncateText: false, // Test purposes
+};


### PR DESCRIPTION
**Changes**
- This includes the edit feature. Only image files (refer to `helper.ts` to see what is considered as image files)
- Broke out the list rendering logic into a component of it's own in prep for part 3 (drag reorder)
- Behaviour expectation:
    - Multiple edits at once is fine
    - Adding files while an item is in edit mode is fine
- To ignore 
    - Label sizes on the Textarea as the update to form labels will be handled in another ticket
    - Error banner (to be done in another ticket)

- [delete] branch

- You may refer to this [ticket](https://jira.ship.gov.sg/browse/CCUBE-252)
- [Figma](https://www.figma.com/file/us90jOpWBahsqK2VAluPvD/Flagship-Design-System?type=design&node-id=8137-51564&t=OEgeClHySghxv7oj-0)

Example array that can be added to initialise the fileItems state of the editable file items story 
```
[
                {
                    id: "1",
                    name: "img-1.jpg",
                    type: "image/jpeg",
                    size: 5000,
                    description: "Some text here",
                },
                {
                    id: "2",
                    name: "img-2.jpg",
                    type: "image/jpeg",
                    size: 10000,
                },
                {
                    id: "3",
                    name: "img-3.jpg",
                    type: "image/jpeg",
                    size: 13000,
                },
                {
                    id: "4",
                    name: "img-4.jpg",
                    type: "image/jpeg",
                    size: 5000,
                    description: "Some text here",
                },
                {
                    id: "5",
                    name: "pdf-doc-5.pdf",
                    type: "application/pdf",
                    size: 3000,
                },
                {
                    id: "6",
                    name: "img-6.jpg",
                    type: "image/jpeg",
                    size: 12000,
                },
            ]
```
