### PR TITLE
Navbar uncollapsible action button

### DIFF
--- a/src/navbar/navbar-action-buttons.styles.tsx
+++ b/src/navbar/navbar-action-buttons.styles.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { Button } from "../button";
 import { MediaQuery } from "../media";
 import { Text } from "../text";
@@ -67,12 +67,18 @@ export const ButtonItem = styled.li<{ $mobile?: boolean }>`
 
         :not(:last-of-type) {
             margin-right: 0;
-            margin-bottom: ${(props) => (props.$mobile ? "1rem" : "unset")};
+            margin-bottom: ${(props) => (props.$mobile ? "1rem" : "0")};
         }
     }
 
     ${MediaQuery.MaxWidth.mobileL} {
-        padding: 0 1rem;
+        ${(props) => {
+            if (props.$mobile) {
+                return css`
+                    padding: 0 1rem;
+                `;
+            }
+        }}
     }
 `;
 

--- a/src/navbar/navbar-action-buttons.styles.tsx
+++ b/src/navbar/navbar-action-buttons.styles.tsx
@@ -18,13 +18,13 @@ export const Wrapper = styled.ul`
 `;
 
 export const MobileWrapper = styled.ul`
-    display: flex;
-    list-style: none;
-    margin-left: 4rem;
-    flex-shrink: 0;
+    display: none;
 
-    ${MediaQuery.MinWidth.tablet} {
-        display: none;
+    ${MediaQuery.MaxWidth.tablet} {
+        display: flex;
+        list-style: none;
+        margin-left: 4rem;
+        flex-shrink: 0;
     }
 `;
 

--- a/src/navbar/navbar-action-buttons.styles.tsx
+++ b/src/navbar/navbar-action-buttons.styles.tsx
@@ -17,6 +17,17 @@ export const Wrapper = styled.ul`
     }
 `;
 
+export const UncollapsableWrapper = styled.ul`
+    display: flex;
+    list-style: none;
+    margin-left: 4rem;
+    flex-shrink: 0;
+
+    ${MediaQuery.MinWidth.tablet} {
+        display: none;
+    }
+`;
+
 export const MobileWrapper = styled.ul`
     display: none;
     list-style: none;
@@ -40,7 +51,7 @@ export const MobileWrapper = styled.ul`
 // =============================================================================
 // BUTTON ITEMS
 // =============================================================================
-export const ButtonItem = styled.li`
+export const ButtonItem = styled.li<{ $mobile?: boolean }>`
     position: relative;
     display: flex;
     align-items: center;
