### PR TITLE
Fix OTP input display on mobile

### DIFF
--- a/src/otp-input/otp-input.styles.tsx
+++ b/src/otp-input/otp-input.styles.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
-import { Input } from "src/input";
-import { Button } from "src/button";
+import { Button } from "../button";
+import { Input } from "../input";
+import { MediaQuery } from "../media";
 
 export const Wrapper = styled.div`
     display: flex;
@@ -28,6 +29,10 @@ export const InputField = styled(Input)`
     input[type="text"] {
         text-align: center;
         -moz-appearance: textfield;
+    }
+
+    ${MediaQuery.MaxWidth.mobileM} {
+        padding: 0 0.5rem;
     }
 `;
 


### PR DESCRIPTION
**Changes**

- reduce the default input padding on smaller screens so that the input text does not get cut off
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Fix `OtpInput` display on small mobile viewports

**Additional information**

- You may refer to this [ticket](https://jira.ship.gov.sg/browse/CCUBE-264)