### PR TITLE
Enhance error display customisation

### DIFF
--- a/src/error-display/error-display.tsx
+++ b/src/error-display/error-display.tsx
@@ -17,6 +17,7 @@ export const ErrorDisplay = ({
     description,
     actionButton,
     additionalProps,
+    imageOnly,
     ...otherProps
 }: ErrorDisplayProps): JSX.Element => {
     // =============================================================================
@@ -99,7 +100,7 @@ export const ErrorDisplay = ({
     return (
         <Container {...otherProps} data-testid={testId}>
             <Img {...updatedAssets.img} alt="" data-id="error-display-image" />
-            {renderContentDisplay()}
+            {!imageOnly && renderContentDisplay()}
             {actionButton && renderActionButton()}
         </Container>
     );

--- a/src/error-display/error-display.tsx
+++ b/src/error-display/error-display.tsx
@@ -65,21 +65,41 @@ export const ErrorDisplay = ({
         ...(getCustomDescription() && { description: getCustomDescription() }),
     };
 
+    const renderContentDisplay = () => {
+        if (updatedAssets.title || updatedAssets.description) {
+            return (
+                <TextContainer>
+                    {updatedAssets.title && (
+                        <Title
+                            data-testid={`${testId}--title`}
+                            data-id="error-display-title"
+                        >
+                            {updatedAssets.title}
+                        </Title>
+                    )}
+                    {updatedAssets.description && (
+                        <DescriptionContainer
+                            data-testid={`${testId}--description`}
+                            data-id="error-display-description"
+                        >
+                            {typeof updatedAssets.description === "string" ? (
+                                <p>{updatedAssets.description}</p>
+                            ) : (
+                                updatedAssets.description
+                            )}
+                        </DescriptionContainer>
+                    )}
+                </TextContainer>
+            );
+        }
+
+        return null;
+    };
+
     return (
         <Container {...otherProps} data-testid={testId}>
-            <Img {...updatedAssets.img} alt="" />
-            <TextContainer>
-                <Title data-testid={`${testId}--title`}>
-                    {updatedAssets.title}
-                </Title>
-                <DescriptionContainer data-testid={`${testId}--description`}>
-                    {typeof updatedAssets.description === "string" ? (
-                        <p>{updatedAssets.description}</p>
-                    ) : (
-                        updatedAssets.description
-                    )}
-                </DescriptionContainer>
-            </TextContainer>
+            <Img {...updatedAssets.img} alt="" data-id="error-display-image" />
+            {renderContentDisplay()}
             {actionButton && renderActionButton()}
         </Container>
     );

--- a/src/error-display/types.ts
+++ b/src/error-display/types.ts
@@ -31,7 +31,10 @@ export interface ErrorDisplayAttributes {
     description?: string | JSX.Element | undefined;
     /** The action button displayed at the bottom of the Error Display */
     actionButton?: React.ButtonHTMLAttributes<HTMLButtonElement> | undefined;
+    /** Additional pre-specified props to control specific content  */
     additionalProps?: MaintenanceAdditionalAttributes | undefined;
+    /** Specifies if only the image is rendered */
+    imageOnly?: boolean | undefined;
 }
 
 export interface ErrorDisplayProps

--- a/stories/error-display/error-display.stories.mdx
+++ b/stories/error-display/error-display.stories.mdx
@@ -74,6 +74,26 @@ The `ErrorDisplay` component is customisable according to your project's needs. 
     </Story>
 </Canvas>
 
+If you require customisations down to the style, you can use the relevant `data-id` properties of each element.
+
+| Element     | Data id                       |
+| ----------- | ----------------------------- |
+| image       | `"error-display-image"`       |
+| title       | `"error-display-title"`       |
+| description | `"error-display-description"` |
+
+> **Note**: For the title and description, you will need to use the `!important` flag when modifying the size, line height and letter spacing
+
+```tsx
+// If you are using Styled Components
+
+export const CustomErrorDisplay = styled(ErrorDisplay)`
+    [data-id="error-display-image"] {
+        /* Your styles here */
+    }
+`;
+```
+
 <Secondary>Variants</Secondary>
 
 > **Note**: Switch to the Canvas tab and use the Controls add-on to view the different error types

--- a/stories/error-display/props-table.tsx
+++ b/stories/error-display/props-table.tsx
@@ -123,6 +123,12 @@ const DATA: ApiTableSectionProps[] = [
                 description: "Additional properties for certain error types",
                 propTypes: ["MaintenanceAdditionalAttributes"],
             },
+            {
+                name: "imageOnly",
+                description:
+                    "Specifying will allow only the image to be rendered",
+                propTypes: ["boolean"],
+            },
         ],
     },
     {

--- a/tests/error-display/error-display.spec.tsx
+++ b/tests/error-display/error-display.spec.tsx
@@ -41,6 +41,22 @@ describe("ErrorDisplay", () => {
         ).toBeInTheDocument();
     });
 
+    it("should not render any text content if the imageOnly prop is specified", () => {
+        render(
+            <ErrorDisplay
+                type="404"
+                title={CUSTOM_TITLE}
+                description={CUSTOM_DESCRIPTION}
+                imageOnly
+            />
+        );
+
+        expect(
+            screen.queryByRole("heading", { level: 1, name: CUSTOM_TITLE })
+        ).not.toBeInTheDocument();
+        expect(screen.queryByText(CUSTOM_DESCRIPTION)).not.toBeInTheDocument();
+    });
+
     describe("description", () => {
         it("should be able to render custom description", () => {
             render(


### PR DESCRIPTION
**Changes**
- Add data ids to the elements to allow modification via css or style inheritance
- Add `imageOnly` prop to render just the image. This will be useful if they want to construct their custom title and description entirely

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- `ErrorDisplay`
    - Add `data-id` property to the elements to enable easier targeting to modify styles
    - Add `imageOnly` prop to render just the image

**Additional information**

- You may refer to this [ticket](https://jira.ship.gov.sg/browse/CCUBE-393)
