### PR TITLE
Adjust Drawer focus and color

### DIFF
--- a/src/drawer/drawer.styles.tsx
+++ b/src/drawer/drawer.styles.tsx
@@ -83,7 +83,7 @@ export const Header = styled.div`
 `;
 
 export const CloseButton = styled(ClickableIcon)`
-    color: ${Color.Neutral[1]};
+    color: ${Color.Neutral[3]};
     padding: 0;
 
     :active,

--- a/src/drawer/drawer.tsx
+++ b/src/drawer/drawer.tsx
@@ -24,7 +24,7 @@ export const Drawer = ({
     // =============================================================================
     const [showOverlay, setShowOverlay] = useState(show);
     const [id] = useState(() => SimpleIdGenerator.generate());
-    const buttonRef = useRef<HTMLButtonElement>();
+    const initialFocusRef = useRef<HTMLHeadingElement>();
 
     // =============================================================================
     // EFFECTS
@@ -44,7 +44,7 @@ export const Drawer = ({
     const handleDialogVisibility = (e: React.TransitionEvent) => {
         if (e.propertyName === "visibility" && show) {
             // focus the first element so that the screenreader enters the dialog
-            buttonRef.current.focus();
+            initialFocusRef.current.focus();
         }
     };
 
@@ -75,11 +75,12 @@ export const Drawer = ({
                         aria-label="Close drawer"
                         onClick={onClose}
                         focusHighlight={false}
-                        ref={buttonRef}
                     >
                         <CrossIcon aria-hidden />
                     </CloseButton>
-                    <Heading id={id}>{heading}</Heading>
+                    <Heading id={id} ref={initialFocusRef}>
+                        {heading}
+                    </Heading>
                 </Header>
                 <Content>{children}</Content>
             </Container>


### PR DESCRIPTION
**Changes**
After checking with UX Liting, 2 minor adjustments to the Drawer component were needed:
- default focus should fall onto the Header, not the cross button
- color of the cross button was wrong (correct is Neutral 3, was Neutral 1)


- [delete] branch
