### PR TITLE
Minor aesthetic changes

### DIFF
--- a/src/form/form-label.style.tsx
+++ b/src/form/form-label.style.tsx
@@ -5,7 +5,6 @@ import { Text, TextStyleHelper } from "../text";
 // =============================================================================
 // STYLING
 // =============================================================================
-export const Label = styled.label<LabelProps>`
 export const Label = styled.label`
     ${TextStyleHelper.getTextStyle("H5", "semibold")}
     color: ${Color.Neutral[3]};

--- a/src/form/form-label.style.tsx
+++ b/src/form/form-label.style.tsx
@@ -3,18 +3,11 @@ import { Color } from "../color";
 import { Text, TextStyleHelper } from "../text";
 
 // =============================================================================
-// STYLE INTERFACE
-// =============================================================================
-interface LabelProps {
-    disabled?: boolean;
-}
-
-// =============================================================================
 // STYLING
 // =============================================================================
 export const Label = styled.label<LabelProps>`
+export const Label = styled.label`
     ${TextStyleHelper.getTextStyle("H5", "semibold")}
-
     color: ${Color.Neutral[3]};
     margin-bottom: 0.5rem;
     display: inline-block;

--- a/src/form/form-label.style.tsx
+++ b/src/form/form-label.style.tsx
@@ -15,8 +15,7 @@ interface LabelProps {
 export const Label = styled.label<LabelProps>`
     ${TextStyleHelper.getTextStyle("H5", "semibold")}
 
-    color: ${(props) =>
-        props.disabled ? Color.Neutral[4](props) : Color.Neutral[3](props)};
+    color: ${Color.Neutral[3]};
     margin-bottom: 0.5rem;
     display: inline-block;
 
@@ -37,6 +36,5 @@ export const ErrorMessage = styled(Text.H6)`
 `;
 
 export const Subtitle = styled(Text.BodySmall)<LabelProps>`
-    color: ${(props) =>
-        props.disabled ? Color.Neutral[4](props) : Color.Neutral[3](props)};
+    color: ${Color.Neutral[3]};
 `;

--- a/src/form/form-label.style.tsx
+++ b/src/form/form-label.style.tsx
@@ -27,6 +27,6 @@ export const ErrorMessage = styled(Text.H6)`
     outline: none;
 `;
 
-export const Subtitle = styled(Text.BodySmall)<LabelProps>`
+export const Subtitle = styled(Text.BodySmall)`
     color: ${Color.Neutral[3]};
 `;

--- a/src/modal/modal-box.styles.tsx
+++ b/src/modal/modal-box.styles.tsx
@@ -35,5 +35,5 @@ export const CloseButton = styled(ClickableIcon)`
 export const CloseIcon = styled(CrossIcon)`
     height: 1.5rem;
     width: 1.5rem;
-    color: ${Color.Neutral[4]};
+    color: ${Color.Neutral[3]};
 `;

--- a/src/spec/design-token-spec/base-design-token-set.ts
+++ b/src/spec/design-token-spec/base-design-token-set.ts
@@ -4,10 +4,10 @@ import { DesignTokenSet } from "../../design-token/types";
 
 export const BaseDesignTokenSet: DesignTokenSet = {
     InputBoxShadow: css`
-        inset 0 0 6px 1px ${Color.Shadow.Accent}
+        inset 0 0 4px 1px ${Color.Shadow.Accent}
     `,
     InputErrorBoxShadow: css`
-        inset 0 0 6px 1px ${Color.Shadow.Red}
+        inset 0 0 4px 1px ${Color.Shadow.Red}
     `,
     ElevationBoxShadow: css`
       0px 2px 8px ${Color.Shadow.Elevation}

--- a/src/spec/design-token-spec/base-design-token-set.ts
+++ b/src/spec/design-token-spec/base-design-token-set.ts
@@ -4,10 +4,10 @@ import { DesignTokenSet } from "../../design-token/types";
 
 export const BaseDesignTokenSet: DesignTokenSet = {
     InputBoxShadow: css`
-        inset 0 0 4px 1px ${Color.Shadow.Accent}
+        inset 0 0 3px 0px ${Color.Shadow.Accent}
     `,
     InputErrorBoxShadow: css`
-        inset 0 0 4px 1px ${Color.Shadow.Red}
+        inset 0 0 3px 0px ${Color.Shadow.Red}
     `,
     ElevationBoxShadow: css`
       0px 2px 8px ${Color.Shadow.Elevation}

--- a/src/spec/design-token-spec/rbs-design-token-set.ts
+++ b/src/spec/design-token-spec/rbs-design-token-set.ts
@@ -4,10 +4,10 @@ import { DesignTokenSet } from "../../design-token/types";
 
 export const RBSDesignTokenSet: DesignTokenSet = {
     InputBoxShadow: css`
-        inset 0 0 6px 1px ${Color.Shadow.Accent}
+        inset 0 0 3px 0px ${Color.Shadow.Accent}
     `,
     InputErrorBoxShadow: css`
-        inset 0 0 6px 1px ${Color.Shadow.Red}
+        inset 0 0 3px 0px ${Color.Shadow.Red}
     `,
     ElevationBoxShadow: css`
       0px 2px 8px ${Color.Shadow.Elevation}


### PR DESCRIPTION
**Changes**
1. Shadow (changed to look more like the ones in Figma): 
- Blur ppty: 3px instead of 6px
- Offset ppty: 0px instead of 1px

2. Colour of disabled Label for all Form input fields: 
- N3 instead of N4 (no need to switch colours if disabled)

3.  Colour of Close Icon for modal: 
- N3 instead of N4


Context for changes:
Designers were doing visual audit of the components and noticed some minor inconsistencies.