### PR TITLE
Update input alignment

### DIFF
--- a/src/date-range-input/date-range-input.style.tsx
+++ b/src/date-range-input/date-range-input.style.tsx
@@ -12,7 +12,7 @@ export const Container = styled(InputWrapper)`
 export const InputContainer = styled.div`
     display: flex;
     align-items: center;
-    height: 3rem;
+    height: calc(3rem - 2px); // exclude top and bottom borders
     width: 100%;
 
     @media screen and (max-width: ${MOBILE_WRAP_WIDTH}px) {

--- a/src/input-group/input-group-list-addon.style.tsx
+++ b/src/input-group/input-group-list-addon.style.tsx
@@ -29,6 +29,7 @@ interface DividerStyleProps {
 export const DisplayContainer = styled.div<StyleProps>`
     position: relative;
     display: flex;
+    align-items: center;
     margin: 0 1rem;
     ${(props) => {
         if (props.$expanded) {
@@ -66,7 +67,7 @@ export const Selector = styled(DropdownSelector)`
 `;
 
 export const SelectorReadOnly = styled.div`
-    height: 3rem;
+    height: calc(3rem - 2px); // exclude top and bottom borders
     display: flex;
     align-items: center;
     padding: 0;
@@ -99,7 +100,6 @@ export const ValueLabel = styled(Text.Body)`
     -webkit-box-orient: vertical;
     overflow: hidden;
     text-overflow: ellipsis;
-    margin-top: 1px; // align with input
 `;
 
 export const PlaceholderLabel = styled(ValueLabel)`
@@ -109,6 +109,8 @@ export const PlaceholderLabel = styled(ValueLabel)`
 export const Divider = styled.div<DividerStyleProps>`
     width: 1px;
     background: ${Color.Neutral[5]};
+    flex-shrink: 0;
+    height: 1.25rem;
 
     ${(props) => {
         if (props.$readOnly) {
@@ -122,11 +124,11 @@ export const Divider = styled.div<DividerStyleProps>`
         switch (props.$position) {
             case "right":
                 return css`
-                    margin: 1rem 0.75rem;
+                    margin: 0 0.75rem;
                 `;
             default:
                 return css`
-                    margin: 1rem 0.75rem 1rem 0;
+                    margin: 0 0.75rem 0 0;
                 `;
         }
     }}

--- a/src/input-group/input-group.style.tsx
+++ b/src/input-group/input-group.style.tsx
@@ -80,7 +80,7 @@ export const MainInput = styled(Input)`
     &&& {
         background: transparent;
         border: none;
-        padding: 0 0 1px 0;
+        padding: 0;
 
         :focus-within {
             outline: none;

--- a/src/input/input.style.tsx
+++ b/src/input/input.style.tsx
@@ -20,7 +20,7 @@ export const InputElement = styled.input<StyleProps>`
     // overwrite default styles
     background: transparent;
     border: none;
-    height: 3rem;
+    height: calc(3rem - 2px); // exclude top and bottom borders
     width: 100%;
     padding: 0;
 

--- a/src/shared/dropdown-wrapper/dropdown-wrapper.styles.tsx
+++ b/src/shared/dropdown-wrapper/dropdown-wrapper.styles.tsx
@@ -38,7 +38,7 @@ export const Selector = styled.button`
     align-items: center;
     justify-content: space-between;
     padding: 0 1rem;
-    height: 3rem;
+    height: calc(3rem - 2px); // exclude top and bottom borders
     width: 100%;
     border-radius: ${BORDER_RADIUS};
     cursor: pointer;

--- a/src/shared/input-wrapper/input-wrapper.tsx
+++ b/src/shared/input-wrapper/input-wrapper.tsx
@@ -38,12 +38,12 @@ export const InputWrapper = styled.div<InputWrapperStyleProps>`
     ${(props) => {
         if (props.$readOnly) {
             return css`
-                border: none;
+                border: 1px solid transparent;
                 padding: 0;
                 background: transparent !important;
 
                 :focus-within {
-                    border: none;
+                    border: 1px solid transparent;
                     box-shadow: none;
                 }
             `;

--- a/src/timepicker/timepicker.styles.tsx
+++ b/src/timepicker/timepicker.styles.tsx
@@ -18,5 +18,5 @@ export const Wrapper = styled.div`
 `;
 
 export const InputSelectorElement = styled(BasicInput)<StyleProps>`
-    height: 3rem;
+    height: calc(3rem - 2px); // exclude top and bottom borders
 `;


### PR DESCRIPTION
**Changes**

- Vertically align children in InputGroup and ensure they fit into the parent boundary of 48px height. Previously the calculated height did not account for the top and bottom borders.
- Also updated remaining inputs that were 50px tall to be 48px exactly
- [delete] branch

**Changelog entry**

- Standardise input heights
- Fix misaligned `InputGroup` children