### PR TITLE
Add drawer

### DIFF
--- a/src/drawer/drawer.styles.tsx
+++ b/src/drawer/drawer.styles.tsx
@@ -1,0 +1,105 @@
+import styled, { css } from "styled-components";
+import { Color } from "../color";
+import { MediaQuery } from "../media";
+import { ClickableIcon } from "../shared/clickable-icon";
+import { Text } from "../text";
+
+// =============================================================================
+// STYLE INTERFACE, transient props are denoted with $
+// See more https://styled-components.com/docs/api#transient-props
+// =============================================================================
+interface IStyleProps {
+    $show: boolean;
+}
+
+// =============================================================================
+// STYLING HELPERS
+// =============================================================================
+const VISIBILITY_STYLE = (show: boolean | undefined) => {
+    if (show) {
+        return css`
+            right: 0;
+            transition: all 300ms cubic-bezier(0.21, 0.79, 0.53, 1);
+            transition-delay: 200ms;
+        `;
+    }
+
+    return css`
+        right: -100%;
+        transition: all 300ms cubic-bezier(0.4, 0.34, 0.38, 1);
+    `;
+};
+
+// =============================================================================
+// STYLING
+// =============================================================================
+export const Container = styled.div<IStyleProps>`
+    position: fixed;
+    top: 0;
+
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+
+    background-color: ${Color.Neutral[8]};
+    box-shadow: 0px 2px 12px rgba(104, 104, 104, 0.25);
+
+    visibility: ${(props) => (props.$show ? "visible" : "hidden")};
+    ${(props) => VISIBILITY_STYLE(props.$show)}
+
+    width: 40%;
+
+    ${MediaQuery.MaxWidth.desktopL} {
+        width: 50%;
+        min-width: 700px;
+    }
+
+    ${MediaQuery.MaxWidth.tablet} {
+        width: 100%;
+        min-width: unset;
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+    }
+`;
+
+export const Header = styled.div`
+    top: 0;
+
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    height: 5rem;
+    padding: 2rem 1rem 1rem;
+    background-color: ${Color.Neutral[8]};
+    border-bottom: 1px solid ${Color.Neutral[5]};
+
+    ${MediaQuery.MaxWidth.tablet} {
+        gap: 0.5rem;
+    }
+`;
+
+export const CloseButton = styled(ClickableIcon)`
+    color: ${Color.Neutral[1]};
+    padding: 0;
+
+    :active,
+    :focus {
+        color: ${Color.Primary};
+    }
+
+    svg {
+        height: 2rem;
+        width: 2rem;
+    }
+`;
+
+export const Heading = styled(Text.H2)`
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+`;
+
+export const Content = styled.div`
+    flex: 1;
+    overflow-y: auto;
+`;

--- a/src/drawer/drawer.styles.tsx
+++ b/src/drawer/drawer.styles.tsx
@@ -8,8 +8,8 @@ import { Text } from "../text";
 // STYLE INTERFACE, transient props are denoted with $
 // See more https://styled-components.com/docs/api#transient-props
 // =============================================================================
