### PR TITLE
Allow Accordion items to be collapsed on first load

### DIFF
--- a/src/accordion/accordion-item.tsx
+++ b/src/accordion/accordion-item.tsx
@@ -25,7 +25,8 @@ export const AccordionItem = ({
     // CONST, STATE, REF
     // =============================================================================
     const expandAll = useContext(AccordionContext);
-    const [expand, setExpand] = useState<boolean>(expandAll || expanded);
+    const [expand, setExpand] = useState<boolean>(expandAll ?? expanded);
+
     const testId = otherProps["data-testid"] || "accordion-item";
 
     const resizeDetector = useResizeDetector();
@@ -34,13 +35,15 @@ export const AccordionItem = ({
     // =============================================================================
     // EFFECTS
     // =============================================================================
-    useEffect(() => {
-        setExpand(expandAll);
-    }, [expandAll]);
 
     useEffect(() => {
         setExpand(expanded);
     }, [expanded]);
+
+    // `setExpand(expandAll)` is after `setExpand(expanded)` to override its setState on initial load
+    useEffect(() => {
+        setExpand(expandAll);
+    }, [expandAll]);
 
     // =============================================================================
     // EVENT HANDLERS

--- a/src/accordion/accordion.tsx
+++ b/src/accordion/accordion.tsx
@@ -13,10 +13,11 @@ const AccordionBase = ({
     children,
     title,
     enableExpandAll = true,
+    initialExpandAll = true,
     showTitleInMobile = false,
     className,
 }: AccordionProps): JSX.Element => {
-    const [expandAll, setExpandAll] = useState<boolean>(true);
+    const [expandAll, setExpandAll] = useState<boolean>(initialExpandAll);
 
     const handleExpandCollapseClick = (event: React.MouseEvent) => {
         event.preventDefault();

--- a/src/accordion/accordion.tsx
+++ b/src/accordion/accordion.tsx
@@ -13,11 +13,13 @@ const AccordionBase = ({
     children,
     title,
     enableExpandAll = true,
-    initialExpandAll = true,
+    initialDisplay = "expand-all",
     showTitleInMobile = false,
     className,
 }: AccordionProps): JSX.Element => {
-    const [expandAll, setExpandAll] = useState<boolean>(initialExpandAll);
+    const [expandAll, setExpandAll] = useState<boolean>(
+        initialDisplay === "expand-all"
+    );
 
     const handleExpandCollapseClick = (event: React.MouseEvent) => {
         event.preventDefault();

--- a/src/accordion/types.ts
+++ b/src/accordion/types.ts
@@ -2,7 +2,7 @@ export interface AccordionProps {
     children: JSX.Element | JSX.Element[];
     title?: string | undefined;
     enableExpandAll?: boolean | undefined;
-    initialExpandAll?: boolean | undefined;
+    initialDisplay?: "collapse-all" | "expand-all" | undefined;
     showTitleInMobile?: boolean | undefined;
     className?: string | undefined;
 }

--- a/src/accordion/types.ts
+++ b/src/accordion/types.ts
@@ -2,6 +2,7 @@ export interface AccordionProps {
     children: JSX.Element | JSX.Element[];
     title?: string | undefined;
     enableExpandAll?: boolean | undefined;
+    initialExpandAll?: boolean | undefined;
     showTitleInMobile?: boolean | undefined;
     className?: string | undefined;
 }

--- a/stories/accordion/props-table.tsx
+++ b/stories/accordion/props-table.tsx
@@ -31,6 +31,13 @@ const ACCORDION_DATA: ApiTableSectionProps[] = [
                 defaultValue: "true",
             },
             {
+                name: "initialDisplay",
+                description:
+                    "Specifies if the inital display of child items and parent state should be all collapsed or all expanded",
+                propTypes: [`"collapse-all"`, `"expand-all"`],
+                defaultValue: "expand-all",
+            },
+            {
                 name: "showTitleInMobile",
                 description:
                     "Specifies if the title should be shown in mobile viewports",


### PR DESCRIPTION
**Changes**
- Allow Accordion items to be collapsed on first load

- [delete] branch

**Changelog entry**

- Add ability to collapse or expand all items on render

**Additional information**
- You may refer to this [MOL-13135](https://jira.ship.gov.sg/browse/MOL-13135)
