### PR TITLE
Reset border style in radio buttons

### DIFF
--- a/src/radio-button/radio-button.styles.tsx
+++ b/src/radio-button/radio-button.styles.tsx
@@ -43,6 +43,7 @@ export const Input = styled.input<RadioButtonProps>`
     /* Hide appearance but keep it focusable using keyboard interactions */
     appearance: none;
     background: transparent;
+    border: none;
 `;
 
 export const Checkmark = styled.div<StyleProps>`

--- a/src/toggle/toggle.styles.tsx
+++ b/src/toggle/toggle.styles.tsx
@@ -126,6 +126,7 @@ export const Input = styled.input`
     /* Hide appearance but keep it focusable using keyboard interactions */
     appearance: none;
     background: transparent;
+    border: none;
 `;
 
 export const TextContainer = styled.div`


### PR DESCRIPTION
Resolves #250 

In Safari 13 radio inputs have a border style which need to be reset. Have identified these two components to be affected.

**Changes**

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

Style fix
- Remove extra border from `Toggle` and `RadioButton` in Safari 13
