### PR TITLE
Hide nav branding and adjust navbar styles

### DIFF
--- a/src/navbar/drawer.tsx
+++ b/src/navbar/drawer.tsx
@@ -66,6 +66,7 @@ const Component = (
                     resources={primary}
                     compress
                     onClick={onBrandClick}
+                    data-id="drawer-brand-primary"
                     data-testid="drawer__brand"
                     type="primary"
                 />
@@ -76,6 +77,7 @@ const Component = (
                             resources={secondary}
                             compress
                             onClick={onBrandClick}
+                            data-id="drawer-brand-secondary"
                             data-testid="drawer__brand-secondary"
                             type="secondary"
                         />
@@ -87,7 +89,7 @@ const Component = (
 
     const renderTopBar = () => (
         <TopBar>
-            <NavBrandContainer>
+            <NavBrandContainer data-id="drawer-brand-container">
                 {!hideNavBranding && renderBrand()}
             </NavBrandContainer>
             <CloseButton

--- a/src/navbar/drawer.tsx
+++ b/src/navbar/drawer.tsx
@@ -18,7 +18,14 @@ const Component = (
     // =============================================================================
     // CONST, STATE, REFS
     // =============================================================================
-    const { show, resources, children, onClose, onBrandClick } = props;
+    const {
+        show,
+        resources,
+        children,
+        hideNavBranding,
+        onClose,
+        onBrandClick,
+    } = props;
     const [viewHeight, setViewHeight] = useState<number>(0);
 
     const { primary, secondary } = resources;
@@ -52,9 +59,9 @@ const Component = (
     // =============================================================================
     // RENDER FUNCTIONS
     // =============================================================================
-    const renderTopBar = () => (
-        <TopBar>
-            <NavBrandContainer>
+    const renderBrand = () => {
+        return (
+            <>
                 <Brand
                     resources={primary}
                     compress
@@ -74,8 +81,15 @@ const Component = (
                         />
                     </>
                 )}
-            </NavBrandContainer>
+            </>
+        );
+    };
 
+    const renderTopBar = () => (
+        <TopBar>
+            <NavBrandContainer>
+                {!hideNavBranding && renderBrand()}
+            </NavBrandContainer>
             <CloseButton
                 onClick={onClose}
                 focusHighlight={false}

--- a/src/navbar/navbar-items.styles.tsx
+++ b/src/navbar/navbar-items.styles.tsx
@@ -13,15 +13,19 @@ interface StyleProps {
     $selected: boolean;
 }
 
-interface ItemStyleProps {
+interface WrapperStyleProps {
     $alignLeft: boolean;
+}
+
+interface ItemStyleProps {
+    $hiddenBranding: boolean;
 }
 
 // =============================================================================
 // WRAPPER
 // =============================================================================
 
-export const Wrapper = styled.ul<ItemStyleProps>`
+export const Wrapper = styled.ul<WrapperStyleProps>`
     display: flex;
     list-style: none;
     position: relative;
@@ -53,7 +57,7 @@ export const LinkItem = styled.li<ItemStyleProps>`
 
     :first-child {
         // negative margin to preserve touch target size for link
-        margin-left: ${(props) => (props.$alignLeft ? "-0.5rem" : "0")};
+        margin-left: ${(props) => (props.$hiddenBranding ? "-0.5rem" : "0")};
     }
 
     ${MediaQuery.MaxWidth.tablet} {

--- a/src/navbar/navbar-items.styles.tsx
+++ b/src/navbar/navbar-items.styles.tsx
@@ -13,14 +13,20 @@ interface StyleProps {
     $selected: boolean;
 }
 
+interface ItemStyleProps {
+    $alignLeft: boolean;
+}
+
 // =============================================================================
 // WRAPPER
 // =============================================================================
 
-export const Wrapper = styled.ul`
+export const Wrapper = styled.ul<ItemStyleProps>`
     display: flex;
     list-style: none;
     position: relative;
+
+    ${(props) => props.$alignLeft && "margin-right: auto;"}
 
     ${MediaQuery.MaxWidth.tablet} {
         display: none;
@@ -41,13 +47,15 @@ export const MobileWrapper = styled.ul`
 // =============================================================================
 // LINK ITEMS
 // =============================================================================
-export const LinkItem = styled.li`
+export const LinkItem = styled.li<ItemStyleProps>`
     display: flex;
     margin-left: 1rem;
 
     :first-child {
-        margin-left: 0;
+        // negative margin to preserve touch target size for link
+        margin-left: ${(props) => (props.$alignLeft ? "-0.5rem" : "0")};
     }
+
     ${MediaQuery.MaxWidth.tablet} {
         flex-direction: column;
         padding: 0.125rem 0;

--- a/src/navbar/navbar-items.tsx
+++ b/src/navbar/navbar-items.tsx
@@ -121,9 +121,8 @@ export const NavbarItems = <T,>({
                         selectedIndex >= 0 &&
                         selectedIndex === index &&
                         showSubMenu;
-                    const alignLeft = index === 0 && hideNavBranding;
                     return (
-                        <LinkItem key={index} $alignLeft={alignLeft}>
+                        <LinkItem key={index} $hiddenBranding={hideNavBranding}>
                             <Link
                                 data-testid={testId}
                                 weight={textWeight}

--- a/src/navbar/navbar-items.tsx
+++ b/src/navbar/navbar-items.tsx
@@ -19,6 +19,7 @@ interface Props<T> {
     selectedId?: string | undefined;
     /** toggle for mobile or desktop view */
     mobile?: boolean | undefined;
+    hideNavBranding?: boolean | undefined;
     onItemClick: (
         event: React.MouseEvent<HTMLAnchorElement>,
         item: NavItemProps<T>
@@ -29,6 +30,7 @@ export const NavbarItems = <T,>({
     items,
     selectedId,
     mobile = false,
+    hideNavBranding,
     onItemClick,
 }: Props<T>): JSX.Element => {
     // =============================================================================
@@ -119,8 +121,9 @@ export const NavbarItems = <T,>({
                         selectedIndex >= 0 &&
                         selectedIndex === index &&
                         showSubMenu;
+                    const alignLeft = index === 0 && hideNavBranding;
                     return (
-                        <LinkItem key={index}>
+                        <LinkItem key={index} $alignLeft={alignLeft}>
                             <Link
                                 data-testid={testId}
                                 weight={textWeight}
@@ -162,8 +165,13 @@ export const NavbarItems = <T,>({
     };
 
     if (items && items.length > 0) {
-        const ContentWrapper = mobile ? MobileWrapper : Wrapper;
-        return <ContentWrapper ref={ref}>{renderItems()}</ContentWrapper>;
+        return mobile ? (
+            <MobileWrapper ref={ref}>{renderItems()}</MobileWrapper>
+        ) : (
+            <Wrapper ref={ref} $alignLeft={hideNavBranding}>
+                {renderItems()}
+            </Wrapper>
+        );
     }
 
     return <></>;

--- a/src/navbar/navbar.styles.tsx
+++ b/src/navbar/navbar.styles.tsx
@@ -21,6 +21,7 @@ export const NAVBAR_MOBILE_HEIGHT = 3.5;
 interface StyleProps {
     $compress?: boolean;
     $fixed?: boolean;
+    $hideNavBranding?: boolean;
 }
 
 // =============================================================================
@@ -55,12 +56,13 @@ export const Nav = styled.nav<StyleProps>`
     }
 `;
 
-export const NavElementsContainer = styled.div`
+export const NavElementsContainer = styled.div<StyleProps>`
     display: flex;
     height: 100%;
-    margin-left: 5rem;
+    margin-left: ${(props) => (props.$hideNavBranding ? "0" : "5rem")};
     flex: 1;
     justify-content: flex-end;
+
     ${MediaQuery.MaxWidth.tablet} {
         margin-left: 0rem;
     }

--- a/src/navbar/navbar.styles.tsx
+++ b/src/navbar/navbar.styles.tsx
@@ -95,6 +95,10 @@ export const NavBrandContainer = styled.div<StyleProps>`
     ${MediaQuery.MaxWidth.tablet} {
         height: 1.5rem;
     }
+
+    ${MediaQuery.MaxWidth.mobileS} {
+        height: 1.25rem;
+    }
 `;
 
 export const NavSeparator = styled.div<StyleProps>`
@@ -106,5 +110,10 @@ export const NavSeparator = styled.div<StyleProps>`
 
     ${MediaQuery.MaxWidth.tablet} {
         margin: 0 1rem;
+    }
+
+    ${MediaQuery.MaxWidth.mobileS} {
+        width: 2px;
+        margin: 0 0.75rem;
     }
 `;

--- a/src/navbar/navbar.tsx
+++ b/src/navbar/navbar.tsx
@@ -43,6 +43,7 @@ const Component = <T,>(
         fixed = true,
         resources = DEFAULT_RESOURCES,
         hideNavElements = false,
+        hideNavBranding = false,
         drawerDismissalExclusions: blockDrawerDismissalMethods = [],
         actionButtons,
         onItemClick,
@@ -188,6 +189,7 @@ const Component = <T,>(
                 onClose={handleDrawerClose}
                 onBrandClick={handleBrandClick}
                 actionButtons={actionButtons}
+                hideNavBranding={hideNavBranding}
             >
                 <NavbarItems
                     items={items.mobile || items.desktop}
@@ -232,13 +234,16 @@ const Component = <T,>(
         return (
             <Layout.Content stretch={isStretch}>
                 <Nav $compress={compress}>
-                    {renderBrand()}
+                    {!hideNavBranding && renderBrand()}
                     {!hideNavElements && (
-                        <NavElementsContainer>
+                        <NavElementsContainer
+                            $hideNavBranding={hideNavBranding}
+                        >
                             <NavbarItems
                                 items={items.desktop}
                                 onItemClick={handleNavItemClick}
                                 selectedId={selectedId}
+                                hideNavBranding={hideNavBranding}
                             />
                             <NavbarActionButtons
                                 actionButtons={actionButtons}

--- a/src/navbar/types.ts
+++ b/src/navbar/types.ts
@@ -64,6 +64,7 @@ export interface NavbarResourcesProps {
 export interface NavbarSharedProps {
     resources?: NavbarResourcesProps | undefined;
     actionButtons?: NavbarActionButtonsProps | undefined;
+    /** Specifies if brand logos are visible */
     hideNavBranding?: boolean | undefined;
 }
 

--- a/src/navbar/types.ts
+++ b/src/navbar/types.ts
@@ -64,6 +64,7 @@ export interface NavbarResourcesProps {
 export interface NavbarSharedProps {
     resources?: NavbarResourcesProps | undefined;
     actionButtons?: NavbarActionButtonsProps | undefined;
+    hideNavBranding?: boolean | undefined;
 }
 
 export type DrawerDismissalMethod =

--- a/stories/navbar/navbar.stories.mdx
+++ b/stories/navbar/navbar.stories.mdx
@@ -751,6 +751,47 @@ the screen with a fixed padding, ignoring the masthead's alignment.
     </Story>
 </Canvas>
 
+<Heading3>Hide branding</Heading3>
+
+When the branding elements are hidden, navigation items will be aligned to the left on desktop.
+
+<Canvas>
+    <Story name="Hidden branding">
+        <Navbar
+            items={{
+                desktop: [
+                    {
+                        id: "home",
+                        children: "Home",
+                    },
+                    {
+                        id: "guides",
+                        children: "Guides",
+                    },
+                    {
+                        id: "lifesg-app",
+                        children: "LifeSG app",
+                    },
+                ],
+            }}
+            actionButtons={{
+                desktop: [
+                    {
+                        type: "button",
+                        args: {
+                            styleType: "secondary",
+                            children: "Logout",
+                        },
+                    },
+                ],
+            }}
+            selectedId="home"
+            fixed={false} /* For storybook purposes */
+            hideNavBranding
+        />
+    </Story>
+</Canvas>
+
 <Secondary>Troubleshooting</Secondary>
 
 > The component also uses a custom script. Should you encounter a content security

--- a/stories/navbar/props-table.tsx
+++ b/stories/navbar/props-table.tsx
@@ -73,6 +73,12 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["string"],
             },
             {
+                name: "hideNavBranding",
+                description: "Specifies if brand logos are visible",
+                propTypes: ["boolean"],
+                defaultValue: "false",
+            },
+            {
                 name: "hideNavElements",
                 description: "Specifies if links and buttons are hidden",
                 propTypes: ["boolean"],


### PR DESCRIPTION
**Changes**

- Introduce prop `hideNavBranding` to hide brand logos in navbar and drawer. Nav items will be aligned to the left.
- Reduce logo size for mobileS to cater for wider logos
- Add data-ids for brand elements in drawer to support targeted styling (previously only navbar brand elements could be targeted)
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

-  Add `hideNavBranding` prop to hide brand logos in `Navbar`
