### PR TITLE
Add onFocus callbacks to date and time inputs, and update Filter examples

### DIFF
--- a/src/calendar/calendar.tsx
+++ b/src/calendar/calendar.tsx
@@ -54,11 +54,13 @@ interface StyleProps {
 // =============================================================================
 const Wrapper = styled.div<StyleProps>`
     width: 41rem;
+
     ${(props) => {
         if (props.$hasBorder) {
             return css`
                 border: 1px solid ${Color.Neutral[5](props)};
                 border-radius: 12px;
+                overflow: hidden;
             `;
         }
     }}

--- a/src/date-input/date-input.tsx
+++ b/src/date-input/date-input.tsx
@@ -22,6 +22,7 @@ export const DateInput = ({
     error,
     value,
     onChange,
+    onFocus,
     onBlur,
     onYearMonthDisplayChange,
     withButton: _withButton = true,
@@ -101,6 +102,10 @@ export const DateInput = ({
 
     const handleFocus = () => {
         setCalendarOpen(true);
+
+        if (onFocus) {
+            onFocus();
+        }
     };
 
     const handleHoverDayCell = (value: string) => {

--- a/src/date-input/types.ts
+++ b/src/date-input/types.ts
@@ -28,7 +28,11 @@ export interface DateInputProps extends CommonCalendarProps {
      */
     onChange?: ((value: string) => void) | undefined;
     /**
-     * Function that returns when a defocus is made on the field
+     * Called when the field is focused
+     */
+    onFocus?: (() => void) | undefined;
+    /**
+     * Called when a defocus is made on the field
      */
     onBlur?: (() => void) | undefined;
     /** Called when there is a change in the current visible month and year */

--- a/src/date-range-input/date-range-input.tsx
+++ b/src/date-range-input/date-range-input.tsx
@@ -51,6 +51,7 @@ export const DateRangeInput = ({
     value,
     valueEnd,
     onChange,
+    onFocus,
     onBlur,
     onYearMonthDisplayChange,
     withButton: _withButton = true,
@@ -301,6 +302,10 @@ export const DateRangeInput = ({
 
     const handleInputFocus = (focusType: FocusType) => () => {
         actions.focus(focusType);
+
+        if (onFocus) {
+            onFocus();
+        }
     };
 
     const handleStartInputBlur = (validFormat: boolean) => {
@@ -367,7 +372,6 @@ export const DateRangeInput = ({
             $error={error}
             id={id}
             data-testid={otherProps["data-testid"]}
-            tabIndex={-1}
             onBlur={handleNodeBlur}
             onKeyDown={handleNodeKeyDown}
             {...otherProps}

--- a/src/date-range-input/types.ts
+++ b/src/date-range-input/types.ts
@@ -32,6 +32,10 @@ export interface DateRangeInputProps extends CommonCalendarProps {
      */
     onChange?: ((startDate: string, endDate: string) => void) | undefined;
     /**
+     * Called when field is focused
+     */
+    onFocus?: (() => void) | undefined;
+    /**
      * Function that returns when a defocus is made on the field
      */
     onBlur?: (() => void) | undefined;

--- a/src/filter/filter-item.tsx
+++ b/src/filter/filter-item.tsx
@@ -76,7 +76,7 @@ export const FilterItem = ({
                     )}
                 </FilterItemHeader>
             )}
-            <ExpandableItem style={isMobile ? undefined : itemAnimationStyles}>
+            <ExpandableItem style={itemAnimationStyles}>
                 <div ref={itemResizeDetector.ref}>
                     <FilterItemBody {...otherProps}>
                         <MinimisableContent

--- a/src/shared/internal-calendar/animated-internal-calendar.style.tsx
+++ b/src/shared/internal-calendar/animated-internal-calendar.style.tsx
@@ -1,6 +1,5 @@
 import { animated } from "react-spring";
 import styled from "styled-components";
-import { Color } from "../../color";
 import { MediaQuery } from "../../media";
 
 export const AnimatedDiv = styled(animated.div)`
@@ -9,7 +8,6 @@ export const AnimatedDiv = styled(animated.div)`
     left: -1px;
     width: calc(100% + 2px);
     max-width: 41rem;
-    background: ${Color.Neutral[8]};
     overflow: hidden;
     z-index: 1;
     min-width: 21rem;

--- a/src/shared/internal-calendar/internal-calendar.style.tsx
+++ b/src/shared/internal-calendar/internal-calendar.style.tsx
@@ -15,12 +15,14 @@ interface GeneralStyleProps {
 export const Container = styled.div<GeneralStyleProps>`
     width: 100%;
     padding: 1.5rem 2rem;
+    background: ${Color.Neutral[8]};
 
     ${(props) => {
         if (props.$type === "input") {
             return css`
                 border: 1px solid ${Color.Neutral[5]};
                 border-radius: 8px;
+                overflow: hidden;
                 padding: 1.5rem 1.25rem;
 
                 [data-id="header"] {

--- a/src/time-range-picker/time-range-picker.tsx
+++ b/src/time-range-picker/time-range-picker.tsx
@@ -18,6 +18,7 @@ export const TimeRangePicker = ({
     format = "24hr",
     readOnly,
     onChange,
+    onFocus,
     onBlur,
     ...otherProps
 }: TimeRangePickerProps) => {
@@ -53,6 +54,7 @@ export const TimeRangePicker = ({
         if (!disabled && !readOnly && !showStartTimeSelector) {
             setShowEndTimeSelector(false);
             setShowStartTimeSelector(true);
+            runOnFocusHandler();
         }
     };
 
@@ -60,6 +62,7 @@ export const TimeRangePicker = ({
         if (!disabled && !readOnly && !showEndTimeSelector) {
             setShowStartTimeSelector(false);
             setShowEndTimeSelector(true);
+            runOnFocusHandler();
         }
     };
 
@@ -100,21 +103,29 @@ export const TimeRangePicker = ({
         setShowEndTimeSelector(false);
         setEndTimeVal(value);
 
-        if (startTimeVal == "") {
-            setShowStartTimeSelector(true);
-        }
-
         const timeValue: TimeRangePickerValue = {
             start: startTimeVal,
             end: value,
         };
 
         onChange && onChange(timeValue);
+
+        if (startTimeVal == "") {
+            setShowStartTimeSelector(true);
+        } else {
+            onBlur && onBlur();
+        }
     };
 
     // =============================================================================
     // HELPER FUNCTIONS
     // =============================================================================
+    const runOnFocusHandler = () => {
+        if (!showStartTimeSelector && !showEndTimeSelector) {
+            onFocus && onFocus();
+        }
+    };
+
     const runOnBlurHandler = () => {
         setShowStartTimeSelector(false);
         setShowEndTimeSelector(false);

--- a/src/time-range-picker/types.ts
+++ b/src/time-range-picker/types.ts
@@ -39,6 +39,10 @@ export interface TimeRangePickerProps {
      */
     onChange?: ((value: TimeRangePickerValue) => void) | undefined;
     /**
+     * Called when the field is focused
+     */
+    onFocus?: (() => void) | undefined;
+    /**
      * Called when a defocus is made on the field
      */
     onBlur?: (() => void) | undefined;

--- a/src/timepicker/timepicker.tsx
+++ b/src/timepicker/timepicker.tsx
@@ -15,6 +15,7 @@ export const Timepicker = ({
     placeholder,
     format = "24hr",
     onChange,
+    onFocus,
     onBlur,
     ...otherProps
 }: TimepickerProps) => {
@@ -37,6 +38,7 @@ export const Timepicker = ({
     const handleInputFocus = () => {
         if (!disabled && !readOnly && !showSelector) {
             setShowSelector(true);
+            onFocus && onFocus();
         }
     };
 
@@ -61,8 +63,8 @@ export const Timepicker = ({
     };
 
     const handleChange = (value: string) => {
-        setShowSelector(false);
         onChange && onChange(value);
+        runOnBlurHandler();
     };
 
     // =============================================================================

--- a/src/timepicker/types.ts
+++ b/src/timepicker/types.ts
@@ -34,6 +34,10 @@ export interface TimepickerProps {
      */
     onChange?: ((value: string) => void) | undefined;
     /**
+     * Called when the field is focused
+     */
+    onFocus?: (() => void) | undefined;
+    /**
      * Called when a defocus is made on the field
      */
     onBlur?: (() => void) | undefined;

--- a/stories/filter/doc-elements.tsx
+++ b/stories/filter/doc-elements.tsx
@@ -41,7 +41,18 @@ export const SearchFilter = ({ mode, value, onChange }: Props<string>) => {
 };
 
 export const DateFilter = ({ value, onChange }: Props<string>) => {
-    return <Form.DateInput value={value} onChange={(date) => onChange(date)} />;
+    const [isFocused, setIsFocused] = useState(false);
+
+    return (
+        <div style={{ height: isFocused ? "33rem" : undefined }}>
+            <Form.DateInput
+                value={value}
+                onChange={(date) => onChange(date)}
+                onFocus={() => setIsFocused(true)}
+                onBlur={() => setIsFocused(false)}
+            />
+        </div>
+    );
 };
 
 export const TextFilter = () => {
@@ -60,15 +71,9 @@ export const TextFilter = () => {
     );
 };
 
-export const useFilters = () => {
-    const INITIAL_STATE = {
-        search: "",
-        cat1: "",
-        cat2: [],
-    };
-
-    const [currentFilters, setCurrentFilters] = useState(INITIAL_STATE);
-    const [draftFilters, setDraftFilters] = useState(INITIAL_STATE);
+export const useFilters = <T extends Record<string, any>>(initialState: T) => {
+    const [currentFilters, setCurrentFilters] = useState(initialState);
+    const [draftFilters, setDraftFilters] = useState(initialState);
     const clearButtonDisabled = Object.values(draftFilters).every((filter) =>
         isEmpty(filter)
     );
@@ -97,8 +102,8 @@ export const useFilters = () => {
     };
 
     const clearFilters = () => {
-        setCurrentFilters(INITIAL_STATE);
-        setDraftFilters(INITIAL_STATE);
+        setCurrentFilters(initialState);
+        setDraftFilters(initialState);
     };
 
     return {

--- a/stories/filter/filter-addons.stories.mdx
+++ b/stories/filter/filter-addons.stories.mdx
@@ -36,7 +36,7 @@ import { Filter } from "@lifesg/react-design-system/filter";
                 saveFilters,
                 dismissFilters,
                 clearFilters,
-            } = useFilters(); // your custom filter state management here
+            } = useFilters({ cat1: [], cat2: [] }); // your custom filter state management here
             return (
                 <StoryContainer>
                     <Filter

--- a/stories/filter/filter.stories.mdx
+++ b/stories/filter/filter.stories.mdx
@@ -42,7 +42,7 @@ import { Filter } from "@lifesg/react-design-system/filter";
                 saveFilters,
                 dismissFilters,
                 clearFilters,
-            } = useFilters(); // your custom filter state management here
+            } = useFilters({ search: "", date: undefined }); // your custom filter state management here
             return (
                 <StoryContainer>
                     <Filter
@@ -68,8 +68,8 @@ import { Filter } from "@lifesg/react-design-system/filter";
                                 <Filter.Item title="Date">
                                     <DateFilter
                                         mode={mode}
-                                        value={draftFilters.cat1}
-                                        onChange={updateFilter(mode, "cat1")}
+                                        value={draftFilters.date}
+                                        onChange={updateFilter(mode, "date")}
                                     />
                                 </Filter.Item>
                                 <Filter.Item title="Just an example of long content that may wrap to the next line">

--- a/stories/form/form-date-input/props-table.tsx
+++ b/stories/form/form-date-input/props-table.tsx
@@ -134,6 +134,11 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["() => void"],
             },
             {
+                name: "onFocus",
+                description: "Called when the field is focused",
+                propTypes: ["() => void"],
+            },
+            {
                 name: "onYearMonthDisplayChange",
                 description:
                     "Called when the current displayed month and year changes",

--- a/stories/form/form-date-range-input/props-table.tsx
+++ b/stories/form/form-date-range-input/props-table.tsx
@@ -150,6 +150,11 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["() => void"],
             },
             {
+                name: "onFocus",
+                description: "Called when the field is focused",
+                propTypes: ["() => void"],
+            },
+            {
                 name: "onYearMonthDisplayChange",
                 description:
                     "Called when the current displayed month and year changes",

--- a/stories/form/form-time-range-picker/props-table.tsx
+++ b/stories/form/form-time-range-picker/props-table.tsx
@@ -79,6 +79,11 @@ const DATA: ApiTableSectionProps[] = [
                 description: "Called when a defocus happens",
                 propTypes: ["() => void"],
             },
+            {
+                name: "onFocus",
+                description: "Called when the field is focused",
+                propTypes: ["() => void"],
+            },
         ],
     },
     {

--- a/stories/form/form-timepicker/props-table.tsx
+++ b/stories/form/form-timepicker/props-table.tsx
@@ -97,6 +97,11 @@ const DATA: ApiTableSectionProps[] = [
                     "Called when a defocus happens. Any changes in the time selection box will not be applied",
                 propTypes: ["() => void"],
             },
+            {
+                name: "onFocus",
+                description: "Called when the field is focused",
+                propTypes: ["() => void"],
+            },
         ],
     },
     ...SHARED_FORM_PROPS_DATA,


### PR DESCRIPTION
**Changes**
- Expose `onFocus` in date and time inputs so that the consumer can detect the dropdown visibility. The current use case is for better handling in Filter items
- Tweak animation of Filter items in mobile mode; previously the height was not animated correctly. There will be a slight layout shift initially however due to the initial animation.
- Amend styling so that calendar variants display correctly on coloured backgrounds
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Add `onFocus` props to date and time pickers
- Fix expand animation on `Filter.Item` in mobile when height changes