### PR TITLE
Update rendering of custom title and description in File Upload

### DIFF
--- a/src/file-upload/file-upload.tsx
+++ b/src/file-upload/file-upload.tsx
@@ -93,6 +93,27 @@ export const FileUpload = ({
     // =========================================================================
     // RENDER FUNCTIONS
     // =========================================================================
+    const renderInfo = () => {
+        if (!title && !description) {
+            return null;
+        }
+
+        return (
+            <TitleContainer>
+                {typeof title === "string" ? (
+                    <Title weight="regular">{title}</Title>
+                ) : (
+                    <div>{title}</div>
+                )}
+                {typeof description === "string" ? (
+                    <Description weight="semibold">{description}</Description>
+                ) : (
+                    <div>{description}</div>
+                )}
+            </TitleContainer>
+        );
+    };
+
     return (
         <FileUploadContext.Provider value={{ activeId, setActiveId }}>
             <FileUploadDropzone
@@ -108,16 +129,7 @@ export const FileUpload = ({
                 multiple={multiple}
                 disabled={disabled || reachedMaxFiles() || readOnly}
             >
-                {(title || description) && (
-                    <TitleContainer>
-                        {title && <Title weight="regular">{title}</Title>}
-                        {description && (
-                            <Description weight="semibold">
-                                {description}
-                            </Description>
-                        )}
-                    </TitleContainer>
-                )}
+                {renderInfo()}
                 {warning && (
                     <WarningAlert type="warning">{warning}</WarningAlert>
                 )}

--- a/src/file-upload/file-upload.tsx
+++ b/src/file-upload/file-upload.tsx
@@ -93,25 +93,28 @@ export const FileUpload = ({
     // =========================================================================
     // RENDER FUNCTIONS
     // =========================================================================
-    const renderInfo = () => {
-        if (!title && !description) {
+    const renderTitle = () => {
+        if (!title) {
             return null;
         }
 
-        return (
-            <TitleContainer>
-                {typeof title === "string" ? (
-                    <Title weight="regular">{title}</Title>
-                ) : (
-                    <div>{title}</div>
-                )}
-                {typeof description === "string" ? (
-                    <Description weight="semibold">{description}</Description>
-                ) : (
-                    <div>{description}</div>
-                )}
-            </TitleContainer>
-        );
+        if (typeof title === "string") {
+            return <Title weight="regular">{title}</Title>;
+        }
+
+        return <div>{title}</div>;
+    };
+
+    const renderDescription = () => {
+        if (!description) {
+            return null;
+        }
+
+        if (typeof description === "string") {
+            return <Description weight="regular">{description}</Description>;
+        }
+
+        return <div>{description}</div>;
     };
 
     return (
@@ -129,7 +132,12 @@ export const FileUpload = ({
                 multiple={multiple}
                 disabled={disabled || reachedMaxFiles() || readOnly}
             >
-                {renderInfo()}
+                {(title || description) && (
+                    <TitleContainer>
+                        {renderTitle()}
+                        {renderDescription()}
+                    </TitleContainer>
+                )}
                 {warning && (
                     <WarningAlert type="warning">{warning}</WarningAlert>
                 )}


### PR DESCRIPTION
Closes #322 

**Changes**

- If title/description is a string type, it will be rendered in `<Text>` for styling
- If a custom JSX element is passed in, it will be rendered in a generic div (this is to preserve the flex-column vertical layout)
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Fix invalid DOM nesting when specifying custom title or description in `FileUpload`