### PR TITLE
Fix SSR error from document and window references

### DIFF
--- a/src/shared/dropdown-wrapper/dropdown-wrapper.tsx
+++ b/src/shared/dropdown-wrapper/dropdown-wrapper.tsx
@@ -20,7 +20,7 @@ export const DropdownWrapper = ({
     // =============================================================================
     // EFFECTS
     // =============================================================================
-    useEventListener("mousedown", handleMouseDownEvent, document);
+    useEventListener("mousedown", handleMouseDownEvent, "document");
 
     // =============================================================================
     // HELPER FUNCTION

--- a/src/time-range-picker/time-range-picker.tsx
+++ b/src/time-range-picker/time-range-picker.tsx
@@ -43,8 +43,8 @@ export const TimeRangePicker = ({
         }
     }, []);
 
-    useEventListener("mousedown", handleMouseDownEvent, document);
-    useEventListener("keyup", handleKeyUpEvent, document);
+    useEventListener("mousedown", handleMouseDownEvent, "document");
+    useEventListener("keyup", handleKeyUpEvent, "document");
 
     // =============================================================================
     // EVENT HANDLERS

--- a/src/timepicker/timepicker.tsx
+++ b/src/timepicker/timepicker.tsx
@@ -28,8 +28,8 @@ export const Timepicker = ({
     // =============================================================================
     // EFFECTS
     // =============================================================================
-    useEventListener("mousedown", handleMouseDownEvent, document);
-    useEventListener("keyup", handleKeyUpEvent, document);
+    useEventListener("mousedown", handleMouseDownEvent, "document");
+    useEventListener("keyup", handleKeyUpEvent, "document");
 
     // =============================================================================
     // EVENT HANDLERS

--- a/src/util/use-event-listener.tsx
+++ b/src/util/use-event-listener.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useRef } from "react";
 
-type Target = Window | HTMLElement | Document | null;
+type Target = "window" | "document" | HTMLElement | null;
+type Element = Window | Document | HTMLElement | null;
 
 export const useEventListener = <K extends keyof WindowEventMap>(
     eventName: K,
     handler: (event: WindowEventMap[K]) => void,
-    element: Target = window
+    target: Target = "window"
 ) => {
     // Create a ref that stores handler
     const savedHandler = useRef<(event: WindowEventMap[K]) => void>();
@@ -17,6 +18,18 @@ export const useEventListener = <K extends keyof WindowEventMap>(
 
     useEffect(
         () => {
+            let element: Element;
+            switch (target) {
+                case "window":
+                    element = window;
+                    break;
+                case "document":
+                    element = document;
+                    break;
+                default:
+                    element = target;
+            }
+
             // Make sure element supports addEventListener
             const isSupported = element && element.addEventListener;
 
@@ -31,6 +44,6 @@ export const useEventListener = <K extends keyof WindowEventMap>(
                 element.removeEventListener(eventName, eventListener);
             };
         },
-        [eventName, element] // Re-run if eventName or element changes
+        [eventName, target] // Re-run if eventName or element changes
     );
 };


### PR DESCRIPTION
**Changes**

Reference window and document objects within the useEffect only. More convenient than doing `typeof document === "undefined"` in multiple places

- [delete] branch

**Changelog entry**

- Fix SSR error in time pickers and dropdown components