### PR TITLE
[Enhancement] Toast to make it sticky

### DIFF
--- a/src/toast/toast.styles.tsx
+++ b/src/toast/toast.styles.tsx
@@ -1,4 +1,3 @@
-import { CrossIcon } from "@lifesg/react-icons/cross";
 import { animated } from "react-spring";
 import { ValidationElementAttributes } from "src/color";
 import { PropertiesToType } from "src/util/utility-types";
@@ -58,7 +57,7 @@ export const Wrapper = styled(animated.div)<StyleProps>`
             background: ${getValidationColorAttributes(props).Background};
             border: 1px solid ${getValidationColorAttributes(props).Border};
             color: ${getValidationColorAttributes(props).Text};
-            svg {
+            & > svg {
                 width: 1.5rem;
                 height: 1.5rem;
                 margin-right: 0.5rem;
@@ -97,17 +96,15 @@ export const Description = styled.div<StyleProps>`
     }}
 `;
 
-export const CloseIcon = styled(CrossIcon)`
-    margin: 0 !important;
-`;
-
 export const DismissButton = styled(ClickableIcon)<StyleProps>`
-    padding: 0 !important;
-    height: max-content;
+    padding: 0.75rem;
+    margin: -0.75rem;
 
     ${(props) => {
         return css`
             svg {
+                width: 1.5rem;
+                height: 1.5rem;
                 color: ${getValidationColorAttributes(props).Text};
             }
             :hover {

--- a/src/toast/toast.styles.tsx
+++ b/src/toast/toast.styles.tsx
@@ -13,7 +13,7 @@ import { ToastType } from "./types";
 //=============================================================================
 interface StyleProps {
     $type: ToastType;
-    $sticky?: boolean | undefined;
+    $fixed?: boolean | undefined;
 }
 
 const getValidationColorAttributes = (
@@ -38,8 +38,8 @@ const getValidationColorAttributes = (
 // =============================================================================
 export const Wrapper = styled(animated.div)<StyleProps>`
     display: flex;
-    position: ${(props) => (props.$sticky ? "fixed" : "relative")};
-    margin: ${(props) => (props.$sticky ? "1rem" : 0)};
+    position: ${(props) => (props.$fixed ? "fixed" : "relative")};
+    margin: ${(props) => (props.$fixed ? "1rem" : 0)};
     top: 0;
     padding: 1rem;
     border-radius: 0.5rem;

--- a/src/toast/toast.styles.tsx
+++ b/src/toast/toast.styles.tsx
@@ -7,6 +7,7 @@ import { Color } from "../color/color";
 import { ClickableIcon } from "../shared/clickable-icon";
 import { Text } from "../text";
 import { ToastType } from "./types";
+import { MediaQuery } from "../media";
 
 //=============================================================================
 // STYLE INTERFACE
@@ -38,13 +39,19 @@ const getValidationColorAttributes = (
 // =============================================================================
 export const Wrapper = styled(animated.div)<StyleProps>`
     display: flex;
+
     position: ${(props) => (props.$fixed ? "fixed" : "relative")};
     margin: ${(props) => (props.$fixed ? "1rem" : 0)};
     top: 0;
+    right: 0;
     padding: 1rem;
     border-radius: 0.5rem;
     line-height: 0;
     z-index: 10;
+
+    ${MediaQuery.MaxWidth.tablet} {
+        left: 0;
+    }
 
     ${(props) => {
         return css`
@@ -64,7 +71,6 @@ export const Wrapper = styled(animated.div)<StyleProps>`
 export const TextContainer = styled.div`
     display: flex;
     flex-direction: column;
-    padding: 0 2rem 0 0;
     padding-right: 2rem;
     flex: 1;
 `;
@@ -92,21 +98,17 @@ export const Description = styled.div<StyleProps>`
 `;
 
 export const CloseIcon = styled(CrossIcon)`
-    margin-top: 0.2rem;
+    margin: 0 !important;
 `;
 
 export const DismissButton = styled(ClickableIcon)<StyleProps>`
-    padding-top: 0px;
-    padding-bottom: 0px;
-    margin-left: 5px;
-    margin-right: -1rem;
+    padding: 0 !important;
     height: max-content;
 
     ${(props) => {
         return css`
             svg {
                 color: ${getValidationColorAttributes(props).Text};
-                margin-right: -0.5rem !important;
             }
             :hover {
                 background: transparent;

--- a/src/toast/toast.styles.tsx
+++ b/src/toast/toast.styles.tsx
@@ -13,6 +13,7 @@ import { ToastType } from "./types";
 //=============================================================================
 interface StyleProps {
     $type: ToastType;
+    $sticky?: boolean;
 }
 
 const getValidationColorAttributes = (
@@ -37,7 +38,9 @@ const getValidationColorAttributes = (
 // =============================================================================
 export const Wrapper = styled(animated.div)<StyleProps>`
     display: flex;
-    position: relative;
+    position: ${(props) => (props.$sticky ? "fixed" : "relative")};
+    top: 0;
+    right: 0;
     padding: 1rem;
     border-radius: 0.5rem;
     line-height: 0;

--- a/src/toast/toast.styles.tsx
+++ b/src/toast/toast.styles.tsx
@@ -39,8 +39,8 @@ const getValidationColorAttributes = (
 export const Wrapper = styled(animated.div)<StyleProps>`
     display: flex;
     position: ${(props) => (props.$sticky ? "fixed" : "relative")};
+    margin: ${(props) => (props.$sticky ? "1rem" : 0)};
     top: 0;
-    right: 0;
     padding: 1rem;
     border-radius: 0.5rem;
     line-height: 0;

--- a/src/toast/toast.styles.tsx
+++ b/src/toast/toast.styles.tsx
@@ -13,7 +13,7 @@ import { ToastType } from "./types";
 //=============================================================================
 interface StyleProps {
     $type: ToastType;
-    $sticky?: boolean;
+    $sticky?: boolean | undefined;
 }
 
 const getValidationColorAttributes = (

--- a/src/toast/toast.tsx
+++ b/src/toast/toast.tsx
@@ -28,6 +28,7 @@ export const Toast = ({
     autoDismiss,
     autoDismissTime = DEFAULT_AUTO_DISMISS_TIME,
     onDismiss,
+    sticky = true,
     ...otherProps
 }: ToastProps) => {
     // =============================================================================
@@ -102,7 +103,12 @@ export const Toast = ({
     };
 
     return (
-        <Wrapper style={transitions} $type={type} {...otherProps}>
+        <Wrapper
+            style={transitions}
+            $type={type}
+            $sticky={sticky}
+            {...otherProps}
+        >
             {renderIcon()}
             <TextContainer>
                 {title && (

--- a/src/toast/toast.tsx
+++ b/src/toast/toast.tsx
@@ -28,7 +28,7 @@ export const Toast = ({
     autoDismiss,
     autoDismissTime = DEFAULT_AUTO_DISMISS_TIME,
     onDismiss,
-    sticky = true,
+    fixed = true,
     ...otherProps
 }: ToastProps) => {
     // =============================================================================
@@ -107,7 +107,7 @@ export const Toast = ({
         <Wrapper
             style={transitions}
             $type={type}
-            $sticky={sticky}
+            $fixed={fixed}
             {...otherProps}
         >
             {renderIcon()}

--- a/src/toast/toast.tsx
+++ b/src/toast/toast.tsx
@@ -5,9 +5,7 @@ import {
     TickCircleFillIcon,
 } from "@lifesg/react-icons";
 import React, { useEffect, useState } from "react";
-import { useMediaQuery } from "react-responsive";
 import { easings, useSpring } from "react-spring";
-import { MediaWidths } from "../spec/media-spec";
 import { Text } from "../text";
 import {
     CloseIcon,
@@ -34,11 +32,8 @@ export const Toast = ({
     // =============================================================================
     // CONST, STATE
     // =============================================================================
-    const [isVisible, setVisible] = useState<boolean>(false);
-    const isMobile = useMediaQuery({
-        maxWidth: MediaWidths.mobileL,
-    });
 
+    const [isVisible, setVisible] = useState<boolean>(false);
     // =============================================================================
     // EFFECTS
     // =============================================================================
@@ -68,13 +63,7 @@ export const Toast = ({
     // =============================================================================
     const transitions = useSpring({
         opacity: isVisible ? 1 : 0,
-        transform: isVisible
-            ? isMobile
-                ? `translateY(0%)`
-                : `translateX(0%)`
-            : isMobile
-            ? `translateY(-1500%)`
-            : `translateX(150%)`,
+        transform: (isVisible && `translateY(0%)`) || `translateY(-1500%)`,
         config: {
             easing: easings.easeInOutQuart,
             duration: 1000,

--- a/src/toast/toast.tsx
+++ b/src/toast/toast.tsx
@@ -38,7 +38,7 @@ export const Toast = ({
     const [isVisible, setVisible] = useState<boolean>(false);
 
     const isMobile = useMediaQuery({
-        maxWidth: MediaWidths.mobileL,
+        maxWidth: MediaWidths.tablet,
     });
     // =============================================================================
     // EFFECTS

--- a/src/toast/toast.tsx
+++ b/src/toast/toast.tsx
@@ -4,8 +4,10 @@ import {
     ICircleFillIcon,
     TickCircleFillIcon,
 } from "@lifesg/react-icons";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
+import { useMediaQuery } from "react-responsive";
 import { easings, useSpring } from "react-spring";
+import { MediaWidths } from "../spec/media-spec";
 import { Text } from "../text";
 import {
     CloseIcon,
@@ -34,6 +36,10 @@ export const Toast = ({
     // =============================================================================
 
     const [isVisible, setVisible] = useState<boolean>(false);
+
+    const isMobile = useMediaQuery({
+        maxWidth: MediaWidths.mobileL,
+    });
     // =============================================================================
     // EFFECTS
     // =============================================================================
@@ -63,7 +69,13 @@ export const Toast = ({
     // =============================================================================
     const transitions = useSpring({
         opacity: isVisible ? 1 : 0,
-        transform: (isVisible && `translateY(0%)`) || `translateY(-1500%)`,
+        transform: isVisible
+            ? isMobile
+                ? `translateY(0%)`
+                : `translateX(0%)`
+            : isMobile
+            ? `translateY(-1500%)`
+            : `translateX(150%)`,
         config: {
             easing: easings.easeInOutQuart,
             duration: 1000,

--- a/src/toast/toast.tsx
+++ b/src/toast/toast.tsx
@@ -1,4 +1,5 @@
 import {
+    CrossIcon,
     ExclamationCircleFillIcon,
     ExclamationTriangleFillIcon,
     ICircleFillIcon,
@@ -10,7 +11,6 @@ import { easings, useSpring } from "react-spring";
 import { MediaWidths } from "../spec/media-spec";
 import { Text } from "../text";
 import {
-    CloseIcon,
     Description,
     DismissButton,
     TextContainer,
@@ -128,7 +128,7 @@ export const Toast = ({
                 )}
             </TextContainer>
             <DismissButton $type={type} onClick={handleDismiss}>
-                <CloseIcon />
+                <CrossIcon />
             </DismissButton>
         </Wrapper>
     );

--- a/src/toast/types.ts
+++ b/src/toast/types.ts
@@ -16,5 +16,5 @@ export interface ToastProps extends React.HTMLAttributes<HTMLDivElement> {
     /** If given, the function will be called when the Toast is dismissed */
     onDismiss?: () => void;
     /** If specified, the Toast will remains sticky at the top of the page */
-    sticky?: boolean;
+    sticky?: boolean | undefined;
 }

--- a/src/toast/types.ts
+++ b/src/toast/types.ts
@@ -15,6 +15,6 @@ export interface ToastProps extends React.HTMLAttributes<HTMLDivElement> {
     autoDismissTime?: number | undefined;
     /** If given, the function will be called when the Toast is dismissed */
     onDismiss?: () => void;
-    /** If specified, the Toast will remains sticky at the top of the page */
-    sticky?: boolean | undefined;
+    /** Specifies if Toast should be fixed to left. Defaults to true */
+    fixed?: boolean | undefined;
 }

--- a/src/toast/types.ts
+++ b/src/toast/types.ts
@@ -16,5 +16,5 @@ export interface ToastProps extends React.HTMLAttributes<HTMLDivElement> {
     /** If given, the function will be called when the Toast is dismissed */
     onDismiss?: () => void;
     /** If specified, the Toast will remains sticky at the top of the page */
-    sticky: boolean;
+    sticky?: boolean;
 }

--- a/src/toast/types.ts
+++ b/src/toast/types.ts
@@ -15,6 +15,6 @@ export interface ToastProps extends React.HTMLAttributes<HTMLDivElement> {
     autoDismissTime?: number | undefined;
     /** If given, the function will be called when the Toast is dismissed */
     onDismiss?: () => void;
-    /** Specifies if Toast should be fixed to left. Defaults to true */
+    /** Specifies if Toast should be fixed to top. Defaults to true */
     fixed?: boolean | undefined;
 }

--- a/src/toast/types.ts
+++ b/src/toast/types.ts
@@ -15,4 +15,6 @@ export interface ToastProps extends React.HTMLAttributes<HTMLDivElement> {
     autoDismissTime?: number | undefined;
     /** If given, the function will be called when the Toast is dismissed */
     onDismiss?: () => void;
+    /** If specified, the Toast will remains sticky at the top of the page */
+    sticky: boolean;
 }

--- a/stories/toast/doc-elements.tsx
+++ b/stories/toast/doc-elements.tsx
@@ -1,8 +1,0 @@
-import styled from "styled-components";
-import { Layout } from "../../src/layout";
-
-export const StyledContent = styled(Layout.Content)`
-    [data-id="container"] {
-        flex-direction: column;
-    }
-`;

--- a/stories/toast/doc-elements.tsx
+++ b/stories/toast/doc-elements.tsx
@@ -1,0 +1,8 @@
+import styled from "styled-components";
+import { Layout } from "../../src/layout";
+
+export const StyledContent = styled(Layout.Content)`
+    [data-id="container"] {
+        flex-direction: column;
+    }
+`;

--- a/stories/toast/props-table.tsx
+++ b/stories/toast/props-table.tsx
@@ -58,7 +58,7 @@ const DATA: ApiTableSectionProps[] = [
                 description: (
                     <>
                         Specifies if the <code>Toast</code> will be
-                        automatically dismissed after{" "}
+                        automatically dismissed after
                         <code>autoDismissTime</code>.
                     </>
                 ),
@@ -69,8 +69,8 @@ const DATA: ApiTableSectionProps[] = [
                 name: "autoDismissTime",
                 description: (
                     <>
-                        Time in milliseconds until the <code>Toast</code>{" "}
-                        automatically dismisses. Defaults to{" "}
+                        Time in milliseconds until the <code>Toast</code>
+                        automatically dismisses. Defaults to
                         <strong>4 seconds</strong>.
                     </>
                 ),

--- a/stories/toast/props-table.tsx
+++ b/stories/toast/props-table.tsx
@@ -58,7 +58,7 @@ const DATA: ApiTableSectionProps[] = [
                 description: (
                     <>
                         Specifies if the <code>Toast</code> will be
-                        automatically dismissed after
+                        automatically dismissed after{" "}
                         <code>autoDismissTime</code>.
                     </>
                 ),
@@ -69,8 +69,8 @@ const DATA: ApiTableSectionProps[] = [
                 name: "autoDismissTime",
                 description: (
                     <>
-                        Time in milliseconds until the <code>Toast</code>
-                        automatically dismisses. Defaults to
+                        Time in milliseconds until the <code>Toast</code>{" "}
+                        automatically dismisses. Defaults to{" "}
                         <strong>4 seconds</strong>.
                     </>
                 ),
@@ -88,7 +88,7 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["() => void"],
             },
             {
-                name: "sticky",
+                name: "fixed",
                 description: (
                     <>
                         Specifies if the <code>Toast</code> is to remain

--- a/stories/toast/props-table.tsx
+++ b/stories/toast/props-table.tsx
@@ -58,7 +58,8 @@ const DATA: ApiTableSectionProps[] = [
                 description: (
                     <>
                         Specifies if the <code>Toast</code> will be
-                        automatically dismissed after <code>autoDismissTime</code>.
+                        automatically dismissed after{" "}
+                        <code>autoDismissTime</code>.
                     </>
                 ),
                 propTypes: ["boolean"],
@@ -85,6 +86,18 @@ const DATA: ApiTableSectionProps[] = [
                     </>
                 ),
                 propTypes: ["() => void"],
+            },
+            {
+                name: "sticky",
+                description: (
+                    <>
+                        Specifies if the <code>Toast</code> is to remain
+                        displayed at the top of the page even though a scroll
+                        has happened
+                    </>
+                ),
+                propTypes: ["boolean"],
+                defaultValue: "true",
             },
         ],
     },

--- a/stories/toast/toast.stories.mdx
+++ b/stories/toast/toast.stories.mdx
@@ -4,12 +4,12 @@ import { Toast } from "src/toast";
 import { Secondary, Heading3, Title } from "../storybook-common";
 import { Text } from "src/text";
 import { PropsTable } from "./props-table";
-import { Button } from "src/button/button.tsx";
+import { Button } from "src/button";
 
 <Meta
     title="Modules/Toast"
     component={Toast}
-    parameters={{ layout: "padded" }}
+    parameters={{ layout: "centered" }}
 />
 
 <Title>Toast</Title>
@@ -162,12 +162,14 @@ Toasts that remains sticky at the top of the page and provides the user of impor
                             Click to open
                         </Button.Default>
                     )}
-                    {isVisible && (
-                        <Toast
-                            type="success"
-                            label="Your bookings has been updated and received by the service provider."
-                        />
-                    )}
+                    <div style={{ display: "flex", justifyContent: "center" }}>
+                        {isVisible && (
+                            <Toast
+                                type="success"
+                                label="The template contains characters that cannot be updated. Please remove the characters and try again."
+                            />
+                        )}
+                    </div>
                 </div>
             );
         }}

--- a/stories/toast/toast.stories.mdx
+++ b/stories/toast/toast.stories.mdx
@@ -4,6 +4,8 @@ import { Toast } from "src/toast";
 import { Secondary, Heading3, Title } from "../storybook-common";
 import { Text } from "src/text";
 import { PropsTable } from "./props-table";
+import { StyledContent } from "./doc-elements";
+import { Button } from "src/button/button.tsx";
 
 <Meta
     title="Modules/Toast"
@@ -23,13 +25,29 @@ import { Toast } from "@lifesg/react-design-system/toast";
 
 <Canvas>
     <Story name="Toast">
-        <Toast type="success" label="This is a success toast message" />
+        <Toast
+            type="success"
+            label="This is a success toast message"
+            sticky={false}
+        />
         <br />
-        <Toast type="warning" label="This is a warning toast message" />
+        <Toast
+            type="warning"
+            label="This is a warning toast message"
+            sticky={false}
+        />
         <br />
-        <Toast type="error" label="This is an error toast message" />
+        <Toast
+            type="error"
+            label="This is an error toast message"
+            sticky={false}
+        />
         <br />
-        <Toast type="info" label="This is an info toast message" />
+        <Toast
+            type="info"
+            label="This is an info toast message"
+            sticky={false}
+        />
     </Story>
 </Canvas>
 
@@ -40,12 +58,14 @@ import { Toast } from "@lifesg/react-design-system/toast";
         <Toast
             type="success"
             label="Your bookings has been updated and received by the service provider."
+            sticky={false}
         />
         <br />
         <Toast
             type="success"
             title="Template successfully updated"
             label="Your bookings has been updated and received by the service provider."
+            sticky={false}
         />
         <br />
         <br />
@@ -53,6 +73,7 @@ import { Toast } from "@lifesg/react-design-system/toast";
             type="warning"
             label="The template contains characters that cannot be updated. Please
                 remove the characters and try again."
+            sticky={false}
         />
         <br />
         <Toast
@@ -60,6 +81,7 @@ import { Toast } from "@lifesg/react-design-system/toast";
             title="Unknown characters"
             label="The template contains characters that cannot be updated. Please
                 remove the characters and try again."
+            sticky={false}
         />
         <br />
         <br />
@@ -67,6 +89,7 @@ import { Toast } from "@lifesg/react-design-system/toast";
             type="error"
             label="An internal system error had occured. Please log out and try
                 again."
+            sticky={false}
         />
         <br />
         <Toast
@@ -74,6 +97,7 @@ import { Toast } from "@lifesg/react-design-system/toast";
             title="System error"
             label="An internal system error had occured. Please log out and try
                 again."
+            sticky={false}
         />
         <br />
         <br />
@@ -81,6 +105,7 @@ import { Toast } from "@lifesg/react-design-system/toast";
             type="info"
             label="The calendar will be automatically updated when you have done
                 editing the event information."
+            sticky={false}
         />
         <br />
         <Toast
@@ -88,6 +113,7 @@ import { Toast } from "@lifesg/react-design-system/toast";
             title="Updated automatically"
             label="The calendar will be automatically updated when you have done
                 editing the event information."
+            sticky={false}
         />
     </Story>
 </Canvas>
@@ -103,6 +129,7 @@ is **4 seconds** and you can specify using the `autoDismiss` property.
             type="success"
             label="Your bookings has been updated and received by the service provider."
             autoDismiss
+            sticky={false}
         />
         <br />
         <Toast
@@ -110,7 +137,41 @@ is **4 seconds** and you can specify using the `autoDismiss` property.
             label="This toast has a custom auto dismiss time of 8 seconds."
             autoDismiss
             autoDismissTime={8000}
+            sticky={false}
         />
+    </Story>
+</Canvas>
+
+<Heading3>Toast Sticky</Heading3>
+
+Toasts that remains sticky at the top of the page and provides the user of important notification.
+
+<Canvas>
+    <Story name="Toast sticky">
+        {() => {
+            const [isVisible, setIsVisible] = useState(false);
+            const openToast = () => setIsVisible(true);
+            const closeToast = () => setIsVisible(false);
+            return (
+                <div>
+                    {isVisible ? (
+                        <Button.Default onClick={closeToast}>
+                            Click to close
+                        </Button.Default>
+                    ) : (
+                        <Button.Default onClick={openToast}>
+                            Click to open
+                        </Button.Default>
+                    )}
+                    {isVisible && (
+                        <Toast
+                            type="success"
+                            label="Your bookings has been updated and received by the service provider."
+                        />
+                    )}
+                </div>
+            );
+        }}
     </Story>
 </Canvas>
 

--- a/stories/toast/toast.stories.mdx
+++ b/stories/toast/toast.stories.mdx
@@ -27,25 +27,25 @@ import { Toast } from "@lifesg/react-design-system/toast";
         <Toast
             type="success"
             label="This is a success toast message"
-            sticky={false}
+            fixed={false}
         />
         <br />
         <Toast
             type="warning"
             label="This is a warning toast message"
-            sticky={false}
+            fixed={false}
         />
         <br />
         <Toast
             type="error"
             label="This is an error toast message"
-            sticky={false}
+            fixed={false}
         />
         <br />
         <Toast
             type="info"
             label="This is an info toast message"
-            sticky={false}
+            fixed={false}
         />
     </Story>
 </Canvas>
@@ -57,14 +57,14 @@ import { Toast } from "@lifesg/react-design-system/toast";
         <Toast
             type="success"
             label="Your bookings has been updated and received by the service provider."
-            sticky={false}
+            fixed={false}
         />
         <br />
         <Toast
             type="success"
             title="Template successfully updated"
             label="Your bookings has been updated and received by the service provider."
-            sticky={false}
+            fixed={false}
         />
         <br />
         <br />
@@ -72,7 +72,7 @@ import { Toast } from "@lifesg/react-design-system/toast";
             type="warning"
             label="The template contains characters that cannot be updated. Please
                 remove the characters and try again."
-            sticky={false}
+            fixed={false}
         />
         <br />
         <Toast
@@ -80,7 +80,7 @@ import { Toast } from "@lifesg/react-design-system/toast";
             title="Unknown characters"
             label="The template contains characters that cannot be updated. Please
                 remove the characters and try again."
-            sticky={false}
+            fixed={false}
         />
         <br />
         <br />
@@ -88,7 +88,7 @@ import { Toast } from "@lifesg/react-design-system/toast";
             type="error"
             label="An internal system error had occured. Please log out and try
                 again."
-            sticky={false}
+            fixed={false}
         />
         <br />
         <Toast
@@ -96,7 +96,7 @@ import { Toast } from "@lifesg/react-design-system/toast";
             title="System error"
             label="An internal system error had occured. Please log out and try
                 again."
-            sticky={false}
+            fixed={false}
         />
         <br />
         <br />
@@ -104,7 +104,7 @@ import { Toast } from "@lifesg/react-design-system/toast";
             type="info"
             label="The calendar will be automatically updated when you have done
                 editing the event information."
-            sticky={false}
+            fixed={false}
         />
         <br />
         <Toast
@@ -112,7 +112,7 @@ import { Toast } from "@lifesg/react-design-system/toast";
             title="Updated automatically"
             label="The calendar will be automatically updated when you have done
                 editing the event information."
-            sticky={false}
+            fixed={false}
         />
     </Story>
 </Canvas>
@@ -128,7 +128,7 @@ is **4 seconds** and you can specify using the `autoDismiss` property.
             type="success"
             label="Your bookings has been updated and received by the service provider."
             autoDismiss
-            sticky={false}
+            fixed={false}
         />
         <br />
         <Toast
@@ -136,17 +136,17 @@ is **4 seconds** and you can specify using the `autoDismiss` property.
             label="This toast has a custom auto dismiss time of 8 seconds."
             autoDismiss
             autoDismissTime={8000}
-            sticky={false}
+            fixed={false}
         />
     </Story>
 </Canvas>
 
-<Heading3>Toast Sticky</Heading3>
+<Heading3>With position (fixed)</Heading3>
 
-Toasts that remains sticky at the top of the page and provides the user of important notification.
+Toasts that remains fixed at the top of the page and provides the user of important notification.
 
 <Canvas>
-    <Story name="Toast sticky">
+    <Story name="With position (fixed)">
         {() => {
             const [isVisible, setIsVisible] = useState(false);
             const openToast = () => setIsVisible(true);

--- a/stories/toast/toast.stories.mdx
+++ b/stories/toast/toast.stories.mdx
@@ -152,20 +152,22 @@ This example demonstrates the default positioning of the Toast. It remains fixed
             const openToast = () => setIsVisible(true);
             const closeToast = () => setIsVisible(false);
             return (
-                <div>
-                    {isVisible ? (
-                        <Button.Default onClick={closeToast}>
-                            Click to close
-                        </Button.Default>
-                    ) : (
-                        <Button.Default onClick={openToast}>
-                            Click to open
-                        </Button.Default>
-                    )}
+                <>
+                    <div>
+                        {isVisible ? (
+                            <Button.Default onClick={closeToast}>
+                                Click to close
+                            </Button.Default>
+                        ) : (
+                            <Button.Default onClick={openToast}>
+                                Click to open
+                            </Button.Default>
+                        )}
+                    </div>
                     {isVisible && (
                         <Toast label="Notification" onDismiss={closeToast} />
                     )}
-                </div>
+                </>
             );
         }}
     </Story>

--- a/stories/toast/toast.stories.mdx
+++ b/stories/toast/toast.stories.mdx
@@ -141,12 +141,12 @@ is **4 seconds** and you can specify using the `autoDismiss` property.
     </Story>
 </Canvas>
 
-<Heading3>With position (fixed)</Heading3>
+<Heading3>Fixed positioning</Heading3>
 
-Toasts that remains fixed at the top of the page and provides the user of important notification.
+This example demonstrates the default positioning of the Toast. It remains fixed at the top while the page is scrolled.
 
 <Canvas>
-    <Story name="With position (fixed)">
+    <Story name="Fixed positioning">
         {() => {
             const [isVisible, setIsVisible] = useState(false);
             const openToast = () => setIsVisible(true);
@@ -162,14 +162,9 @@ Toasts that remains fixed at the top of the page and provides the user of import
                             Click to open
                         </Button.Default>
                     )}
-                    <div style={{ display: "flex", justifyContent: "center" }}>
-                        {isVisible && (
-                            <Toast
-                                type="success"
-                                label="The template contains characters that cannot be updated. Please remove the characters and try again."
-                            />
-                        )}
-                    </div>
+                    {isVisible && (
+                        <Toast label="Notification" onDismiss={closeToast} />
+                    )}
                 </div>
             );
         }}

--- a/stories/toast/toast.stories.mdx
+++ b/stories/toast/toast.stories.mdx
@@ -4,7 +4,6 @@ import { Toast } from "src/toast";
 import { Secondary, Heading3, Title } from "../storybook-common";
 import { Text } from "src/text";
 import { PropsTable } from "./props-table";
-import { StyledContent } from "./doc-elements";
 import { Button } from "src/button/button.tsx";
 
 <Meta


### PR DESCRIPTION
**Changes**
add variants of overlay + sticky


- [delete] branch

**Changelog entry**
- [WARNING] Make `Toast` a floating element by default. You may make it inline by passing `sticky={false}`
-  Update `Toast` animation for tablet view

**Additional information**

- You may refer to this [BOOKINGSG-4430](https://jira.ship.gov.sg/browse/BOOKINGSG-4430)
- Figma reference: [link](https://www.figma.com/file/us90jOpWBahsqK2VAluPvD/Flagship-Design-System?node-id=3061%3A19059&mode=dev)

**Labels**
[Enhancement]
