### PR TITLE
Minor style fix to Navbar

### DIFF
--- a/src/navbar/navbar.styles.tsx
+++ b/src/navbar/navbar.styles.tsx
@@ -27,7 +27,7 @@ interface StyleProps {
 // STYLING
 // =============================================================================
 export const Wrapper = styled.div<StyleProps>`
-    position: ${(props) => (props.$fixed ? "fixed" : "relative")};
+    position: ${(props) => (props.$fixed ? "sticky" : "relative")};
     background-color: white;
     z-index: 30;
     top: 0;


### PR DESCRIPTION
**Changes**
- Noticed that when we expand the Masthead, the main content does not get pushed down and it is due to the `fixed` style being set (`fixed` was a legacy implementation)
- Update to use `sticky` instead

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- **[BREAKING]** Update sticky style for fixed `Navbar`. This style will mean you will no longer need to add additional padding to your pages to deal with the Navbar's positioning.
