### PR TITLE
[MISC][DH] add `autoDismissTime` prop to Toast component to customize…

### DIFF
--- a/src/toast/toast.tsx
+++ b/src/toast/toast.tsx
@@ -19,11 +19,14 @@ import {
 } from "./toast.styles";
 import { ToastProps } from "./types";
 
+const defaultAutoDismissTime = 4000;
+
 export const Toast = ({
     type = "success",
     title,
     label,
     autoDismiss,
+    autoDismissTime = defaultAutoDismissTime,
     onDismiss,
     ...otherProps
 }: ToastProps) => {
@@ -45,11 +48,11 @@ export const Toast = ({
     useEffect(() => {
         if (!autoDismiss) return;
 
-        setTimeout(() => {
+        const timeout = setTimeout(() => {
             setVisible(false);
-        }, timer);
+        }, autoDismissTime);
 
-        return () => clearTimeout(timer);
+        return () => clearTimeout(timeout);
     }, [autoDismiss]);
 
     // =============================================================================
@@ -123,5 +126,3 @@ export const Toast = ({
         </Wrapper>
     );
 };
-
-const timer = 4000;

--- a/src/toast/toast.tsx
+++ b/src/toast/toast.tsx
@@ -19,14 +19,14 @@ import {
 } from "./toast.styles";
 import { ToastProps } from "./types";
 
-const defaultAutoDismissTime = 4000;
+const DEFAULT_AUTO_DISMISS_TIME = 4000;
 
 export const Toast = ({
     type = "success",
     title,
     label,
     autoDismiss,
-    autoDismissTime = defaultAutoDismissTime,
+    autoDismissTime = DEFAULT_AUTO_DISMISS_TIME,
     onDismiss,
     ...otherProps
 }: ToastProps) => {

--- a/src/toast/types.ts
+++ b/src/toast/types.ts
@@ -11,6 +11,8 @@ export interface ToastProps extends React.HTMLAttributes<HTMLDivElement> {
     title?: string | undefined;
     /** If specified, the Toast will be automatically dismissed after 4 seconds */
     autoDismiss?: boolean | undefined;
+    /** Time until auto dismissal in milliseconds. Requires `autoDismiss` to be `true` */
+    autoDismissTime?: number | undefined;
     /** If given, the function will be called when the Toast is dismissed */
     onDismiss?: () => void;
 }

--- a/stories/toast/props-table.tsx
+++ b/stories/toast/props-table.tsx
@@ -58,8 +58,7 @@ const DATA: ApiTableSectionProps[] = [
                 description: (
                     <>
                         Specifies if the <code>Toast</code> will be
-                        automatically dismissed after{" "}
-                        <strong>autoDismissTime</strong>.
+                        automatically dismissed after <code>autoDismissTime</code>.
                     </>
                 ),
                 propTypes: ["boolean"],

--- a/stories/toast/props-table.tsx
+++ b/stories/toast/props-table.tsx
@@ -58,11 +58,24 @@ const DATA: ApiTableSectionProps[] = [
                 description: (
                     <>
                         Specifies if the <code>Toast</code> will be
-                        automatically dismiss after <strong>4 seconds</strong>
+                        automatically dismissed after{" "}
+                        <strong>autoDismissTime</strong>.
                     </>
                 ),
                 propTypes: ["boolean"],
                 defaultValue: "false",
+            },
+            {
+                name: "autoDismissTime",
+                description: (
+                    <>
+                        Time in milliseconds until the <code>Toast</code>{" "}
+                        automatically dismisses. Defaults to{" "}
+                        <strong>4 seconds</strong>.
+                    </>
+                ),
+                propTypes: ["number"],
+                defaultValue: "4000",
             },
             {
                 name: "onDismiss",

--- a/stories/toast/toast.stories.mdx
+++ b/stories/toast/toast.stories.mdx
@@ -104,6 +104,13 @@ is **4 seconds** and you can specify using the `autoDismiss` property.
             label="Your bookings has been updated and received by the service provider."
             autoDismiss
         />
+        <br />
+        <Toast
+            type="info"
+            label="This toast has a custom auto dismiss time of 8 seconds."
+            autoDismiss
+            autoDismissTime={8000}
+        />
     </Story>
 </Canvas>
 


### PR DESCRIPTION
**Changes**
Added optional `autoDismissTime` prop to `Toast` component to customize the auto dismiss timing. Defaults to 4 seconds as previously.

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Added optional `autoDismissTime` prop to `Toast` component to customize the auto dismiss timing
