### PR TITLE
Add min width for animated internal calendar

### DIFF
--- a/src/shared/internal-calendar/animated-internal-calendar.style.tsx
+++ b/src/shared/internal-calendar/animated-internal-calendar.style.tsx
@@ -1,6 +1,7 @@
 import { animated } from "react-spring";
 import styled from "styled-components";
 import { Color } from "../../color";
+import { MediaQuery } from "../../media";
 
 export const AnimatedDiv = styled(animated.div)`
     position: absolute;
@@ -11,4 +12,9 @@ export const AnimatedDiv = styled(animated.div)`
     background: ${Color.Neutral[8]};
     overflow: hidden;
     z-index: 1;
+    min-width: 21rem;
+
+    ${MediaQuery.MaxWidth.mobileL} {
+        min-width: 17.5rem;
+    }
 `;

--- a/src/shared/internal-calendar/calendar-manager.tsx
+++ b/src/shared/internal-calendar/calendar-manager.tsx
@@ -355,7 +355,7 @@ const Component = (
 
     const renderHeader = () => {
         return (
-            <Header data-id="calendar-header">
+            <Header data-testid="calendar-header">
                 <HeaderInputDropdown>
                     {renderDropdownButtons()}
                 </HeaderInputDropdown>
@@ -443,7 +443,7 @@ const Component = (
         <Container
             ref={containerRef}
             tabIndex={-1}
-            data-id="calendar-container"
+            data-testid="calendar-container"
             {...otherProps}
         >
             {showNavigationHeader && renderHeader()}

--- a/src/shared/internal-calendar/calendar-manager.tsx
+++ b/src/shared/internal-calendar/calendar-manager.tsx
@@ -355,7 +355,7 @@ const Component = (
 
     const renderHeader = () => {
         return (
-            <Header data-testid="calendar-header">
+            <Header data-id="calendar-header" data-testid="calendar-header">
                 <HeaderInputDropdown>
                     {renderDropdownButtons()}
                 </HeaderInputDropdown>
@@ -443,6 +443,7 @@ const Component = (
         <Container
             ref={containerRef}
             tabIndex={-1}
+            data-id="calendar-container"
             data-testid="calendar-container"
             {...otherProps}
         >

--- a/src/shared/internal-calendar/internal-calendar-day.tsx
+++ b/src/shared/internal-calendar/internal-calendar-day.tsx
@@ -454,7 +454,7 @@ export const InternalCalendarDay = ({
     };
 
     return (
-        <Wrapper>
+        <Wrapper data-testid="calendar-content">
             {renderHeader()}
             {renderDayCells()}
         </Wrapper>


### PR DESCRIPTION
**Changes**
- Add min-width in animated calendar so that the date input & date range input calendar does not get cut off
- Add default data-testid

- [delete] branch

**Additional information**

- You may refer to this [BOOKINGSG-4349](https://jira.ship.gov.sg/browse/BOOKINGSG-4349)
