### PR TITLE
Preserve text caret position in formatted input fields

### DIFF
--- a/src/input-group/input-group-list-addon.tsx
+++ b/src/input-group/input-group-list-addon.tsx
@@ -15,15 +15,18 @@ import {
 import { MainInput } from "./input-group.style";
 import { InputGroupProps, ListAddon } from "./types";
 
-export const InputGroupListAddon = <T, V>({
-    addon,
-    error,
-    onChange,
-    readOnly,
-    className,
-    onBlur,
-    ...otherProps
-}: InputGroupProps<T, V>) => {
+export const Component = <T, V>(
+    {
+        addon,
+        error,
+        onChange,
+        readOnly,
+        className,
+        onBlur,
+        ...otherProps
+    }: InputGroupProps<T, V>,
+    ref
+) => {
     const {
         placeholder,
         options,
@@ -210,6 +213,7 @@ export const InputGroupListAddon = <T, V>({
             {renderSelector()}
             <Divider $readOnly={readOnly} $position={position} />
             <MainInput
+                ref={ref}
                 {...otherProps}
                 readOnly={readOnly}
                 error={error}
@@ -234,3 +238,5 @@ export const InputGroupListAddon = <T, V>({
         </DropdownWrapper>
     );
 };
+
+export const InputGroupListAddon = React.forwardRef(Component);

--- a/src/input-group/input-group.tsx
+++ b/src/input-group/input-group.tsx
@@ -30,6 +30,7 @@ const Component = <T, V>(
                 if (listAddon.options && listAddon.options.length > 0) {
                     return (
                         <InputGroupListAddon
+                            ref={ref}
                             addon={addon}
                             error={error}
                             className={className}
@@ -61,6 +62,7 @@ const Component = <T, V>(
                                 {customAddon.children}
                             </AddOnContainer>
                             <MainInput
+                                ref={ref}
                                 {...otherProps}
                                 allowClear={allowClear && position !== "right"}
                                 error={error}
@@ -93,6 +95,7 @@ const Component = <T, V>(
                                 {labelAddon.value}
                             </AddOnContainer>
                             <MainInput
+                                ref={ref}
                                 {...otherProps}
                                 allowClear={allowClear && position !== "right"}
                                 error={error}

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -1,6 +1,6 @@
 import React, { useImperativeHandle, useRef } from "react";
 import { InputWrapper } from "../shared/input-wrapper/input-wrapper";
-import { StringHelper } from "../util/string-helper";
+import { StringHelper, useNextInputState } from "../util";
 import { ClearContainer, ClearIcon, InputElement } from "./input.style";
 import { InputProps, InputRef } from "./types";
 
@@ -25,6 +25,11 @@ const Component = (
     // =============================================================================
     const elementRef = useRef<HTMLInputElement>();
     useImperativeHandle(ref, () => elementRef.current, []);
+
+    const getNextInputState = useNextInputState({
+        ref: elementRef,
+        formatter: (value) => StringHelper.transformWithSpaces(value, spacing),
+    });
 
     // =============================================================================
     // EVENT HANDLERS
@@ -65,16 +70,14 @@ const Component = (
     const handleSpacingAndCaretPosition = (
         event: React.ChangeEvent<HTMLInputElement>
     ) => {
-        const element = event.target;
-        const currentValue = element.value;
+        const { nextValue, updateCursorPosition } = getNextInputState();
 
         // Send to handler unspaced value
-        const valueWithoutSpace = element.value.replace(/\s/g, "");
-        element.value = valueWithoutSpace;
+        const valueWithoutSpace = nextValue.replace(/\s/g, "");
+        event.target.value = valueWithoutSpace;
         onChange(event);
 
-        // reset element value
-        element.value = currentValue;
+        updateCursorPosition();
     };
 
     const shouldShowClear = () => {

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -70,14 +70,14 @@ const Component = (
     const handleSpacingAndCaretPosition = (
         event: React.ChangeEvent<HTMLInputElement>
     ) => {
-        const { nextValue, updateCursorPosition } = getNextInputState();
+        const { nextValue, updateCaretPosition } = getNextInputState();
 
         // Send to handler unspaced value
         const valueWithoutSpace = nextValue.replace(/\s/g, "");
         event.target.value = valueWithoutSpace;
         onChange(event);
 
-        updateCursorPosition();
+        updateCaretPosition();
     };
 
     const shouldShowClear = () => {

--- a/src/phone-number-input/phone-number-input.tsx
+++ b/src/phone-number-input/phone-number-input.tsx
@@ -70,10 +70,10 @@ export const PhoneNumberInput = ({
         }
     };
 
-    const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        const { nextValue, updateCursorPosition } = getNextInputState();
+    const handleInputChange = () => {
+        const { nextValue, updateCaretPosition } = getNextInputState();
 
-        updateCursorPosition();
+        updateCaretPosition();
         performLocalChangeHandler(nextValue, selectedCountry);
         if (onChange) {
             performOnChangeHandler(nextValue, selectedCountry);

--- a/src/unit-number/unit-number-input.tsx
+++ b/src/unit-number/unit-number-input.tsx
@@ -157,29 +157,17 @@ export const UnitNumberInput = ({
         }
     };
 
-    const getNextInputState = (el: HTMLInputElement) => {
-        const rawValue = el.value;
-        const value = rawValue.toLocaleUpperCase().replace(/[^0-9A-Za-z]/g, "");
-
-        // offset the text caret to compensate for removed characters
-        const removed = rawValue.length - value.length;
-        const cursorPosition = Math.max(0, el.selectionEnd - removed);
-
-        return { value, cursorPosition };
-    };
-
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         const targetName = event.target.name as FieldType;
 
         if (targetName === "floor") {
-            const { nextValue, updateCursorPosition } =
-                getNextFloorInputState();
-            updateCursorPosition();
+            const { nextValue, updateCaretPosition } = getNextFloorInputState();
+            updateCaretPosition();
             setFloorValue(nextValue);
             performOnChangeHandler(nextValue, targetName);
         } else {
-            const { nextValue, updateCursorPosition } = getNextUnitInputState();
-            updateCursorPosition();
+            const { nextValue, updateCaretPosition } = getNextUnitInputState();
+            updateCaretPosition();
             setUnitValue(nextValue);
             performOnChangeHandler(nextValue, targetName);
         }

--- a/src/unit-number/unit-number-input.tsx
+++ b/src/unit-number/unit-number-input.tsx
@@ -146,12 +146,26 @@ export const UnitNumberInput = ({
         }
     };
 
+    const getNextInputState = (el: HTMLInputElement) => {
+        const rawValue = el.value;
+        const value = rawValue.toLocaleUpperCase().replace(/[^0-9A-Za-z]/g, "");
+
+        // offset the text caret to compensate for removed characters
+        const removed = rawValue.length - value.length;
+        const cursorPosition = Math.max(0, el.selectionEnd - removed);
+
+        return { value, cursorPosition };
+    };
+
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         const targetName = event.target.name as FieldType;
+        const { value, cursorPosition } = getNextInputState(event.target);
 
-        const value = event.target.value
-            .toLocaleUpperCase()
-            .replace(/[^0-9A-Za-z]/, "");
+        // sync DOM value with the new state value
+        event.target.value = value;
+        // set text caret position to prevent jump on next render
+        event.target.selectionStart = cursorPosition;
+        event.target.selectionEnd = cursorPosition;
 
         if (targetName === "floor") {
             setFloorValue(value);

--- a/src/unit-number/unit-number-input.tsx
+++ b/src/unit-number/unit-number-input.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { InputWrapper } from "../shared/input-wrapper/input-wrapper";
-import { StringHelper } from "../util/string-helper";
+import { StringHelper, useNextInputState } from "../util";
 import { UnitNumberInputProps } from "./types";
 import {
     FloorInput,
@@ -47,6 +47,17 @@ export const UnitNumberInput = ({
     const floorValueStateRef = useRef<string>(floorValue);
     const unitValueStateRef = useRef<string>(unitValue);
     const currentFocusStateRef = useRef<FieldType>(currentFocus);
+
+    const formatter = (value) =>
+        value.toLocaleUpperCase().replace(/[^0-9A-Za-z]/g, "");
+    const getNextFloorInputState = useNextInputState({
+        ref: floorInputRef,
+        formatter,
+    });
+    const getNextUnitInputState = useNextInputState({
+        ref: unitInputRef,
+        formatter,
+    });
 
     // =============================================================================
     // REF FUNCTIONS
@@ -159,20 +170,18 @@ export const UnitNumberInput = ({
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         const targetName = event.target.name as FieldType;
-        const { value, cursorPosition } = getNextInputState(event.target);
-
-        // sync DOM value with the new state value
-        event.target.value = value;
-        // set text caret position to prevent jump on next render
-        event.target.selectionStart = cursorPosition;
-        event.target.selectionEnd = cursorPosition;
 
         if (targetName === "floor") {
-            setFloorValue(value);
-            performOnChangeHandler(value, targetName);
+            const { nextValue, updateCursorPosition } =
+                getNextFloorInputState();
+            updateCursorPosition();
+            setFloorValue(nextValue);
+            performOnChangeHandler(nextValue, targetName);
         } else {
-            setUnitValue(value);
-            performOnChangeHandler(value, targetName);
+            const { nextValue, updateCursorPosition } = getNextUnitInputState();
+            updateCursorPosition();
+            setUnitValue(nextValue);
+            performOnChangeHandler(nextValue, targetName);
         }
     };
 

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -2,4 +2,5 @@ export * from "./calendar-helper";
 export * from "./date-helper";
 export * from "./simple-id-generator";
 export * from "./string-helper";
+export * from "./use-next-input-state";
 export * from "./use-state-ref";

--- a/src/util/use-next-input-state.ts
+++ b/src/util/use-next-input-state.ts
@@ -1,0 +1,33 @@
+export function useNextInputState({
+    ref,
+    formatter,
+}: {
+    ref: React.RefObject<HTMLInputElement>;
+    formatter: (value: string) => string;
+}) {
+    const getNextInputState = () => {
+        const el = ref.current;
+        const rawValue = el.value;
+        const nextValue = formatter(rawValue);
+
+        // compensate for characters that will be removed and added to the
+        // string before the text caret
+        const rawSubstr = rawValue.substring(0, el.selectionEnd);
+        const nextSubstr = formatter(rawSubstr);
+        const diff = rawSubstr.length - nextSubstr.length;
+        const nextCursorPosition = Math.max(0, el.selectionEnd - diff);
+
+        const updateCursorPosition = () => {
+            el.value = nextValue;
+            el.setSelectionRange(nextCursorPosition, nextCursorPosition);
+        };
+
+        return {
+            nextValue,
+            nextCursorPosition,
+            updateCursorPosition,
+        };
+    };
+
+    return getNextInputState;
+}

--- a/src/util/use-next-input-state.ts
+++ b/src/util/use-next-input-state.ts
@@ -15,17 +15,16 @@ export function useNextInputState({
         const rawSubstr = rawValue.substring(0, el.selectionEnd);
         const nextSubstr = formatter(rawSubstr);
         const diff = rawSubstr.length - nextSubstr.length;
-        const nextCursorPosition = Math.max(0, el.selectionEnd - diff);
+        const nextCaretPosition = Math.max(0, el.selectionEnd - diff);
 
-        const updateCursorPosition = () => {
+        const updateCaretPosition = () => {
             el.value = nextValue;
-            el.setSelectionRange(nextCursorPosition, nextCursorPosition);
+            el.setSelectionRange(nextCaretPosition, nextCaretPosition);
         };
 
         return {
             nextValue,
-            nextCursorPosition,
-            updateCursorPosition,
+            updateCaretPosition,
         };
     };
 

--- a/tests/input/input.spec.tsx
+++ b/tests/input/input.spec.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Input } from "src/input";
+
+// =============================================================================
+// UNIT TESTS
+// =============================================================================
+describe("Input", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should render default component", () => {
+        render(<Input />);
+
+        expect(screen.queryByTestId("input")).toHaveValue("");
+    });
+
+    it("should render component with value", () => {
+        render(<Input value="test" />);
+
+        expect(screen.queryByTestId("input")).toHaveValue("test");
+    });
+
+    describe("tel type with spacing", () => {
+        it("should format value and preserve caret position", async () => {
+            render(<Input type="tel" spacing={2} value="123456" />);
+
+            expect(screen.queryByTestId("input")).toHaveValue("12 34 56");
+        });
+
+        describe("change handling", () => {
+            it("should format value and preserve caret position", async () => {
+                render(<Input type="tel" spacing={2} onChange={jest.fn()} />);
+
+                const input: HTMLInputElement = screen.queryByTestId("input");
+                const inputSpy = jest.spyOn(input, "setSelectionRange");
+
+                fireEvent.change(input, {
+                    target: {
+                        value: "12 346 5",
+                        selectionStart: 6,
+                        selectionEnd: 6,
+                    },
+                });
+
+                expect(input).toHaveValue("12 34 65");
+                expect(inputSpy).toBeCalledWith(7, 7);
+            });
+
+            it("should remove non-numeric characters and preserve caret position", async () => {
+                render(<Input type="tel" spacing={2} onChange={jest.fn()} />);
+
+                const input: HTMLInputElement = screen.queryByTestId("input");
+                const inputSpy = jest.spyOn(input, "setSelectionRange");
+
+                fireEvent.change(input, {
+                    target: {
+                        value: "12 3!4",
+                        selectionStart: 5,
+                        selectionEnd: 5,
+                    },
+                });
+
+                expect(input).toHaveValue("12 34");
+                expect(inputSpy).toBeCalledWith(4, 4);
+            });
+        });
+    });
+});

--- a/tests/phone-number-input/phone-number-input.spec.tsx
+++ b/tests/phone-number-input/phone-number-input.spec.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { PhoneNumberInput } from "src/phone-number-input";
+
+// =============================================================================
+// UNIT TESTS
+// =============================================================================
+describe("PhoneNumberInput", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should render default component", () => {
+        render(<PhoneNumberInput />);
+
+        expect(screen.queryByTestId("addon-selector")).toHaveTextContent(
+            "Select"
+        );
+        expect(screen.queryByTestId("input")).toHaveValue("");
+    });
+
+    it("should render component with formatted value", () => {
+        render(
+            <PhoneNumberInput
+                value={{ countryCode: "994", number: "123456789" }}
+            />
+        );
+
+        expect(screen.queryByTestId("addon-selector")).toHaveTextContent(
+            "+994"
+        );
+        expect(screen.queryByTestId("input")).toHaveValue("(12) 345 67 89");
+    });
+
+    describe("change handling", () => {
+        it("should format number and preserve caret position", async () => {
+            render(<PhoneNumberInput value={{ countryCode: "994" }} />);
+
+            const input: HTMLInputElement = screen.queryByTestId("input");
+            const inputSpy = jest.spyOn(input, "setSelectionRange");
+
+            fireEvent.change(input, {
+                target: {
+                    value: "231",
+                    selectionStart: 2,
+                    selectionEnd: 2,
+                },
+            });
+
+            expect(input).toHaveValue("(23) 1");
+            expect(inputSpy).toBeCalledWith(3, 3);
+        });
+
+        it("should remove non-numeric characters and preserve caret position", async () => {
+            render(<PhoneNumberInput value={{ countryCode: "994" }} />);
+
+            const input: HTMLInputElement = screen.queryByTestId("input");
+            const inputSpy = jest.spyOn(input, "setSelectionRange");
+
+            fireEvent.change(input, {
+                target: {
+                    value: "(1!2",
+                    selectionStart: 3,
+                    selectionEnd: 3,
+                },
+            });
+
+            expect(input).toHaveValue("(12");
+            expect(inputSpy).toBeCalledWith(2, 2);
+        });
+    });
+});

--- a/tests/unit-number/unit-number.spec.tsx
+++ b/tests/unit-number/unit-number.spec.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { UnitNumberInput } from "src/unit-number";
+
+// =============================================================================
+// UNIT TESTS
+// =============================================================================
+describe("UnitNumberInput", () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it("should render default component", () => {
+        render(<UnitNumberInput />);
+
+        expect(screen.queryByTestId("floor-input")).toHaveValue("");
+        expect(screen.queryByTestId("floor-input")).toHaveAttribute(
+            "placeholder",
+            "00"
+        );
+        expect(screen.queryByTestId("unit-input")).toHaveValue("");
+        expect(screen.queryByTestId("unit-input")).toHaveAttribute(
+            "placeholder",
+            "8888"
+        );
+    });
+
+    it("should render component with formatted floor and unit values", () => {
+        render(<UnitNumberInput value="1-3" />);
+
+        expect(screen.queryByTestId("floor-input")).toHaveValue("01");
+        expect(screen.queryByTestId("unit-input")).toHaveValue("03");
+    });
+
+    describe("change handling", () => {
+        it("should convert letters to uppercase and preserve caret position", async () => {
+            render(<UnitNumberInput />);
+
+            const floorInput: HTMLInputElement =
+                screen.queryByTestId("floor-input");
+            const floorInputSpy = jest.spyOn(floorInput, "setSelectionRange");
+
+            const unitInput: HTMLInputElement =
+                screen.queryByTestId("unit-input");
+            const unitInputSpy = jest.spyOn(unitInput, "setSelectionRange");
+
+            fireEvent.change(floorInput, {
+                target: {
+                    value: "a1",
+                    selectionStart: 1,
+                    selectionEnd: 1,
+                },
+            });
+
+            fireEvent.change(unitInput, {
+                target: {
+                    value: "b2",
+                    selectionStart: 1,
+                    selectionEnd: 1,
+                },
+            });
+
+            expect(floorInput).toHaveValue("A1");
+            expect(floorInputSpy).toBeCalledWith(1, 1);
+            expect(unitInput).toHaveValue("B2");
+            expect(unitInputSpy).toBeCalledWith(1, 1);
+        });
+
+        it("should remove non-alphanumeric characters and preserve caret position", async () => {
+            render(<UnitNumberInput />);
+
+            const floorInput: HTMLInputElement =
+                screen.queryByTestId("floor-input");
+            const floorInputSpy = jest.spyOn(floorInput, "setSelectionRange");
+
+            const unitInput: HTMLInputElement =
+                screen.queryByTestId("unit-input");
+            const unitInputSpy = jest.spyOn(unitInput, "setSelectionRange");
+
+            fireEvent.change(floorInput, {
+                target: {
+                    value: "A!1",
+                    selectionStart: 2,
+                    selectionEnd: 2,
+                },
+            });
+
+            fireEvent.change(unitInput, {
+                target: {
+                    value: "B!2",
+                    selectionStart: 2,
+                    selectionEnd: 2,
+                },
+            });
+
+            expect(floorInput).toHaveValue("A1");
+            expect(floorInputSpy).toBeCalledWith(1, 1);
+            expect(unitInput).toHaveValue("B2");
+            expect(unitInputSpy).toBeCalledWith(1, 1);
+        });
+    });
+});


### PR DESCRIPTION
**Changes**

- Add logic in `onChange` handlers to calculate the next text caret position
  - The position is offset by the number of characters that are removed and added, which can be derived from the difference between the length of the original input and the final formatted input
  - Not perfect e.g. with `(12) ┃345`, typing space results in `(12┃) 345` but keeping it simple to avoid handling all the edge cases
- Misc fix: pass refs down to the main input field in `InputGroup` variants
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

Bug fix
- Prevent text caret jumping to end when typing in the middle of input in `PhoneNumberInput` and `UnitNumberInput`
