### PR TITLE
Resize navbar brand

### DIFF
--- a/src/navbar/brand.styles.tsx
+++ b/src/navbar/brand.styles.tsx
@@ -1,5 +1,4 @@
 import styled from "styled-components";
-import { MediaQuery } from "../media";
 import { Transition } from "../transition";
 import { BrandType } from "./types";
 
@@ -8,7 +7,6 @@ import { BrandType } from "./types";
 // See more https://styled-components.com/docs/api#transient-props
 // =============================================================================
 interface StyleProps {
-    $compress?: boolean | undefined;
     $type?: BrandType | undefined;
 }
 
@@ -18,22 +16,12 @@ interface StyleProps {
 export const Clickable = styled.a<StyleProps>`
     display: flex;
     justify-content: center;
+    height: 100%;
 
     img {
         width: auto;
-        height: ${(props) =>
-            props.$type === "primary"
-                ? props.$compress
-                    ? 1.25
-                    : 1.625
-                : props.$compress
-                ? 2
-                : 2.5}rem;
+        height: 100%;
         transition: ${Transition.Base};
         object-fit: contain;
-
-        ${MediaQuery.MaxWidth.tablet} {
-            height: ${(props) => (props.$type === "primary" ? 1 : 1.5)}rem;
-        }
     }
 `;

--- a/src/navbar/brand.tsx
+++ b/src/navbar/brand.tsx
@@ -6,6 +6,7 @@ import { ImageWithFallback } from "../shared/image-with-fallback/image-with-fall
 interface Props {
     resources: NavbarBrandingProps;
     compress?: boolean | undefined;
+    "data-id"?: string | undefined;
     "data-testid"?: string | undefined;
     type: BrandType;
     onClick?:
@@ -19,6 +20,7 @@ interface Props {
 export const Brand = ({
     resources,
     onClick,
+    "data-id": dataId,
     "data-testid": testId = "navbar-brand",
     type,
 }: Props) => {
@@ -37,6 +39,7 @@ export const Brand = ({
             aria-label={resources.brandName + "-app-home-page"}
             onClick={handleClick}
             tabIndex={0}
+            data-id={dataId}
             data-testid={testId}
             $type={type}
         >

--- a/src/navbar/brand.tsx
+++ b/src/navbar/brand.tsx
@@ -18,7 +18,6 @@ interface Props {
 
 export const Brand = ({
     resources,
-    compress,
     onClick,
     "data-testid": testId = "navbar-brand",
     type,
@@ -37,7 +36,6 @@ export const Brand = ({
             role="link"
             aria-label={resources.brandName + "-app-home-page"}
             onClick={handleClick}
-            $compress={compress}
             tabIndex={0}
             data-testid={testId}
             $type={type}

--- a/src/navbar/navbar.styles.tsx
+++ b/src/navbar/navbar.styles.tsx
@@ -82,23 +82,27 @@ export const MobileMenuIcon = styled(MenuIcon)`
     color: ${Color.Neutral[1]};
 `;
 
-export const NavBrandContainer = styled.div`
+export const NavBrandContainer = styled.div<StyleProps>`
     display: flex;
-    height: 100%;
     flex-direction: row;
     align-items: center;
     flex-shrink: 0;
+
+    height: ${(props) => (props.$compress ? 1.5 : 2)}rem;
+
+    ${MediaQuery.MaxWidth.tablet} {
+        height: 1.5rem;
+    }
 `;
 
 export const NavSeparator = styled.div<StyleProps>`
     display: flex;
     background-color: ${Color.Neutral[5]};
-    height: ${(props) => (props.$compress ? 2 : 2.5)}rem;
+    height: 100%;
     width: 1px;
     margin: 0 ${(props) => (props.$compress ? 1.125 : 1.5)}rem;
 
     ${MediaQuery.MaxWidth.tablet} {
-        height: 1.5rem;
         margin: 0 1rem;
     }
 `;

--- a/src/navbar/navbar.styles.tsx
+++ b/src/navbar/navbar.styles.tsx
@@ -100,7 +100,7 @@ export const NavSeparator = styled.div<StyleProps>`
     background-color: ${Color.Neutral[5]};
     height: 100%;
     width: 1px;
-    margin: 0 ${(props) => (props.$compress ? 1.125 : 1.5)}rem;
+    margin: 0 ${(props) => (props.$compress ? 1 : 1.5)}rem;
 
     ${MediaQuery.MaxWidth.tablet} {
         margin: 0 1rem;

--- a/src/navbar/navbar.tsx
+++ b/src/navbar/navbar.tsx
@@ -204,11 +204,11 @@ const Component = <T,>(
     );
 
     const renderBrand = () => (
-        <NavBrandContainer>
+        <NavBrandContainer $compress={compress} data-id="brand-container">
             <Brand
                 resources={primary}
-                compress={compress}
                 onClick={handleBrandClick}
+                data-id="brand-primary"
                 data-testid="main__brand"
                 type="primary"
             />
@@ -217,8 +217,8 @@ const Component = <T,>(
                     <NavSeparator $compress={compress} />
                     <Brand
                         resources={secondary}
-                        compress={compress}
                         onClick={handleBrandClick}
+                        data-id="brand-secondary"
                         data-testid="main__brand-secondary"
                         type="secondary"
                     />

--- a/src/navbar/navbar.tsx
+++ b/src/navbar/navbar.tsx
@@ -36,6 +36,7 @@ import {
 const Component = <T,>(
     {
         items,
+        className,
         id,
         selectedId,
         compress = false,
@@ -264,6 +265,7 @@ const Component = <T,>(
         <Wrapper
             ref={elementRef}
             $fixed={fixed}
+            className={className}
             id={id || "navbar-wrapper"}
             data-testid={otherProps["data-testid"] || "navbar-wrapper"}
         >

--- a/src/navbar/types.ts
+++ b/src/navbar/types.ts
@@ -92,6 +92,7 @@ export type NavbarDrawerHandle = HTMLDivElement & {
 
 export interface NavbarProps<T = void> extends NavbarSharedProps {
     items: NavItemsProps<T>;
+    className?: string | undefined;
     id?: string | undefined;
     "data-testid"?: string | undefined;
     selectedId?: string | undefined;


### PR DESCRIPTION
**Changes**
- Adjust brand logo heights in Navbar
  - desktop: 32px (uncollapsed), 24px (collapsed)
  - tablet/mobile: 24px
- Add `data-id` to support custom styling
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Resize brand logo in `Navbar` and support targeted styling for brand section