### PR TITLE
Cater for searching secondary label in lowercase

### DIFF
--- a/src/shared/dropdown-list/dropdown-list.tsx
+++ b/src/shared/dropdown-list/dropdown-list.tsx
@@ -205,9 +205,16 @@ export const DropdownList = <T, V>({
                     typeof label === "object"
                         ? label.title.toLowerCase()
                         : label.toLowerCase();
-                const secondaryLabel = typeof label === "string" ? undefined : label.secondaryLabel.toLowerCase();;
-
-                return (title.includes(searchValue.trim().toLowerCase()) || (secondaryLabel && secondaryLabel.includes(searchValue.trim().toLowerCase())));
+                const secondaryLabel =
+                    typeof label === "string"
+                        ? undefined
+                        : label.secondaryLabel?.toLowerCase();
+                const updatedSearchValue = searchValue.trim().toLowerCase();
+                return (
+                    title.includes(updatedSearchValue) ||
+                    (secondaryLabel &&
+                        secondaryLabel.includes(updatedSearchValue))
+                );
             });
             setDisplayListItems(updated);
         }

--- a/src/shared/dropdown-list/dropdown-list.tsx
+++ b/src/shared/dropdown-list/dropdown-list.tsx
@@ -205,18 +205,9 @@ export const DropdownList = <T, V>({
                     typeof label === "object"
                         ? label.title.toLowerCase()
                         : label.toLowerCase();
+                const secondaryLabel = typeof label === "string" ? undefined : label.secondaryLabel.toLowerCase();;
 
-                // include secondary label filter/search
-                if (typeof label === "object" && label.secondaryLabel) {
-                    return (
-                        title.includes(searchValue.trim().toLowerCase()) ||
-                        label.secondaryLabel.includes(
-                            searchValue.trim().toLowerCase()
-                        )
-                    );
-                }
-
-                return title.includes(searchValue.trim().toLowerCase());
+                return (title.includes(searchValue.trim().toLowerCase()) || (secondaryLabel && secondaryLabel.includes(searchValue.trim().toLowerCase())));
             });
             setDisplayListItems(updated);
         }


### PR DESCRIPTION
**Changes**

Convert secondary label to lowercase before matching against search input

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

Bug fix
- Update search logic in `InputSelect`, `InputMultiSelect` and `InputGroup` to be case-insensitive for secondary label
