### PR TITLE
[MISC][WL] add key to filter checkbox toggle

### DIFF
--- a/src/filter/addons/filter-item-checkbox.tsx
+++ b/src/filter/addons/filter-item-checkbox.tsx
@@ -172,6 +172,7 @@ export const FilterItemCheckbox = <T,>({
 
         return (
             <StyledToggle
+                key={optionValue}
                 type="checkbox"
                 checked={checked}
                 $visible={


### PR DESCRIPTION
**Changes**
- Add missing key for filter checkbox toggle button
- This resolves the react warning to have unique key prop