### PR TITLE
[BOOKINGSG-4350][WK] fix flat option error if it is  fisrt item on th…

### DIFF
--- a/src/shared/nested-dropdown-list/nested-dropdown-list-helper.ts
+++ b/src/shared/nested-dropdown-list/nested-dropdown-list-helper.ts
@@ -81,11 +81,18 @@ export namespace NestedDropdownListHelper {
 const getInitialSubItem = <V1, V2, V3>(
     list: Map<string, CombinedFormattedOptionProps<V1, V2, V3>> | undefined
 ): string[] => {
+    let targetItem = null;
     for (const item of list.values()) {
         if (item.subItems && item.subItems.size) {
-            const [firstItemKey] = item.subItems.keys();
-            return item.subItems.get(firstItemKey).keyPath;
+            targetItem = item;
+            break;
         }
-        getInitialSubItem(item.subItems);
     }
+
+    if (!targetItem) {
+        const value = list.values().next().value;
+        return value.keyPath.slice(0, -1);
+    }
+
+    return getInitialSubItem(targetItem.subItems);
 };

--- a/src/shared/nested-dropdown-list/nested-dropdown-list-helper.ts
+++ b/src/shared/nested-dropdown-list/nested-dropdown-list-helper.ts
@@ -15,7 +15,6 @@ export namespace NestedDropdownListHelper {
 
         if (!keyPath || !keyPath.length) {
             keyPath = getInitialSubItem(currentItems);
-            console.log("keyPath: ", keyPath);
         }
 
         const list = produce(

--- a/src/shared/nested-dropdown-list/nested-dropdown-list-helper.ts
+++ b/src/shared/nested-dropdown-list/nested-dropdown-list-helper.ts
@@ -15,6 +15,7 @@ export namespace NestedDropdownListHelper {
 
         if (!keyPath || !keyPath.length) {
             keyPath = getInitialSubItem(currentItems);
+            keyPath = keyPath.slice(0, -1);
         }
 
         const list = produce(
@@ -88,5 +89,5 @@ const getInitialSubItem = <V1, V2, V3>(
     }
 
     const value = list.values().next().value;
-    return value.keyPath.slice(0, -1);
+    return value.keyPath;
 };

--- a/src/shared/nested-dropdown-list/nested-dropdown-list-helper.ts
+++ b/src/shared/nested-dropdown-list/nested-dropdown-list-helper.ts
@@ -15,6 +15,7 @@ export namespace NestedDropdownListHelper {
 
         if (!keyPath || !keyPath.length) {
             keyPath = getInitialSubItem(currentItems);
+            console.log("keyPath: ", keyPath);
         }
 
         const list = produce(
@@ -81,18 +82,12 @@ export namespace NestedDropdownListHelper {
 const getInitialSubItem = <V1, V2, V3>(
     list: Map<string, CombinedFormattedOptionProps<V1, V2, V3>> | undefined
 ): string[] => {
-    let targetItem = null;
     for (const item of list.values()) {
         if (item.subItems && item.subItems.size) {
-            targetItem = item;
-            break;
+            return getInitialSubItem(item.subItems);
         }
     }
 
-    if (!targetItem) {
-        const value = list.values().next().value;
-        return value.keyPath.slice(0, -1);
-    }
-
-    return getInitialSubItem(targetItem.subItems);
+    const value = list.values().next().value;
+    return value.keyPath.slice(0, -1);
 };


### PR DESCRIPTION
**Changes**
Description of changes...
1. Fix error when flat option in first item list on the root
2. Should expanded the first subItems list 


```
// should not cause error if the flat option in root level
// should expanded first subItems list item. That is ["999", "822"]
export const options = [
    {
        label: "Option 1",
        value: { id: 200, name: "Option 1" },
        key: "200",
    },
    {
        label: "Category 1",
        value: { id: 999, name: "category 1" },
        key: "999",
        subItems: [
            {
                label: "Sub Category A",
                value: {
                    id: 820,
                    name: "Sub category a",
                },
                key: "820",
            },
            {
                label: "Sub Category B",
                value: { id: 821, name: "Sub category b" },
                key: "821",
            },
            {
                label: "Sub Category C",
                value: {
                    id: 822,
                    name: "Sub category c",
                },
                key: "822",
                subItems: [
                    {
                        label: "Honey",
                        value: {
                            id: 104,
                            name: "honey",
                        },
                        key: "104",
                    },
                ],
            },
        ],
    },
];

```

- [delete] branch