### PR TITLE
Class name props

### DIFF
--- a/src/animations/loading-dots-spinner/loading-dots-spinner.tsx
+++ b/src/animations/loading-dots-spinner/loading-dots-spinner.tsx
@@ -6,14 +6,13 @@ import { LottieLoadingDotsSpinner } from "./lottie-animation";
 
 export const LoadingDotsSpinner = ({
     color,
-    id,
-    "data-testid": testId,
+    ...otherProps
 }: CustomisableAnimationProps) => {
     const theme = useTheme();
     const animationColor =
         color || Color.Primary({ theme: theme || BaseTheme });
     return (
-        <Container data-testid={testId} id={id}>
+        <Container {...otherProps}>
             <LottieLoadingDotsSpinner color={animationColor} />
         </Container>
     );

--- a/src/box-container/box-container.tsx
+++ b/src/box-container/box-container.tsx
@@ -24,7 +24,6 @@ export const BoxContainer = ({
     expanded = false,
     callToActionComponent,
     displayState = "default",
-    className,
     subComponentTestIds,
     ...otherProps
 }: BoxContainerProps) => {
@@ -92,10 +91,7 @@ export const BoxContainer = ({
     };
 
     return (
-        <Container
-            className={className}
-            data-testid={otherProps["data-testid"]}
-        >
+        <Container {...otherProps}>
             <Header data-testid="header">
                 <LabelText
                     id="title"

--- a/src/box-container/types.ts
+++ b/src/box-container/types.ts
@@ -16,4 +16,5 @@ export interface BoxContainerProps {
     className?: string | undefined;
     subComponentTestIds?: BoxContainerSubComponentTestIds | undefined;
     "data-testid"?: string | undefined;
+    id?: string | undefined;
 }

--- a/src/breadcrumb/types.ts
+++ b/src/breadcrumb/types.ts
@@ -10,6 +10,7 @@ export interface BreadcrumbProps {
     fadeColor?: string[] | FadeColorSet | undefined;
     fadePosition?: FadePosition | undefined;
     itemStyle?: string | undefined;
+    className?: string | undefined;
     id?: string | undefined;
     "data-testid"?: string | undefined;
 }

--- a/src/drawer/types.ts
+++ b/src/drawer/types.ts
@@ -1,6 +1,6 @@
 export interface DrawerProps {
     children?: React.ReactNode | undefined;
-    classname?: string | undefined;
+    className?: string | undefined;
     "data-testid"?: string | undefined;
     id?: string | undefined;
     /** The drawer header text */

--- a/src/error-display/types.ts
+++ b/src/error-display/types.ts
@@ -41,4 +41,5 @@ export interface ErrorDisplayProps
     extends React.HTMLAttributes<HTMLElement>,
         ErrorDisplayAttributes {
     type: ErrorDisplayType;
+    "data-testid"?: string | undefined;
 }

--- a/src/feedback-rating/feedback-rating.tsx
+++ b/src/feedback-rating/feedback-rating.tsx
@@ -18,16 +18,16 @@ export const FeedbackRating = (props: FeedbackRatingProps): JSX.Element => {
         buttonLabel,
         description,
         rating,
-        className,
         onRatingChange,
         onSubmit,
+        ...otherProps
     } = props;
     const bannerSrc = imgSrc ?? FeedbackRatingData.IMG;
     const componentDescription =
         description ?? FeedbackRatingData.DEFAULT_DESCRIPTION;
 
     return (
-        <MainContainer className={className}>
+        <MainContainer {...otherProps}>
             {bannerSrc && (
                 <Image
                     src={bannerSrc}

--- a/src/feedback-rating/types.ts
+++ b/src/feedback-rating/types.ts
@@ -3,6 +3,8 @@ export interface FeedbackRatingProps {
     description?: string | undefined;
     buttonLabel?: string | undefined;
     className?: string | undefined;
+    id?: string | undefined;
+    "data-testid"?: string | undefined;
     rating: number;
     onRatingChange: (value: number) => void;
     onSubmit: () => void;

--- a/src/file-upload/dropzone.tsx
+++ b/src/file-upload/dropzone.tsx
@@ -90,7 +90,7 @@ const Component = (
                 accept={accept}
                 capture={capture}
                 multiple={multiple}
-                data-testid={`${testId}-input` || "dropzone-input"}
+                data-testid={testId ? `${testId}-input` : "dropzone-input"}
                 onChange={handleChange}
             />
             {children}

--- a/src/file-upload/dropzone.tsx
+++ b/src/file-upload/dropzone.tsx
@@ -32,6 +32,7 @@ const Component = (
         border,
         disabled,
         onChange,
+        "data-testid": testId,
     }: Props,
     ref: React.Ref<DropzoneElement>
 ) => {
@@ -75,7 +76,7 @@ const Component = (
     return (
         <Container
             id={id}
-            data-testid="dropzone"
+            data-testid={testId || "dropzone"}
             $border={border}
             className={className}
             {...getRootProps()}
@@ -89,7 +90,7 @@ const Component = (
                 accept={accept}
                 capture={capture}
                 multiple={multiple}
-                data-testid="dropzone-input"
+                data-testid={`${testId}-input` || "dropzone-input"}
                 onChange={handleChange}
             />
             {children}

--- a/src/file-upload/file-upload.tsx
+++ b/src/file-upload/file-upload.tsx
@@ -24,6 +24,7 @@ export const FileUpload = ({
     className,
     name,
     id,
+    "data-testid": testId,
     accept,
     capture,
     multiple,
@@ -102,6 +103,7 @@ export const FileUpload = ({
                 capture={capture}
                 border={styleType === "bordered"}
                 className={className}
+                data-testid={testId}
                 name={name}
                 multiple={multiple}
                 disabled={disabled || reachedMaxFiles() || readOnly}

--- a/src/file-upload/types.ts
+++ b/src/file-upload/types.ts
@@ -30,6 +30,7 @@ export interface FileInputProps {
     disabled?: boolean | undefined;
     id?: string | undefined;
     className?: string | undefined;
+    "data-testid"?: string | undefined;
     name?: string | undefined;
 }
 

--- a/src/footer/footer.tsx
+++ b/src/footer/footer.tsx
@@ -30,6 +30,7 @@ export const Footer = <T,>({
     copyrightInfo,
     onFooterLinkClick,
     layout = "default",
+    ...otherProps
 }: FooterProps<T>) => {
     // =============================================================================
     // CONST, STATE, REFS
@@ -132,7 +133,7 @@ export const Footer = <T,>({
     };
 
     return (
-        <BaseFooter>
+        <BaseFooter {...otherProps}>
             {renderTopSection()}
             <MobileOnlyBorder />
             <BottomSection type="grid" stretch={isStretch}>

--- a/src/footer/types.ts
+++ b/src/footer/types.ts
@@ -32,6 +32,9 @@ export interface FooterProps<T = void> {
     onFooterLinkClick?: ((link: FooterLinkProps<T>) => void) | undefined;
     /** Determines if the content of the footer scales with the max width */
     layout?: "default" | "stretch" | undefined;
+    id?: string | undefined;
+    "data-testid"?: string | undefined;
+    className?: string | undefined;
 }
 
 // TODO: Update component and migration

--- a/src/image-button/types.ts
+++ b/src/image-button/types.ts
@@ -1,5 +1,6 @@
 export interface ImageButtonProps
     extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    "data-testid"?: string | undefined;
     /** The image source to be rendered */
     imgSrc: string;
     selected?: boolean | undefined;

--- a/src/masonry/types.ts
+++ b/src/masonry/types.ts
@@ -12,6 +12,7 @@ export interface ColumnCountAttribute {
 export interface MasonryGridProps extends React.HTMLAttributes<HTMLDivElement> {
     numOfCols: ColumnCountAttribute;
     children: JSX.Element | JSX.Element[];
+    "data-testid"?: string | undefined;
 }
 
 export interface MasonryTileProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/src/notification-banner/types.ts
+++ b/src/notification-banner/types.ts
@@ -7,6 +7,7 @@ export interface NotificationBannerProps
     visible?: boolean | undefined;
     sticky?: boolean | undefined;
     onDismiss?: (() => void) | undefined;
+    "data-testid"?: string | undefined;
 }
 
 export interface NotificationBannerWithForwardedRefProps

--- a/src/progress-indicator/progress-indicator.tsx
+++ b/src/progress-indicator/progress-indicator.tsx
@@ -20,6 +20,7 @@ export const ProgressIndicator = <T,>({
     displayExtractor,
     fadeColor,
     fadePosition = "both",
+    ...otherProps
 }: ProgressIndicatorProps<T>) => {
     // =============================================================================
     // CONST, STATE, REFS
@@ -175,7 +176,7 @@ export const ProgressIndicator = <T,>({
     };
 
     return (
-        <Wrapper ref={wrapperRef}>
+        <Wrapper ref={wrapperRef} {...otherProps}>
             <Content ref={contentRef}>{renderSteps()}</Content>
             {showFade && renderFade()}
         </Wrapper>

--- a/src/progress-indicator/types.ts
+++ b/src/progress-indicator/types.ts
@@ -6,4 +6,7 @@ export interface ProgressIndicatorProps<T> {
     fadeColor?: string[] | undefined;
     fadePosition?: FadePosition | undefined;
     displayExtractor?: ((item: T) => string) | undefined;
+    className?: string | undefined;
+    id?: string | undefined;
+    "data-testid"?: string | undefined;
 }

--- a/src/shared/dropdown-wrapper/dropdown-wrapper.tsx
+++ b/src/shared/dropdown-wrapper/dropdown-wrapper.tsx
@@ -11,6 +11,7 @@ export const DropdownWrapper = ({
     testId,
     onBlur,
     readOnly,
+    className,
 }: DropdownSelectorProps): JSX.Element => {
     // =============================================================================
     // CONST, STATE, REFS
@@ -42,7 +43,7 @@ export const DropdownWrapper = ({
     // RENDER FUNCTIONS
     // =============================================================================
     return (
-        <Wrapper>
+        <Wrapper className={className}>
             <ElementBoundary
                 ref={nodeRef}
                 error={error && !show}

--- a/src/uneditable-section/types.ts
+++ b/src/uneditable-section/types.ts
@@ -17,4 +17,7 @@ export interface UneditableSectionProps {
     bottomSection?: JSX.Element | undefined;
     /** The body of the entire section */
     children?: JSX.Element | JSX.Element[] | undefined;
+    className?: string | undefined;
+    "data-testid"?: string | undefined;
+    id?: string | undefined;
 }

--- a/src/uneditable-section/uneditable-section.tsx
+++ b/src/uneditable-section/uneditable-section.tsx
@@ -16,6 +16,7 @@ export const UneditableSectionBase = ({
     topSection,
     bottomSection,
     children,
+    ...otherProps
 }: UneditableSectionProps) => {
     // =============================================================================
     // RENDER FUNCTIONS
@@ -57,7 +58,7 @@ export const UneditableSectionBase = ({
     };
 
     return (
-        <Wrapper>
+        <Wrapper {...otherProps}>
             <Container type="grid">{renderChildren()}</Container>
         </Wrapper>
     );

--- a/src/unit-number/unit-number-input.tsx
+++ b/src/unit-number/unit-number-input.tsx
@@ -322,12 +322,12 @@ export const UnitNumberInput = ({
 
     return (
         <InputWrapper
+            {...otherProps}
             ref={nodeRef}
             onClick={handleNodeClick}
             $disabled={disabled}
             $error={error}
             $readOnly={readOnly}
-            data-testid={otherProps["data-testid"]}
             tabIndex={-1}
             onBlur={handleNodeBlur}
         >

--- a/stories/box-container/props-table.tsx
+++ b/stories/box-container/props-table.tsx
@@ -1,133 +1,96 @@
 import React from "react";
-import {
-    DefaultCol,
-    DescriptionCol,
-    NameCol,
-    Section,
-    Table,
-} from "../storybook-common/api-table";
+import { ApiTable } from "../storybook-common/api-table";
+import { ApiTableSectionProps } from "../storybook-common/api-table/types";
 
-export const PropsTable = () => (
-    <Table>
-        <tr>
-            <NameCol mandatory>title</NameCol>
-            <DescriptionCol propTypes={["string"]}>
-                The label text for the header
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-        <tr>
-            <NameCol mandatory>children</NameCol>
-            <DescriptionCol propTypes={["JSX.Element", "JSX.Element[]"]}>
-                The content of the component
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-        <tr>
-            <NameCol>collapsible</NameCol>
-            <DescriptionCol propTypes={["boolean"]}>
-                Specifies if the contents can be collapsed or expanded
-            </DescriptionCol>
-            <DefaultCol>{["true"]}</DefaultCol>
-        </tr>
-        <tr>
-            <NameCol>expanded</NameCol>
-            <DescriptionCol propTypes={["boolean"]}>
-                <>
-                    Specifies if contents are expanded. Only valid if
-                    <code>collapsible</code> is set to <code>true</code>
-                </>
-            </DescriptionCol>
-            <DefaultCol>{["false"]}</DefaultCol>
-        </tr>
-        <tr>
-            <NameCol>callToActionComponent</NameCol>
-            <DescriptionCol propTypes={["JSX.Element"]}>
-                A custom call to action component for the header
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-        <tr>
-            <NameCol>displayState</NameCol>
-            <DescriptionCol propTypes={[`"default"`, `"error"`, `"warning"`]}>
-                Specifies the display state which renders an icon
-            </DescriptionCol>
-            <DefaultCol>{[`"default"`]}</DefaultCol>
-        </tr>
-        <tr>
-            <NameCol>className</NameCol>
-            <DescriptionCol propTypes={["string"]}>
-                The style class to override the default styling
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-        <tr>
-            <NameCol>data-testid</NameCol>
-            <DescriptionCol propTypes={["string"]}>
-                The id used for testing purposes
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-        <tr>
-            <NameCol>subComponentTestIds</NameCol>
-            <DescriptionCol propTypes={["BoxContainerSubComponentTestIds"]}>
-                The id used for testing the label and handle button
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
+const DATA: ApiTableSectionProps[] = [
+    {
+        attributes: [
+            {
+                name: "title",
+                mandatory: true,
+                description: "The label text for the header",
+                propTypes: ["string"],
+            },
+            {
+                name: "children",
+                mandatory: true,
+                description: "The content of the component",
+                propTypes: ["JSX.Element", "JSX.Element[]"],
+            },
+            {
+                name: "collapsible",
+                description:
+                    "Specifies if the contents can be collapsed or expanded",
+                propTypes: ["boolean"],
+                defaultValue: "true",
+            },
+            {
+                name: "expanded",
+                description: (
+                    <>
+                        Specifies if contents are expanded. Only valid if
+                        <code>collapsible</code> is set to <code>true</code>
+                    </>
+                ),
+                propTypes: ["boolean"],
+                defaultValue: "false",
+            },
+            {
+                name: "callToActionComponent",
+                description: "A custom call to action component for the header",
+                propTypes: ["JSX.Element"],
+            },
+            {
+                name: "displayState",
+                description:
+                    "Specifies the display state which renders an icon",
+                propTypes: [`"default"`, `"error"`, `"warning"`],
+                defaultValue: `"default"`,
+            },
+            {
+                name: "subComponentTestIds",
+                description:
+                    "The id used for testing the label and handle button",
+                propTypes: ["BoxContainerSubComponentTestIds"],
+            },
+            {
+                name: "id",
+                description: "The unique id of the component",
+                propTypes: ["string"],
+            },
+            {
+                name: "className",
+                description: "The class selector of the component",
+                propTypes: ["string"],
+            },
+            {
+                name: "data-testid",
+                description: "The test identifier for the component",
+                propTypes: ["string"],
+            },
+        ],
+    },
+    {
+        name: "BoxContainerSubComponentTestIds",
+        attributes: [
+            {
+                name: "title",
+                description: "The id used for the header title",
+                propTypes: ["string"],
+            },
+            {
+                name: "displayStateIcon",
+                description:
+                    "The id used for the display state icon in the header",
+                propTypes: ["string"],
+            },
+            {
+                name: "handle",
+                description: "The id used for the expand and collapse handle",
+                propTypes: ["string"],
+            },
+        ],
+    },
+];
 
-        <Section>BoxContainerSubComponentTestIds</Section>
-
-        <tr>
-            <NameCol>title</NameCol>
-            <DescriptionCol propTypes={["string"]}>
-                The id used for the header title
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-        <tr>
-            <NameCol>displayStateIcon</NameCol>
-            <DescriptionCol propTypes={["string"]}>
-                The id used for the display state icon in the header
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-        <tr>
-            <NameCol>handle</NameCol>
-            <DescriptionCol propTypes={["string"]}>
-                The id used for the expand and collapse handle
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-    </Table>
-);
-
-export const AccordionItemPropsTable = () => (
-    <Table>
-        <tr>
-            <NameCol mandatory>children</NameCol>
-            <DescriptionCol propTypes={["JSX.Element", "JSX.Element[]"]}>
-                The content of the Accordion.Item
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-        <tr>
-            <NameCol>actionLink</NameCol>
-            <DescriptionCol
-                propTypes={
-                    <a
-                        href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement"
-                        target="_blank"
-                        rel="noreferrer"
-                    >
-                        <code>HTMLAnchorAttributes</code>
-                    </a>
-                }
-            >
-                The attributes of an action link that performs an action on
-                click
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-    </Table>
-);
+export const PropsTable = () => <ApiTable sections={DATA} />;

--- a/stories/breadcrumb/props-table.tsx
+++ b/stories/breadcrumb/props-table.tsx
@@ -54,17 +54,17 @@ const DATA: ApiTableSectionProps[] = [
             },
             {
                 name: "id",
-                description: (
-                    <>
-                        A unique identifier for each <code>Breadcrumb</code>
-                        &nbsp;item
-                    </>
-                ),
+                description: "The unique id of the component",
+                propTypes: ["string"],
+            },
+            {
+                name: "className",
+                description: "The class selector of the component",
                 propTypes: ["string"],
             },
             {
                 name: "data-testid",
-                description: "The id used for testing purposes",
+                description: "The test identifier for the component",
                 propTypes: ["string"],
             },
         ],

--- a/stories/card/card.stories.mdx
+++ b/stories/card/card.stories.mdx
@@ -75,4 +75,6 @@ export const StyledCard = styled(Card)`
 
 <Secondary>Component API</Secondary>
 
+This component also inherits the [HTMLDivAttributes](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement)
+
 <PropsTable />

--- a/stories/card/props-table.tsx
+++ b/stories/card/props-table.tsx
@@ -6,9 +6,9 @@ const DATA: ApiTableSectionProps[] = [
     {
         attributes: [
             {
-                name: "children",
-                description: "The contents of the bubble",
-                propTypes: ["string", "JSX.Element"],
+                name: "data-testid",
+                description: "The test identifier for the component",
+                propTypes: ["string"],
             },
         ],
     },

--- a/stories/feedback-rating/props-table.tsx
+++ b/stories/feedback-rating/props-table.tsx
@@ -34,6 +34,21 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["number"],
             },
             {
+                name: "id",
+                description: "The unique id of the component",
+                propTypes: ["string"],
+            },
+            {
+                name: "className",
+                description: "The class selector of the component",
+                propTypes: ["string"],
+            },
+            {
+                name: "data-testid",
+                description: "The test identifier for the component",
+                propTypes: ["string"],
+            },
+            {
                 name: "onRatingChange",
                 mandatory: true,
                 description: (

--- a/stories/footer/props-table.tsx
+++ b/stories/footer/props-table.tsx
@@ -22,7 +22,7 @@ const DATA: ApiTableSectionProps[] = [
                         <code>Footer</code>
                     </>
                 ),
-                propTypes: ["JEX.Element", "JSX.Element[]"],
+                propTypes: ["JSX.Element", "JSX.Element[]"],
             },
             {
                 name: "showDownloadAddon",
@@ -77,6 +77,21 @@ const DATA: ApiTableSectionProps[] = [
                     "Specifies the layout type of the content in the footer",
                 propTypes: ["stretch | default"],
                 defaultValue: "default",
+            },
+            {
+                name: "id",
+                description: "The unique id of the component",
+                propTypes: ["string"],
+            },
+            {
+                name: "className",
+                description: "The class selector of the component",
+                propTypes: ["string"],
+            },
+            {
+                name: "data-testid",
+                description: "The test identifier for the component",
+                propTypes: ["string"],
             },
         ],
     },

--- a/stories/progress-indicator/props-table.tsx
+++ b/stories/progress-indicator/props-table.tsx
@@ -50,6 +50,21 @@ const DATA: ApiTableSectionProps[] = [
                     "The function to derive the display value of the step item",
                 propTypes: ["(item: T) => string"],
             },
+            {
+                name: "id",
+                description: "The unique id of the component",
+                propTypes: ["string"],
+            },
+            {
+                name: "className",
+                description: "The class selector of the component",
+                propTypes: ["string"],
+            },
+            {
+                name: "data-testid",
+                description: "The test identifier for the component",
+                propTypes: ["string"],
+            },
         ],
     },
 ];

--- a/stories/uneditable-section/props-table.tsx
+++ b/stories/uneditable-section/props-table.tsx
@@ -50,6 +50,21 @@ const MAIN_DATA: ApiTableSectionProps[] = [
                     "The body of the entire section. Gives flexibility for custom composition of the component",
                 propTypes: [`JSX.Element[]`, `JSX.Element`],
             },
+            {
+                name: "id",
+                description: "The unique id of the component",
+                propTypes: ["string"],
+            },
+            {
+                name: "className",
+                description: "The class selector of the component",
+                propTypes: ["string"],
+            },
+            {
+                name: "data-testid",
+                description: "The test identifier for the component",
+                propTypes: ["string"],
+            },
         ],
     },
     {


### PR DESCRIPTION
**Changes**

- Ensure components receive the `className` attribute for custom styling
- Also noticed that some components do not take in the standard `id` and `data-testid` attributes, took the chance to add them and correct the prop table documentation
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

Bug fix
- Pass `className`, `id` and `data-testid` props to all components