-interface IStyleProps {
-    $show: boolean;
+interface StyleProps {
+    $show?: boolean | undefined;
 }
 
 // =============================================================================
@@ -33,7 +33,7 @@ const VISIBILITY_STYLE = (show: boolean | undefined) => {
 // =============================================================================
 // STYLING
 // =============================================================================
-export const Container = styled.div<IStyleProps>`
+export const Container = styled.div<StyleProps>`
     position: fixed;
     top: 0;
 

--- a/src/drawer/drawer.styles.tsx
+++ b/src/drawer/drawer.styles.tsx
@@ -48,6 +48,9 @@ export const Container = styled.div<IStyleProps>`
     ${(props) => VISIBILITY_STYLE(props.$show)}
 
     width: 40%;
+    border-top-left-radius: 8px;
+    border-bottom-left-radius: 8px;
+    overflow: hidden;
 
     ${MediaQuery.MaxWidth.desktopL} {
         width: 50%;

--- a/src/drawer/drawer.styles.tsx
+++ b/src/drawer/drawer.styles.tsx
@@ -75,6 +75,7 @@ export const Header = styled.div`
 
     ${MediaQuery.MaxWidth.tablet} {
         gap: 0.5rem;
+        padding: 2rem 1.25rem 1rem;
     }
 `;
 

--- a/src/drawer/drawer.tsx
+++ b/src/drawer/drawer.tsx
@@ -1,0 +1,74 @@
+import { CrossIcon } from "@lifesg/react-icons/cross";
+import { useEffect, useState } from "react";
+import { Overlay } from "../overlay";
+import {
+    CloseButton,
+    Container,
+    Content,
+    Header,
+    Heading,
+} from "./drawer.styles";
+import { DrawerProps } from "./types";
+
+export const Drawer = ({
+    children,
+    heading,
+    show,
+    onClose,
+    onOverlayClick,
+    ...otherProps
+}: DrawerProps) => {
+    // =============================================================================
+    // CONST, STATE, REFS
+    // =============================================================================
+    const [showOverlay, setShowOverlay] = useState(show);
+
+    // =============================================================================
+    // EFFECTS
+    // =============================================================================
+    useEffect(() => {
+        if (!show) {
+            const timer = setTimeout(() => setShowOverlay(false), 500);
+            return () => clearTimeout(timer);
+        } else {
+            setShowOverlay(true);
+        }
+    }, [show]);
+
+    // =============================================================================
+    // EVENT HANDLERS
+    // =============================================================================
+    const handleClick = (event: React.MouseEvent) => {
+        event.stopPropagation();
+    };
+
+    // =============================================================================
+    // RENDER FUNCTIONS
+    // =============================================================================
+    return (
+        <Overlay
+            show={showOverlay}
+            enableOverlayClick
+            onOverlayClick={onOverlayClick}
+        >
+            <Container
+                $show={show}
+                data-testid="drawer"
+                onClick={handleClick}
+                {...otherProps}
+            >
+                <Header>
+                    <CloseButton
+                        aria-label="Close drawer"
+                        onClick={onClose}
+                        focusHighlight={false}
+                    >
+                        <CrossIcon aria-hidden />
+                    </CloseButton>
+                    <Heading>{heading}</Heading>
+                </Header>
+                <Content>{children}</Content>
+            </Container>
+        </Overlay>
+    );
+};

--- a/src/drawer/drawer.tsx
+++ b/src/drawer/drawer.tsx
@@ -1,6 +1,7 @@
 import { CrossIcon } from "@lifesg/react-icons/cross";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Overlay } from "../overlay";
+import { SimpleIdGenerator } from "../util";
 import {
     CloseButton,
     Container,
@@ -22,6 +23,8 @@ export const Drawer = ({
     // CONST, STATE, REFS
     // =============================================================================
     const [showOverlay, setShowOverlay] = useState(show);
+    const [id] = useState(() => SimpleIdGenerator.generate());
+    const buttonRef = useRef<HTMLButtonElement>();
 
     // =============================================================================
     // EFFECTS
@@ -38,6 +41,13 @@ export const Drawer = ({
     // =============================================================================
     // EVENT HANDLERS
     // =============================================================================
+    const handleDialogVisibility = (e: React.TransitionEvent) => {
+        if (e.propertyName === "visibility" && show) {
+            // focus the first element so that the screenreader enters the dialog
+            buttonRef.current.focus();
+        }
+    };
+
     const handleClick = (event: React.MouseEvent) => {
         event.stopPropagation();
     };
@@ -55,6 +65,9 @@ export const Drawer = ({
                 $show={show}
                 data-testid="drawer"
                 onClick={handleClick}
+                role="dialog"
+                aria-labelledby={id}
+                onTransitionEnd={handleDialogVisibility}
                 {...otherProps}
             >
                 <Header>
@@ -62,10 +75,11 @@ export const Drawer = ({
                         aria-label="Close drawer"
                         onClick={onClose}
                         focusHighlight={false}
+                        ref={buttonRef}
                     >
                         <CrossIcon aria-hidden />
                     </CloseButton>
-                    <Heading>{heading}</Heading>
+                    <Heading id={id}>{heading}</Heading>
                 </Header>
                 <Content>{children}</Content>
             </Container>

--- a/src/drawer/index.ts
+++ b/src/drawer/index.ts
@@ -1,0 +1,2 @@
+export * from "./drawer";
+export * from "./types";

--- a/src/drawer/types.ts
+++ b/src/drawer/types.ts
@@ -7,8 +7,8 @@ export interface DrawerProps {
     heading?: string | undefined;
     /** Toggles the visibility of the drawer */
     show?: boolean | undefined;
-    /** Callback when the close button is clicked */
+    /** Called when the close button is clicked */
     onClose?: (() => void) | undefined;
-    /** Callback when the overlay is clicked */
+    /** Called when the overlay is clicked */
     onOverlayClick?: (() => void) | undefined;
 }

--- a/src/drawer/types.ts
+++ b/src/drawer/types.ts
@@ -1,0 +1,14 @@
+export interface DrawerProps {
+    children?: React.ReactNode | undefined;
+    classname?: string | undefined;
+    "data-testid"?: string | undefined;
+    id?: string | undefined;
+    /** The drawer header text */
+    heading?: string | undefined;
+    /** Toggles the visibility of the drawer */
+    show?: boolean | undefined;
+    /** Callback when the close button is clicked */
+    onClose?: (() => void) | undefined;
+    /** Callback when the overlay is clicked */
+    onOverlayClick?: (() => void) | undefined;
+}

--- a/src/filter/filter-item.styles.tsx
+++ b/src/filter/filter-item.styles.tsx
@@ -28,7 +28,7 @@ export const FilterItemWrapper = styled.div<StyleProps>`
     background-color: ${(props) =>
         props.$collapsible ? Color.Neutral[7](props) : Color.Neutral[8](props)};
 
-    ${MediaQuery.MaxWidth.mobileL} {
+    ${MediaQuery.MaxWidth.tablet} {
         background-color: ${Color.Neutral[7]};
     }
 `;
@@ -38,7 +38,7 @@ export const Divider = styled.div<DividerStyleProps>`
     height: 1px;
     background-color: ${Color.Neutral[5]};
 
-    ${MediaQuery.MaxWidth.mobileL} {
+    ${MediaQuery.MaxWidth.tablet} {
         display: ${(props) => (props.$showMobileDivider ? "block" : "none")};
         margin: 0 1rem;
     }
@@ -54,7 +54,7 @@ export const FilterItemHeader = styled.div`
 
     background-color: ${Color.Neutral[8]};
 
-    ${MediaQuery.MaxWidth.mobileL} {
+    ${MediaQuery.MaxWidth.tablet} {
         background-color: transparent;
     }
 `;
@@ -79,7 +79,7 @@ export const ChevronIcon = styled(ChevronDownIcon)<StyleProps>`
 export const FilterItemTitle = styled(Text.H4)`
     margin: 1.5rem 0 1.5rem 1.25rem;
 
-    ${MediaQuery.MaxWidth.mobileL} {
+    ${MediaQuery.MaxWidth.tablet} {
         ${TextStyleHelper.getTextStyle("H5", "semibold")}
         margin: 1.5rem 1.25rem 0 1.25rem;
     }
@@ -96,8 +96,8 @@ export const ExpandableItem = styled(animated.div)`
 export const FilterItemBody = styled.div`
     padding: 1rem 1.25rem;
 
-    ${MediaQuery.MaxWidth.mobileL} {
-        padding: 1.5rem 1.25rem;
+    ${MediaQuery.MaxWidth.tablet} {
+        padding: 1rem 1.25rem;
     }
 `;
 
@@ -114,7 +114,7 @@ export const FilterItemMinimiseButton = styled(Button.Small)`
     padding: 0;
     margin: 1rem 0 0 0;
 
-    ${MediaQuery.MaxWidth.mobileL} {
+    ${MediaQuery.MaxWidth.tablet} {
         span {
             ${TextStyleHelper.getTextStyle("H6", "semibold")}
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export * from "./checkbox";
 export * from "./color";
 export * from "./date-input";
 export * from "./date-range-input";
+export * from "./drawer";
 export * from "./error-display";
 export * from "./feedback-rating";
 export * from "./filter";

--- a/src/navbar/drawer.styles.tsx
+++ b/src/navbar/drawer.styles.tsx
@@ -8,7 +8,7 @@ import { ClickableIcon } from "../shared/clickable-icon";
 // STYLE INTERFACE, transient props are denoted with $
 // See more https://styled-components.com/docs/api#transient-props
 // =============================================================================
-interface IStyleProps {
+interface StyleProps {
     $show: boolean;
     $viewHeight?: number | undefined;
 }
@@ -42,7 +42,7 @@ export const Wrapper = styled.div`
     }
 `;
 
-export const Container = styled.div<IStyleProps>`
+export const Container = styled.div<StyleProps>`
     position: absolute;
     overflow-y: auto;
     overflow-x: hidden;

--- a/stories/drawer/drawer.stories.mdx
+++ b/stories/drawer/drawer.stories.mdx
@@ -1,0 +1,96 @@
+import { Canvas, Meta, Preview, Story } from "@storybook/addon-docs";
+import { useState } from "react";
+import { Drawer } from "src/drawer";
+import { Button } from "src/button";
+import { Text } from "src/text";
+import { Secondary, Heading3, Title } from "../storybook-common";
+import { PropsTable } from "./props-table";
+
+<Meta title="Modules/Drawer" component={Drawer} />
+
+<Title>Drawer</Title>
+
+<Secondary>Overview</Secondary>
+
+Displays content in a side panel overlay that slides in from the right.
+
+```tsx
+import { Drawer } from "@lifesg/react-design-system/drawer";
+```
+
+<Canvas>
+    <Story name="Drawer">
+        {() => {
+            const [show, setShow] = useState(false);
+            const openDrawer = () => setShow(true);
+            const closeDrawer = () => setShow(false);
+            return (
+                <>
+                    <Button.Default onClick={openDrawer}>
+                        Open drawer
+                    </Button.Default>
+                    <Drawer
+                        enableOverlayClick
+                        show={show}
+                        onClose={closeDrawer}
+                        onOverlayClick={closeDrawer}
+                        heading="Header text"
+                    >
+                        <Text.Body style={{ padding: "1rem" }}>
+                            Lorem ipsum dolor sit amet, consectetur adipiscing
+                            elit, sed do eiusmod tempor incididunt ut labore et
+                            dolore magna aliqua. Ut enim ad minim veniam, quis
+                            nostrud exercitation ullamco laboris nisi ut aliquip
+                            ex ea commodo consequat.
+                        </Text.Body>
+                    </Drawer>
+                </>
+            );
+        }}
+    </Story>
+</Canvas>
+
+<Heading3>Handling content overflow</Heading3>
+
+<Canvas>
+    <Story name="Handling content overflow">
+        {() => {
+            const [show, setShow] = useState(false);
+            const openDrawer = () => setShow(true);
+            const closeDrawer = () => setShow(false);
+            return (
+                <>
+                    <Button.Default onClick={openDrawer}>
+                        Open drawer
+                    </Button.Default>
+                    <Drawer
+                        enableOverlayClick
+                        show={show}
+                        onClose={closeDrawer}
+                        onOverlayClick={closeDrawer}
+                        heading="This title is truncated to a single line when it exceeds the available space"
+                    >
+                        <div
+                            style={{
+                                padding: "1rem",
+                            }}
+                        >
+                            <Text.Body
+                                style={{
+                                    height: "100vh",
+                                }}
+                            >
+                                Drawer content is scrollable when its height is
+                                taller than the current screen. The header
+                                remains at the top when scrolling down.
+                            </Text.Body>
+                            <Text.Body>
+                                This line marks the end of content.
+                            </Text.Body>
+                        </div>
+                    </Drawer>
+                </>
+            );
+        }}
+    </Story>
+</Canvas>

--- a/stories/drawer/drawer.stories.mdx
+++ b/stories/drawer/drawer.stories.mdx
@@ -30,7 +30,6 @@ import { Drawer } from "@lifesg/react-design-system/drawer";
                         Open drawer
                     </Button.Default>
                     <Drawer
-                        enableOverlayClick
                         show={show}
                         onClose={closeDrawer}
                         onOverlayClick={closeDrawer}
@@ -64,7 +63,6 @@ import { Drawer } from "@lifesg/react-design-system/drawer";
                         Open drawer
                     </Button.Default>
                     <Drawer
-                        enableOverlayClick
                         show={show}
                         onClose={closeDrawer}
                         onOverlayClick={closeDrawer}

--- a/stories/drawer/drawer.stories.mdx
+++ b/stories/drawer/drawer.stories.mdx
@@ -94,3 +94,7 @@ import { Drawer } from "@lifesg/react-design-system/drawer";
         }}
     </Story>
 </Canvas>
+
+<Secondary>Component API</Secondary>
+
+<PropsTable />

--- a/stories/drawer/props-table.tsx
+++ b/stories/drawer/props-table.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { ApiTable } from "../storybook-common/api-table";
+import { ApiTableSectionProps } from "../storybook-common/api-table/types";
+
+const DATA: ApiTableSectionProps[] = [
+    {
+        attributes: [
+            {
+                name: "children",
+                description: "The contents of the drawer",
+                propTypes: ["React.ReactNode"],
+            },
+            {
+                name: "className",
+                description: "The class selector of the component",
+                propTypes: ["string"],
+            },
+            {
+                name: "data-testid",
+                description: "The test identifier of the component",
+                propTypes: ["string"],
+            },
+            {
+                name: "heading",
+                description: "The drawer header text",
+                propTypes: ["React.ReactNode"],
+            },
+            {
+                name: "id",
+                description: "The unique identifier of the component",
+                propTypes: ["string"],
+            },
+            {
+                name: "show",
+                description: "Toggles the visibility of the drawer",
+                propTypes: ["boolean"],
+            },
+            {
+                name: "onClose",
+                description: "Callback when the close button is clicked",
+                propTypes: ["() => void"],
+            },
+            {
+                name: "onOverlayClick",
+                description: "Callback when the overlay is clicked",
+                propTypes: ["() => void"],
+            },
+        ],
+    },
+];
+
+export const PropsTable = () => <ApiTable sections={DATA} />;

--- a/stories/drawer/props-table.tsx
+++ b/stories/drawer/props-table.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ApiTable } from "../storybook-common/api-table";
+import { ApiTable, code } from "../storybook-common/api-table";
 import { ApiTableSectionProps } from "../storybook-common/api-table/types";
 
 const DATA: ApiTableSectionProps[] = [
@@ -7,7 +7,7 @@ const DATA: ApiTableSectionProps[] = [
         attributes: [
             {
                 name: "children",
-                description: "The contents of the drawer",
+                description: <>The contents of the {code("Drawer")}</>,
                 propTypes: ["React.ReactNode"],
             },
             {
@@ -22,8 +22,8 @@ const DATA: ApiTableSectionProps[] = [
             },
             {
                 name: "heading",
-                description: "The drawer header text",
-                propTypes: ["React.ReactNode"],
+                description: <>The header text of the {code("Drawer")}</>,
+                propTypes: ["string"],
             },
             {
                 name: "id",
@@ -32,17 +32,24 @@ const DATA: ApiTableSectionProps[] = [
             },
             {
                 name: "show",
-                description: "Toggles the visibility of the drawer",
+                description: (
+                    <>Toggles the visibility of the {code("Drawer")}</>
+                ),
                 propTypes: ["boolean"],
             },
             {
                 name: "onClose",
-                description: "Callback when the close button is clicked",
+                description: "Called when the close button is clicked",
                 propTypes: ["() => void"],
             },
             {
                 name: "onOverlayClick",
-                description: "Callback when the overlay is clicked",
+                description: (
+                    <>
+                        Called when the overlay of the {code("Drawer")} is
+                        clicked
+                    </>
+                ),
                 propTypes: ["() => void"],
             },
         ],

--- a/tests/drawer/drawer.spec.tsx
+++ b/tests/drawer/drawer.spec.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Drawer } from "../../src";
+
+// =============================================================================
+// UNIT TESTS
+// =============================================================================
+describe("Drawer", () => {
+    it("should render the component", () => {
+        const header = "test_1";
+        const content = "test_2";
+        render(
+            <Drawer heading={header} show>
+                <div>{content}</div>
+            </Drawer>
+        );
+
+        expect(screen.queryByLabelText("Close drawer")).toBeVisible();
+        expect(screen.queryByText(header)).toBeVisible();
+        expect(screen.queryByText(content)).toBeVisible();
+    });
+
+    it("should not display contents when the drawer not visible", () => {
+        const header = "test_1";
+        const content = "test_2";
+        render(
+            <Drawer heading={header}>
+                <div>{content}</div>
+            </Drawer>
+        );
+
+        expect(screen.queryByLabelText("Close drawer")).not.toBeVisible();
+        expect(screen.queryByText(header)).not.toBeVisible();
+        expect(screen.queryByText(content)).not.toBeVisible();
+    });
+
+    it("should call onClose when the close button is clicked", () => {
+        const onClose = jest.fn();
+        const onOverlayClick = jest.fn();
+        render(
+            <Drawer show onClose={onClose} onOverlayClick={onOverlayClick} />
+        );
+
+        fireEvent.click(screen.queryByLabelText("Close drawer"));
+
+        expect(onClose).toBeCalled();
+        expect(onOverlayClick).not.toBeCalled();
+    });
+
+    it("should call onOverlayClick when the overlay is clicked", () => {
+        const onClose = jest.fn();
+        const onOverlayClick = jest.fn();
+        render(
+            <Drawer show onClose={onClose} onOverlayClick={onOverlayClick} />
+        );
+
+        fireEvent.click(screen.queryByTestId("overlay-wrapper"));
+
+        expect(onClose).not.toBeCalled();
+        expect(onOverlayClick).toBeCalled();
+    });
+});


### PR DESCRIPTION
**Changes**

Add drawer component

- Referencing the [WAI ARIA dialog modal pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/) for aria markup
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Add `Drawer` to render content in a side panel overlay

**Additional information**

- You may refer to this [ticket](https://jira.ship.gov.sg/browse/CCUBE-257)
- Figma link: https://figma.fun/AxKNyW
- Did some exploration of the native `<dialog>` element with the `showModal` method
  - It's supposed to manage inert, autofocus and focus trapping out of the box. Haven't tested how autofocus works with animated components though
  - Unfortunately it's only available in newer browsers. There is a polyfill but it's not perfect and also means another dependency. Perhaps worth revisiting if there's ever an accessibility audit and if support for older browsers can be phased out by then