@@ -56,7 +67,7 @@ export const ButtonItem = styled.li`
 
         :not(:last-of-type) {
             margin-right: 0;
-            margin-bottom: 1rem;
+            margin-bottom: ${(props) => (props.$mobile ? "1rem" : "unset")};
         }
     }
 

--- a/src/navbar/navbar-action-buttons.styles.tsx
+++ b/src/navbar/navbar-action-buttons.styles.tsx
@@ -17,7 +17,7 @@ export const Wrapper = styled.ul`
     }
 `;
 
-export const UncollapsableWrapper = styled.ul`
+export const MobileWrapper = styled.ul`
     display: flex;
     list-style: none;
     margin-left: 4rem;
@@ -28,7 +28,7 @@ export const UncollapsableWrapper = styled.ul`
     }
 `;
 
-export const MobileWrapper = styled.ul`
+export const DrawerWrapper = styled.ul`
     display: none;
     list-style: none;
 

--- a/src/navbar/navbar-action-buttons.tsx
+++ b/src/navbar/navbar-action-buttons.tsx
@@ -8,8 +8,8 @@ import {
     DownloadAppImageLinkWrapper,
     DownloadAppTitle,
     DownloadAppWrapper,
+    DrawerWrapper,
     MobileWrapper,
-    UncollapsableWrapper,
     Wrapper,
 } from "./navbar-action-buttons.styles";
 import { NavbarButtonComponentProps, NavbarButtonProps } from "./types";
@@ -198,25 +198,22 @@ export const NavbarActionButtons = ({
         });
     };
 
-    const renderUncollapsableButtons = () => {
+    if (actionButtons && actionButtons.length > 0) {
         const uncollapsableActionButtons = actionButtons.filter(
             (actionButton) => !!actionButton.uncollapsible
         );
-        return (
-            <UncollapsableWrapper>
-                {renderButtons(false, uncollapsableActionButtons)}
-            </UncollapsableWrapper>
-        );
-    };
-
-    if (actionButtons && actionButtons.length > 0) {
-        const ContentWrapper = mobile ? MobileWrapper : Wrapper;
-        return (
-            <>
-                {!mobile && renderUncollapsableButtons()}
-                <ContentWrapper>{renderButtons(mobile)}</ContentWrapper>
-            </>
-        );
+        if (mobile) {
+            return <DrawerWrapper>{renderButtons(mobile)}</DrawerWrapper>;
+        } else {
+            return (
+                <>
+                    <MobileWrapper>
+                        {renderButtons(false, uncollapsableActionButtons)}
+                    </MobileWrapper>
+                    <Wrapper>{renderButtons(mobile)}</Wrapper>
+                </>
+            );
+        }
     }
 
     return <></>;

--- a/src/navbar/navbar-action-buttons.tsx
+++ b/src/navbar/navbar-action-buttons.tsx
@@ -196,37 +196,41 @@ export const NavbarActionButtons = ({
         });
     };
 
-    const actionButtonList = actionButtons?.mobile || actionButtons.desktop;
-    const uncollapsableActionButtons = actionButtonList.filter(
-        (actionButton) => !!actionButton.uncollapsible
-    );
-    const collapsableActionButtons = actionButtonList.filter(
-        (actionButton) => !actionButton.uncollapsible
-    );
-    if (mobile) {
-        return (
-            <>
-                {collapsableActionButtons.length > 0 && (
-                    <DrawerWrapper>
-                        {renderButtons(mobile, collapsableActionButtons)}
-                    </DrawerWrapper>
-                )}
-            </>
+    if (actionButtons) {
+        const actionButtonList = actionButtons?.mobile || actionButtons.desktop;
+        const uncollapsableActionButtons = actionButtonList.filter(
+            (actionButton) => !!actionButton.uncollapsible
         );
-    } else {
-        return (
-            <>
-                {uncollapsableActionButtons.length > 0 && (
-                    <MobileWrapper>
-                        {renderButtons(false, uncollapsableActionButtons)}
-                    </MobileWrapper>
-                )}
-                {actionButtons.desktop.length > 0 && (
-                    <Wrapper>
-                        {renderButtons(mobile, actionButtons.desktop)}
-                    </Wrapper>
-                )}
-            </>
+        const collapsableActionButtons = actionButtonList.filter(
+            (actionButton) => !actionButton.uncollapsible
         );
+        if (mobile) {
+            return (
+                <>
+                    {collapsableActionButtons.length > 0 && (
+                        <DrawerWrapper>
+                            {renderButtons(mobile, collapsableActionButtons)}
+                        </DrawerWrapper>
+                    )}
+                </>
+            );
+        } else {
+            return (
+                <>
+                    {uncollapsableActionButtons.length > 0 && (
+                        <MobileWrapper>
+                            {renderButtons(false, uncollapsableActionButtons)}
+                        </MobileWrapper>
+                    )}
+                    {actionButtons.desktop.length > 0 && (
+                        <Wrapper>
+                            {renderButtons(mobile, actionButtons.desktop)}
+                        </Wrapper>
+                    )}
+                </>
+            );
+        }
     }
+
+    return <></>;
 };

--- a/src/navbar/navbar-action-buttons.tsx
+++ b/src/navbar/navbar-action-buttons.tsx
@@ -9,6 +9,7 @@ import {
     DownloadAppTitle,
     DownloadAppWrapper,
     MobileWrapper,
+    UncollapsableWrapper,
     Wrapper,
 } from "./navbar-action-buttons.styles";
 import { NavbarButtonComponentProps, NavbarButtonProps } from "./types";
@@ -26,6 +27,7 @@ interface Props {
         event: React.MouseEvent<HTMLButtonElement> | React.MouseEvent<Element>,
         actionButton: NavbarButtonProps
     ) => void;
+    uncollapsible?: boolean | undefined;
 }
 
 export const NavbarActionButtons = ({
@@ -118,14 +120,23 @@ export const NavbarActionButtons = ({
         );
     };
 
-    const renderButtons = (isMobile = false) => {
+    const renderButtons = (
+        isMobile = false,
+        actionButtonList = actionButtons
+    ) => {
         /**
          * In drawer view, download app button will always be at
          * the bottom, hence we will shift it to the back
          */
-        const buttonsToRender = isMobile
-            ? moveDownloadButtonToTheBack(actionButtons)
-            : actionButtons;
+        let buttonsToRender = isMobile
+            ? moveDownloadButtonToTheBack(actionButtonList)
+            : actionButtonList;
+
+        if (isMobile) {
+            buttonsToRender = buttonsToRender.filter(
+                (item) => !item.uncollapsible
+            );
+        }
 
         return buttonsToRender.map((actionButton, index) => {
             let component: JSX.Element;
@@ -176,7 +187,10 @@ export const NavbarActionButtons = ({
 
             if (component) {
                 return (
-                    <ButtonItem key={`action-button-${index + 1}`}>
+                    <ButtonItem
+                        key={`action-button-${index + 1}`}
+                        $mobile={isMobile}
+                    >
                         {component}
                     </ButtonItem>
                 );
@@ -184,9 +198,25 @@ export const NavbarActionButtons = ({
         });
     };
 
+    const renderUncollapsableButtons = () => {
+        const uncollapsableActionButtons = actionButtons.filter(
+            (actionButton) => !!actionButton.uncollapsible
+        );
+        return (
+            <UncollapsableWrapper>
+                {renderButtons(false, uncollapsableActionButtons)}
+            </UncollapsableWrapper>
+        );
+    };
+
     if (actionButtons && actionButtons.length > 0) {
         const ContentWrapper = mobile ? MobileWrapper : Wrapper;
-        return <ContentWrapper>{renderButtons(mobile)}</ContentWrapper>;
+        return (
+            <>
+                {!mobile && renderUncollapsableButtons()}
+                <ContentWrapper>{renderButtons(mobile)}</ContentWrapper>
+            </>
+        );
     }
 
     return <></>;

--- a/src/navbar/navbar-action-buttons.tsx
+++ b/src/navbar/navbar-action-buttons.tsx
@@ -12,7 +12,11 @@ import {
     MobileWrapper,
     Wrapper,
 } from "./navbar-action-buttons.styles";
-import { NavbarButtonComponentProps, NavbarButtonProps } from "./types";
+import {
+    NavbarActionButtonsProps,
+    NavbarButtonComponentProps,
+    NavbarButtonProps,
+} from "./types";
 
 const APP_STORE_ICON =
     "https://assets.life.gov.sg/react-design-system/img/download/apple-app-store.png";
@@ -20,7 +24,7 @@ const PLAY_STORE_ICON =
     "https://assets.life.gov.sg/react-design-system/img/download/google-play-store.png";
 
 interface Props {
-    actionButtons?: NavbarButtonProps[] | undefined;
+    actionButtons?: NavbarActionButtonsProps | undefined;
     /** toggle for mobile or desktop view */
     mobile?: boolean | undefined;
     onActionButtonClick: (
@@ -192,11 +196,12 @@ export const NavbarActionButtons = ({
         });
     };
 
-    if (actionButtons && actionButtons.length > 0) {
-        const uncollapsableActionButtons = actionButtons.filter(
+    if (actionButtons && actionButtons.desktop.length > 0) {
+        const actionButtonList = actionButtons?.mobile || actionButtons.desktop;
+        const uncollapsableActionButtons = actionButtonList.filter(
             (actionButton) => !!actionButton.uncollapsible
         );
-        const collapsableActionButtons = actionButtons.filter(
+        const collapsableActionButtons = actionButtonList.filter(
             (actionButton) => !actionButton.uncollapsible
         );
         if (mobile) {
@@ -211,7 +216,9 @@ export const NavbarActionButtons = ({
                     <MobileWrapper>
                         {renderButtons(false, uncollapsableActionButtons)}
                     </MobileWrapper>
-                    <Wrapper>{renderButtons(mobile, actionButtons)}</Wrapper>
+                    <Wrapper>
+                        {renderButtons(mobile, actionButtons.desktop)}
+                    </Wrapper>
                 </>
             );
         }

--- a/src/navbar/navbar-action-buttons.tsx
+++ b/src/navbar/navbar-action-buttons.tsx
@@ -196,33 +196,37 @@ export const NavbarActionButtons = ({
         });
     };
 
-    if (actionButtons && actionButtons.desktop.length > 0) {
-        const actionButtonList = actionButtons?.mobile || actionButtons.desktop;
-        const uncollapsableActionButtons = actionButtonList.filter(
-            (actionButton) => !!actionButton.uncollapsible
+    const actionButtonList = actionButtons?.mobile || actionButtons.desktop;
+    const uncollapsableActionButtons = actionButtonList.filter(
+        (actionButton) => !!actionButton.uncollapsible
+    );
+    const collapsableActionButtons = actionButtonList.filter(
+        (actionButton) => !actionButton.uncollapsible
+    );
+    if (mobile) {
+        return (
+            <>
+                {collapsableActionButtons.length > 0 && (
+                    <DrawerWrapper>
+                        {renderButtons(mobile, collapsableActionButtons)}
+                    </DrawerWrapper>
+                )}
+            </>
         );
-        const collapsableActionButtons = actionButtonList.filter(
-            (actionButton) => !actionButton.uncollapsible
-        );
-        if (mobile) {
-            return (
-                <DrawerWrapper>
-                    {renderButtons(mobile, collapsableActionButtons)}
-                </DrawerWrapper>
-            );
-        } else {
-            return (
-                <>
+    } else {
+        return (
+            <>
+                {uncollapsableActionButtons.length > 0 && (
                     <MobileWrapper>
                         {renderButtons(false, uncollapsableActionButtons)}
                     </MobileWrapper>
+                )}
+                {actionButtons.desktop.length > 0 && (
                     <Wrapper>
                         {renderButtons(mobile, actionButtons.desktop)}
                     </Wrapper>
-                </>
-            );
-        }
+                )}
+            </>
+        );
     }
-
-    return <></>;
 };

--- a/src/navbar/navbar-action-buttons.tsx
+++ b/src/navbar/navbar-action-buttons.tsx
@@ -121,22 +121,16 @@ export const NavbarActionButtons = ({
     };
 
     const renderButtons = (
-        isMobile = false,
-        actionButtonList = actionButtons
+        isMobile: boolean,
+        actionButtonList: NavbarButtonProps[]
     ) => {
         /**
          * In drawer view, download app button will always be at
          * the bottom, hence we will shift it to the back
          */
-        let buttonsToRender = isMobile
+        const buttonsToRender = isMobile
             ? moveDownloadButtonToTheBack(actionButtonList)
             : actionButtonList;
-
-        if (isMobile) {
-            buttonsToRender = buttonsToRender.filter(
-                (item) => !item.uncollapsible
-            );
-        }
 
         return buttonsToRender.map((actionButton, index) => {
             let component: JSX.Element;
@@ -202,15 +196,22 @@ export const NavbarActionButtons = ({
         const uncollapsableActionButtons = actionButtons.filter(
             (actionButton) => !!actionButton.uncollapsible
         );
+        const collapsableActionButtons = actionButtons.filter(
+            (actionButton) => !actionButton.uncollapsible
+        );
         if (mobile) {
-            return <DrawerWrapper>{renderButtons(mobile)}</DrawerWrapper>;
+            return (
+                <DrawerWrapper>
+                    {renderButtons(mobile, collapsableActionButtons)}
+                </DrawerWrapper>
+            );
         } else {
             return (
                 <>
                     <MobileWrapper>
                         {renderButtons(false, uncollapsableActionButtons)}
                     </MobileWrapper>
-                    <Wrapper>{renderButtons(mobile)}</Wrapper>
+                    <Wrapper>{renderButtons(mobile, actionButtons)}</Wrapper>
                 </>
             );
         }

--- a/src/navbar/navbar.tsx
+++ b/src/navbar/navbar.tsx
@@ -225,7 +225,9 @@ const Component = <T,>(
                             />
                             <NavbarActionButtons
                                 actionButtons={
-                                    actionButtons && actionButtons.desktop
+                                    actionButtons &&
+                                    (actionButtons?.mobile ||
+                                        actionButtons.desktop)
                                 }
                                 onActionButtonClick={handleActionButtonClick}
                             />

--- a/src/navbar/navbar.tsx
+++ b/src/navbar/navbar.tsx
@@ -176,10 +176,7 @@ const Component = <T,>(
                     mobile
                 />
                 <NavbarActionButtons
-                    actionButtons={
-                        actionButtons &&
-                        (actionButtons?.mobile || actionButtons.desktop)
-                    }
+                    actionButtons={actionButtons}
                     onActionButtonClick={handleActionButtonClick}
                     mobile
                 />
@@ -224,11 +221,7 @@ const Component = <T,>(
                                 selectedId={selectedId}
                             />
                             <NavbarActionButtons
-                                actionButtons={
-                                    actionButtons &&
-                                    (actionButtons?.mobile ||
-                                        actionButtons.desktop)
-                                }
+                                actionButtons={actionButtons}
                                 onActionButtonClick={handleActionButtonClick}
                             />
                             <MobileMenuButton

--- a/src/navbar/types.ts
+++ b/src/navbar/types.ts
@@ -31,6 +31,7 @@ export interface NavbarButtonComponentProps {
 export interface NavbarButtonProps {
     type: "download" | "button" | "component";
     args?: ButtonProps | NavbarButtonComponentProps | undefined;
+    uncollapsible?: boolean | undefined;
 }
 
 export interface NavbarActionButtonsProps {

--- a/stories/navbar/navbar.stories.mdx
+++ b/stories/navbar/navbar.stories.mdx
@@ -267,7 +267,7 @@ You can also choose to render a custom component of your choice as an action but
 
 <Heading3>Uncollapsible action buttons</Heading3>
 
-You can also choose to render action button as uncollapsible.
+You can set an action button to be uncollapsible, so it remains visible in the navigation bar on mobile viewports.
 
 <Canvas>
     <Story name="Uncollapsible action buttons">

--- a/stories/navbar/navbar.stories.mdx
+++ b/stories/navbar/navbar.stories.mdx
@@ -1,4 +1,5 @@
 import { GearIcon } from "@lifesg/react-icons/gear";
+import { InboxIcon } from "@lifesg/react-icons/inbox";
 import { Canvas, Meta, Story } from "@storybook/addon-docs";
 import { useState } from "react";
 import { IconButton } from "src/icon-button";
@@ -264,6 +265,57 @@ You can also choose to render a custom component of your choice as an action but
     </Story>
 </Canvas>
 
+<Heading3>Uncollapsible action buttons</Heading3>
+
+You can also choose to render action button as uncollapsible.
+
+<Canvas>
+    <Story name="Uncollapsible action buttons">
+        <Navbar
+            items={{
+                desktop: [
+                    {
+                        id: "home",
+                        children: "Home",
+                        href: "https://www.life.gov.sg",
+                        target: "_blank",
+                    },
+                    {
+                        id: "guides",
+                        children: "Guides",
+                        href: "https://www.life.gov.sg",
+                    },
+                    {
+                        id: "lifesg-app",
+                        children: "LifeSG app",
+                        href: "https://www.life.gov.sg",
+                    },
+                ],
+            }}
+            actionButtons={{
+                desktop: [
+                    {
+                        type: "component",
+                        args: {
+                            render: (
+                                <InboxIcon
+                                    style={{
+                                        width: "1.25rem",
+                                        height: "1.25rem",
+                                    }}
+                                />
+                            ),
+                        },
+                        uncollapsible: true,
+                    },
+                ],
+            }}
+            selectedId="home"
+            fixed={false} /* For storybook purposes */
+        />
+    </Story>
+</Canvas>
+
 <Heading3>Prevent dismissal of drawer on specific actions</Heading3>
 
 In this example, we are preventing the drawer's dismissal on the brand logo click. We'll make use of
@@ -440,20 +492,6 @@ In this example, a co-brand is displayed next to the primary brand.
             }}
             actionButtons={{
                 desktop: [
-                    {
-                        type: "button",
-                        args: {
-                            styleType: "link",
-                            children: "FAQ",
-                        },
-                    },
-                    {
-                        type: "button",
-                        args: {
-                            styleType: "secondary",
-                            children: "Logout",
-                        },
-                    },
                     {
                         type: "download",
                     },

--- a/stories/navbar/props-table.tsx
+++ b/stories/navbar/props-table.tsx
@@ -266,6 +266,12 @@ const DATA: ApiTableSectionProps[] = [
                     </>
                 ),
             },
+            {
+                name: "uncollapsible",
+                description:
+                    "Specifies if the action button should collapse in mobile viewports",
+                propTypes: ["boolean"],
+            },
         ],
     },
     {


### PR DESCRIPTION
**Changes**
Add uncollapsible props to navbar action button

- [delete] branch

**Changelog entry**

-  Description of change in `Navbar`
- Add uncollapsible props to navbar action button
- if uncollapsible is true. it will always be visible across the viewport and will not be collapse to the drawer.

**Additional information**

- You may refer to this [BOOKINGSG-4514](https://jira.ship.gov.sg/browse/BOOKINGSG-4514)
- Figma reference: [link](https://www.figma.com/file/UUg9P4nOScnJXfrA2By2aw/Facilities-%E2%80%94-Admin-Portal?type=design&node-id=6178-248501&mode=design&t=nhfcQgLYnfO0C9FB-0 )
