### PR TITLE
Fix popover rendering out of screen

### DIFF
--- a/src/popover/popover.styles.tsx
+++ b/src/popover/popover.styles.tsx
@@ -29,7 +29,7 @@ const getVisibilityStyle = (visible: boolean) => {
             visibility: visible;
             opacity: 1;
             transition: ${Transition.Base};
-            z-index: 2;
+            z-index: 1000;
         `;
     } else {
         return css`

--- a/src/popover/popover.tsx
+++ b/src/popover/popover.tsx
@@ -114,6 +114,10 @@ export const Popover = ({
                 return hasExceededTop ? "top-center" : "none";
             }
 
+            if (hasExceededTop) {
+                return "top-center";
+            }
+
             // All ok, do nothing
             return undefined;
         }


### PR DESCRIPTION
**Changes**
1. fixed popover rendering out of the top of the screen.
2. update z-index so that it renders on top of the LifeSG's navigation bar.

Refer to screenshot attached to [jira ticket](https://github.com/LifeSG/react-design-system/pull/251) for both issues.

- delete branch