### PR TITLE
Display mobile mode in tablet viewport

### DIFF
--- a/src/filter/addons/filter-item-checkbox.styles.tsx
+++ b/src/filter/addons/filter-item-checkbox.styles.tsx
@@ -13,7 +13,7 @@ export const StyledFilterItem = styled(FilterItem)`
         position: relative; // to get the item position relative to this parent
         padding: 0.5rem 0.5rem 0;
 
-        ${MediaQuery.MaxWidth.mobileL} {
+        ${MediaQuery.MaxWidth.tablet} {
             padding: 1rem 1.25rem 0.5rem;
         }
     }
@@ -21,7 +21,7 @@ export const StyledFilterItem = styled(FilterItem)`
     [data-id="minimise-button"] {
         margin: 0.5rem 1.25rem 0;
 
-        ${MediaQuery.MaxWidth.mobileL} {
+        ${MediaQuery.MaxWidth.tablet} {
             margin: 0.5rem 1.25rem 0;
         }
     }
@@ -31,7 +31,7 @@ export const Group = styled.div`
     display: flex;
     flex-direction: column;
 
-    ${MediaQuery.MaxWidth.mobileL} {
+    ${MediaQuery.MaxWidth.tablet} {
         flex-direction: row;
         flex-wrap: wrap;
         gap: 1rem;

--- a/src/filter/filter-item.styles.tsx
+++ b/src/filter/filter-item.styles.tsx
@@ -28,7 +28,7 @@ export const FilterItemWrapper = styled.div<StyleProps>`
     background-color: ${(props) =>
         props.$collapsible ? Color.Neutral[7](props) : Color.Neutral[8](props)};
 
-    ${MediaQuery.MaxWidth.mobileL} {
+    ${MediaQuery.MaxWidth.tablet} {
         background-color: ${Color.Neutral[7]};
     }
 `;
@@ -38,7 +38,7 @@ export const Divider = styled.div<DividerStyleProps>`
     height: 1px;
     background-color: ${Color.Neutral[5]};
 
-    ${MediaQuery.MaxWidth.mobileL} {
+    ${MediaQuery.MaxWidth.tablet} {
         display: ${(props) => (props.$showMobileDivider ? "block" : "none")};
         margin: 0 1rem;
     }
@@ -54,7 +54,7 @@ export const FilterItemHeader = styled.div`
 
     background-color: ${Color.Neutral[8]};
 
-    ${MediaQuery.MaxWidth.mobileL} {
+    ${MediaQuery.MaxWidth.tablet} {
         background-color: transparent;
     }
 `;
@@ -79,7 +79,7 @@ export const ChevronIcon = styled(ChevronDownIcon)<StyleProps>`
 export const FilterItemTitle = styled(Text.H4)`
     margin: 1.5rem 0 1.5rem 1.25rem;
 
-    ${MediaQuery.MaxWidth.mobileL} {
+    ${MediaQuery.MaxWidth.tablet} {
         ${TextStyleHelper.getTextStyle("H5", "semibold")}
         margin: 1.5rem 1.25rem 0 1.25rem;
     }
@@ -95,10 +95,6 @@ export const ExpandableItem = styled(animated.div)`
 
 export const FilterItemBody = styled.div`
     padding: 1rem 1.25rem;
-
-    ${MediaQuery.MaxWidth.mobileL} {
-        padding: 1.5rem 1.25rem;
-    }
 `;
 
 export const MinimisableContent = styled(animated.div)<{
@@ -114,7 +110,7 @@ export const FilterItemMinimiseButton = styled(Button.Small)`
     padding: 0;
     margin: 1rem 0 0 0;
 
-    ${MediaQuery.MaxWidth.mobileL} {
+    ${MediaQuery.MaxWidth.tablet} {
         span {
             ${TextStyleHelper.getTextStyle("H6", "semibold")}
         }

--- a/src/filter/filter.styles.tsx
+++ b/src/filter/filter.styles.tsx
@@ -11,14 +11,14 @@ import { Text } from "../text/text";
 // =============================================================================
 
 export const DesktopView = styled.div`
-    ${MediaQuery.MaxWidth.mobileL} {
+    ${MediaQuery.MaxWidth.tablet} {
         display: none;
     }
 `;
 
 export const MobileView = styled.div`
     display: none;
-    ${MediaQuery.MaxWidth.mobileL} {
+    ${MediaQuery.MaxWidth.tablet} {
         display: block;
     }
 `;
@@ -55,7 +55,7 @@ export const FilterHeader = styled.div`
 
     background-color: ${Color.Neutral[8]};
 
-    ${MediaQuery.MaxWidth.mobileL} {
+    ${MediaQuery.MaxWidth.tablet} {
         border-bottom: 1px solid ${Color.Neutral[5]};
     }
 `;
@@ -64,7 +64,7 @@ export const FilterTitle = styled(Text.H4)`
     flex: 1;
     margin: 1.5rem 0 1rem 1.25rem;
 
-    ${MediaQuery.MaxWidth.mobileL} {
+    ${MediaQuery.MaxWidth.tablet} {
         text-align: center;
         margin: 1.5rem 0;
     }
@@ -90,7 +90,7 @@ export const FilterClearButton = styled(Button.Small)`
     padding: 1.5rem 1.25rem 1rem 1.25rem;
     height: auto;
 
-    ${MediaQuery.MaxWidth.mobileL} {
+    ${MediaQuery.MaxWidth.tablet} {
         padding: 1.5rem 1.25rem;
     }
 `;

--- a/src/filter/filter.tsx
+++ b/src/filter/filter.tsx
@@ -44,7 +44,7 @@ const FilterBase = ({
     // =============================================================================
     useMediaQuery(
         {
-            maxWidth: MediaWidths.mobileL,
+            maxWidth: MediaWidths.tablet,
         },
         undefined,
         (isMobile) => {


### PR DESCRIPTION
**Changes**

Render Filter toggle button in mobile and tablet viewports. Basically updated the media queries to use `tablet` instead of `mobileL`

- [delete] branch

**Changelog entry**

- Display mobile mode of `Filter` in tablet viewport