### PR TITLE
Remove the default value of expanded and only allow expanded prop to set initial state for Accordion.Item

### DIFF
--- a/src/accordion/accordion-item.tsx
+++ b/src/accordion/accordion-item.tsx
@@ -1,9 +1,9 @@
-import { isFunction } from "lodash";
 import React, {
     forwardRef,
     useContext,
     useEffect,
     useImperativeHandle,
+    useRef,
     useState,
 } from "react";
 import { useResizeDetector } from "react-resize-detector";
@@ -29,27 +29,12 @@ function Component(
         type = "default",
         ...otherProps
     }: AccordionItemProps,
-    ref: React.Ref<HTMLDivElement>
+    ref: React.Ref<AccordionItemHandle>
 ) {
-    useImperativeHandle(
-        ref,
-        () => {
-            if (!isFunction(ref)) {
-                return Object.assign(ref.current, {
-                    expand(): void {
-                        setExpand(true);
-                    },
-                    collapse(): void {
-                        setExpand(false);
-                    },
-                });
-            }
-        },
-        []
-    );
     // =============================================================================
     // CONST, STATE, REF
     // =============================================================================
+    const elementRef = useRef<HTMLDivElement>();
     const expandAll = useContext(AccordionContext);
     const [expand, setExpand] = useState<boolean>(expanded ?? expandAll);
     const [hasFirstLoad, setHasFirstLoad] = useState<boolean>(false);
@@ -58,6 +43,20 @@ function Component(
 
     const resizeDetector = useResizeDetector();
     const childRef = resizeDetector.ref;
+
+    useImperativeHandle(
+        ref,
+        () =>
+            Object.assign(elementRef.current, {
+                expand(): void {
+                    setExpand(true);
+                },
+                collapse(): void {
+                    setExpand(false);
+                },
+            }),
+        []
+    );
 
     // =============================================================================
     // EFFECTS
@@ -137,7 +136,7 @@ function Component(
             data-testid={testId}
             className={otherProps.className}
             $isCollapsed={expand}
-            ref={ref}
+            ref={elementRef}
         >
             <TitleContainer>
                 {renderTitle()}

--- a/src/accordion/accordion-item.tsx
+++ b/src/accordion/accordion-item.tsx
@@ -17,7 +17,7 @@ import { AccordionItemProps } from "./types";
 export const AccordionItem = ({
     title,
     children,
-    expanded = true,
+    expanded,
     type = "default",
     ...otherProps
 }: AccordionItemProps) => {
@@ -25,7 +25,8 @@ export const AccordionItem = ({
     // CONST, STATE, REF
     // =============================================================================
     const expandAll = useContext(AccordionContext);
-    const [expand, setExpand] = useState<boolean>(expandAll ?? expanded);
+    const [expand, setExpand] = useState<boolean>(expanded ?? expandAll);
+    const [hadFirstLoad, setHadFirstLoad] = useState<boolean>(false);
 
     const testId = otherProps["data-testid"] || "accordion-item";
 
@@ -37,13 +38,14 @@ export const AccordionItem = ({
     // =============================================================================
 
     useEffect(() => {
-        setExpand(expanded);
-    }, [expanded]);
-
-    // `setExpand(expandAll)` is after `setExpand(expanded)` to override its setState on initial load
-    useEffect(() => {
-        setExpand(expandAll);
+        if (hadFirstLoad) {
+            setExpand(expandAll);
+        }
     }, [expandAll]);
+
+    useEffect(() => {
+        setHadFirstLoad(true);
+    }, []);
 
     // =============================================================================
     // EVENT HANDLERS

--- a/src/accordion/accordion-item.tsx
+++ b/src/accordion/accordion-item.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { forwardRef, useContext, useEffect, useState } from "react";
 import { useResizeDetector } from "react-resize-detector";
 import { useSpring } from "react-spring";
 import { AccordionContext } from "./accordion-context";
@@ -14,13 +14,17 @@ import {
 } from "./accordion-item.style";
 import { AccordionItemProps } from "./types";
 
-export const AccordionItem = ({
-    title,
-    children,
-    expanded,
-    type = "default",
-    ...otherProps
-}: AccordionItemProps) => {
+
+function _AccordionItem(
+    {
+        title,
+        children,
+        expanded,
+        type = "default",
+        ...otherProps
+    }: AccordionItemProps,
+    ref: React.Ref<HTMLDivElement>
+) {
     // =============================================================================
     // CONST, STATE, REF
     // =============================================================================
@@ -111,6 +115,7 @@ export const AccordionItem = ({
             data-testid={testId}
             className={otherProps.className}
             $isCollapsed={expand}
+            ref={ref}
         >
             <TitleContainer>
                 {renderTitle()}
@@ -128,4 +133,6 @@ export const AccordionItem = ({
             {renderContent()}
         </Container>
     );
-};
+}
+
+export const AccordionItem = forwardRef(_AccordionItem);

--- a/src/accordion/accordion-item.tsx
+++ b/src/accordion/accordion-item.tsx
@@ -54,8 +54,11 @@ function Component(
                 collapse(): void {
                     setExpand(false);
                 },
+                isExpanded() {
+                    return expand;
+                },
             }),
-        []
+        [expand]
     );
 
     // =============================================================================

--- a/src/accordion/accordion-item.tsx
+++ b/src/accordion/accordion-item.tsx
@@ -26,7 +26,7 @@ export const AccordionItem = ({
     // =============================================================================
     const expandAll = useContext(AccordionContext);
     const [expand, setExpand] = useState<boolean>(expanded ?? expandAll);
-    const [hadFirstLoad, setHadFirstLoad] = useState<boolean>(false);
+    const [hasFirstLoad, setHasFirstLoad] = useState<boolean>(false);
 
     const testId = otherProps["data-testid"] || "accordion-item";
 
@@ -38,13 +38,19 @@ export const AccordionItem = ({
     // =============================================================================
 
     useEffect(() => {
-        if (hadFirstLoad) {
+        if (hasFirstLoad) {
             setExpand(expandAll);
         }
     }, [expandAll]);
 
     useEffect(() => {
-        setHadFirstLoad(true);
+        if (hasFirstLoad) {
+            setExpand(expanded);
+        }
+    }, [expanded]);
+
+    useEffect(() => {
+        setHasFirstLoad(true);
     }, []);
 
     // =============================================================================
@@ -60,15 +66,13 @@ export const AccordionItem = ({
     // RENDER FUNCTIONS
     // =============================================================================
     // React spring animation configuration
-    const resizeHeight = resizeDetector.height;
-    const expandableStyles = useSpring({
-        height: hadFirstLoad ? (expand ? resizeHeight : 0) : resizeHeight,
-    });
+    const resizeHeight = { height: expand ? resizeDetector.height : 0 };
+    const expandableStyles = useSpring(resizeHeight);
 
     const renderContent = () => {
         return (
             <Expandable
-                style={expandableStyles}
+                style={hasFirstLoad ? expandableStyles : resizeHeight}
                 $isCollapsed={expand}
                 data-testid={`${testId}-expandable-container`}
             >

--- a/src/accordion/accordion-item.tsx
+++ b/src/accordion/accordion-item.tsx
@@ -1,4 +1,11 @@
-import React, { forwardRef, useContext, useEffect, useState } from "react";
+import { isFunction } from "lodash";
+import React, {
+    forwardRef,
+    useContext,
+    useEffect,
+    useImperativeHandle,
+    useState,
+} from "react";
 import { useResizeDetector } from "react-resize-detector";
 import { useSpring } from "react-spring";
 import { AccordionContext } from "./accordion-context";
@@ -12,10 +19,9 @@ import {
     TitleContainer,
     TitleH4,
 } from "./accordion-item.style";
-import { AccordionItemProps } from "./types";
+import { AccordionItemHandle, AccordionItemProps } from "./types";
 
-
-function _AccordionItem(
+function Component(
     {
         title,
         children,
@@ -25,6 +31,22 @@ function _AccordionItem(
     }: AccordionItemProps,
     ref: React.Ref<HTMLDivElement>
 ) {
+    useImperativeHandle(
+        ref,
+        () => {
+            if (!isFunction(ref)) {
+                return Object.assign(ref.current, {
+                    expand(): void {
+                        setExpand(true);
+                    },
+                    collapse(): void {
+                        setExpand(false);
+                    },
+                });
+            }
+        },
+        []
+    );
     // =============================================================================
     // CONST, STATE, REF
     // =============================================================================
@@ -135,4 +157,7 @@ function _AccordionItem(
     );
 }
 
-export const AccordionItem = forwardRef(_AccordionItem);
+export const AccordionItem = forwardRef<
+    AccordionItemHandle,
+    AccordionItemProps
+>(Component);

--- a/src/accordion/accordion-item.tsx
+++ b/src/accordion/accordion-item.tsx
@@ -60,8 +60,9 @@ export const AccordionItem = ({
     // RENDER FUNCTIONS
     // =============================================================================
     // React spring animation configuration
+    const resizeHeight = resizeDetector.height;
     const expandableStyles = useSpring({
-        height: expand ? resizeDetector.height : 0,
+        height: hadFirstLoad ? (expand ? resizeHeight : 0) : resizeHeight,
     });
 
     const renderContent = () => {

--- a/src/accordion/types.ts
+++ b/src/accordion/types.ts
@@ -18,6 +18,11 @@ export interface AccordionItemProps {
     type?: AccordionItemType | undefined;
 }
 
+export type AccordionItemHandle = HTMLDivElement & {
+    expand: () => void;
+    collapse: () => void;
+};
+
 /**
  * Transient props are denoted with $
  * See more https://styled-components.com/docs/api#transient-props

--- a/src/accordion/types.ts
+++ b/src/accordion/types.ts
@@ -12,6 +12,9 @@ export type AccordionItemType = "default" | "small";
 export interface AccordionItemProps {
     title: string;
     children: JSX.Element | JSX.Element[];
+    /**
+     * Only for initial state, do not use to programmatically expand/collapse Accordion.Item after first load
+     */
     expanded?: boolean | undefined;
     "data-testid"?: string | undefined;
     className?: string | undefined;

--- a/src/accordion/types.ts
+++ b/src/accordion/types.ts
@@ -12,6 +12,10 @@ export type AccordionItemType = "default" | "small";
 export interface AccordionItemProps {
     title: string;
     children: JSX.Element | JSX.Element[];
+    /**
+     * Omit or set this to undefined to allow 'Hide All'/'Show All' in parent to take precedence
+     * for cases where we want the default expand behaviour
+     */
     expanded?: boolean | undefined;
     "data-testid"?: string | undefined;
     className?: string | undefined;

--- a/src/accordion/types.ts
+++ b/src/accordion/types.ts
@@ -25,6 +25,7 @@ export interface AccordionItemProps {
 export type AccordionItemHandle = HTMLDivElement & {
     expand: () => void;
     collapse: () => void;
+    isExpanded: () => boolean;
 };
 
 /**

--- a/src/accordion/types.ts
+++ b/src/accordion/types.ts
@@ -12,9 +12,6 @@ export type AccordionItemType = "default" | "small";
 export interface AccordionItemProps {
     title: string;
     children: JSX.Element | JSX.Element[];
-    /**
-     * Only for initial state, do not use to programmatically expand/collapse Accordion.Item after first load
-     */
     expanded?: boolean | undefined;
     "data-testid"?: string | undefined;
     className?: string | undefined;

--- a/stories/accordion/props-table.tsx
+++ b/stories/accordion/props-table.tsx
@@ -84,8 +84,7 @@ const ACCORDION_ITEM_DATA: ApiTableSectionProps[] = [
             },
             {
                 name: "expanded",
-                description:
-                    "Specifies if the item is expanded on for first load",
+                description: "Specifies if the item is expanded",
                 propTypes: ["boolean"],
             },
             {

--- a/stories/accordion/props-table.tsx
+++ b/stories/accordion/props-table.tsx
@@ -84,7 +84,8 @@ const ACCORDION_ITEM_DATA: ApiTableSectionProps[] = [
             },
             {
                 name: "expanded",
-                description: "Specifies if the item is expanded",
+                description:
+                    "Specifies if the item is expanded. Omit or set this to undefined to allow 'Hide All'/'Show All' in parent to take precedence for cases where we want the default expand behaviour",
                 propTypes: ["boolean"],
             },
             {

--- a/stories/accordion/props-table.tsx
+++ b/stories/accordion/props-table.tsx
@@ -84,9 +84,9 @@ const ACCORDION_ITEM_DATA: ApiTableSectionProps[] = [
             },
             {
                 name: "expanded",
-                description: "Specifies if the item is expanded",
+                description:
+                    "Specifies if the item is expanded on for first load",
                 propTypes: ["boolean"],
-                defaultValue: "true",
             },
             {
                 name: "className",

--- a/stories/accordion/props-table.tsx
+++ b/stories/accordion/props-table.tsx
@@ -1,11 +1,5 @@
 import React from "react";
-import {
-    ApiTable,
-    DefaultCol,
-    DescriptionCol,
-    NameCol,
-    Table,
-} from "../storybook-common/api-table";
+import { ApiTable, code } from "../storybook-common/api-table";
 import { ApiTableSectionProps } from "../storybook-common/api-table/types";
 import { TabAttribute, Tabs } from "../storybook-common/tabs";
 
@@ -84,8 +78,13 @@ const ACCORDION_ITEM_DATA: ApiTableSectionProps[] = [
             },
             {
                 name: "expanded",
-                description:
-                    "Specifies if the item is expanded. Omit or set this to undefined to allow 'Hide All'/'Show All' in parent to take precedence for cases where we want the default expand behaviour",
+                description: (
+                    <>
+                        Specifies if the item is expanded. When set, this takes
+                        precedence over {code("initialDisplay")} of the
+                        {code("Accordion")}
+                    </>
+                ),
                 propTypes: ["boolean"],
             },
             {


### PR DESCRIPTION
**Changes**
Remove the default value of expanded in `Accordion.Item` to allow expandAll === false from parent
`Accordion.Item` height will not use animation on first load (to allow easier scrollHeight calculation)

Add handles to allow expand/collapse of individual items. 

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- [WARNING] Remove the default value of expanded in `Accordion.Item`

**Additional information**

- You may refer to this[MOL-13135](https://jira.ship.gov.sg/browse/MOL-13135)
