### PR TITLE
[MOL-13717][JC|TK] fix SquareFillIcon missing in br web

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
                 "typescript": "^4.8.2"
             },
             "peerDependencies": {
-                "@lifesg/react-icons": "^1.3.0",
+                "@lifesg/react-icons": "^1.4.0",
                 "react": "^17.0.2 || ^18.0.0",
                 "react-dom": "^17.0.2 || ^18.0.0",
                 "styled-components": "^5.3.5"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "typescript": "^4.8.2"
     },
     "peerDependencies": {
-        "@lifesg/react-icons": "^1.3.0",
+        "@lifesg/react-icons": "^1.4.0",
         "react": "^17.0.2 || ^18.0.0",
         "react-dom": "^17.0.2 || ^18.0.0",
         "styled-components": "^5.3.5"


### PR DESCRIPTION
**Changes**
update peerDependencies `@lifesg/react-icons` from 1.3.0 to 1.4.0

- delete branch

<!-- Remove if not required -->
**Changelog entry**

- Update peerDependencies `@lifesg/react-icons` from 1.3.0 to 1.4.0
