### PR TITLE
Initial expanded state of Filter Item

### DIFF
--- a/src/filter/filter-item.tsx
+++ b/src/filter/filter-item.tsx
@@ -117,10 +117,14 @@ export const FilterItem = ({
                     )}
                 </FilterItemHeader>
             )}
-            <ExpandableItem style={itemAnimationStyles}>
+            <ExpandableItem
+                data-testid="expandable-container"
+                style={itemAnimationStyles}
+            >
                 <div ref={itemResizeDetector.ref}>
                     <FilterItemBody {...otherProps}>
                         <MinimisableContent
+                            data-testid="minimisable-container"
                             $height={contentHeight}
                             $minimisable={minimisable}
                         >

--- a/src/filter/filter.tsx
+++ b/src/filter/filter.tsx
@@ -118,6 +118,7 @@ const FilterBase = ({
         return (
             <>
                 <FilterButton
+                    data-testid="filter-show-button"
                     styleType="light"
                     onClick={handleShowFilter}
                     type="button"
@@ -125,7 +126,7 @@ const FilterBase = ({
                     <StyledFilterIcon /> {toggleFilterButtonLabel}
                 </FilterButton>
                 <Overlay show={visible} disableTransition>
-                    <MobileContainer>
+                    <MobileContainer data-testid="filter-mobile">
                         {renderHeader("mobile")}
                         <FilterBody>{renderChildren("mobile")}</FilterBody>
                         <FilterFooter>
@@ -144,7 +145,7 @@ const FilterBase = ({
 
     const renderDesktop = () => {
         return (
-            <DesktopContainer>
+            <DesktopContainer data-testid="filter-desktop">
                 {renderHeader("default")}
                 {renderChildren("default")}
             </DesktopContainer>

--- a/src/filter/types.ts
+++ b/src/filter/types.ts
@@ -29,6 +29,12 @@ export interface FilterItemProps {
     id?: string | undefined;
     "data-testid"?: string | undefined;
     collapsible?: boolean | undefined;
+    /** Specifies the initial expand state for the uncontrolled component */
+    initialExpanded?: boolean | undefined;
+    /** Specifies the expand state for the controlled component */
+    expanded?: boolean | undefined;
+    /** Called when the expand state changes */
+    onExpandChange?: ((expanded: boolean) => void) | undefined;
     minimisable?: boolean | undefined;
     minimisedHeight?: number | undefined;
 }

--- a/stories/filter/filter.stories.mdx
+++ b/stories/filter/filter.stories.mdx
@@ -113,6 +113,49 @@ Each item can be configured with `collapsible`, `showDivider` and `showMobileDiv
     </Story>
 </Canvas>
 
+<Heading3>Expanded state</Heading3>
+
+By default, the expanded state is handled by the component. For advanced use cases, the filter item can be used as a controlled component.
+
+> Note: this example works in desktop only
+
+<Canvas>
+    <Story name="Handling expanded state">
+        {() => {
+            const [expanded, setExpanded] = useState("item-1");
+            const handleExpandChange = (item) => setExpanded(item);
+            return (
+                <StoryContainer>
+                    <Filter>
+                        <Filter.Item
+                            title="Uncontrolled"
+                            showMobileDivider={false}
+                            initialExpanded
+                        >
+                            Expanded by default with{" "}
+                            <code>initialExpanded</code> prop
+                        </Filter.Item>
+                        <Filter.Item
+                            title="Controlled Item 1"
+                            expanded={expanded === "item-1"}
+                            onExpandChange={() => handleExpandChange("item-1")}
+                        >
+                            Controlled by <code>expanded</code> prop
+                        </Filter.Item>
+                        <Filter.Item
+                            title="Controlled Item 2"
+                            expanded={expanded === "item-2"}
+                            onExpandChange={() => handleExpandChange("item-2")}
+                        >
+                            Controlled by <code>expanded</code> prop
+                        </Filter.Item>
+                    </Filter>
+                </StoryContainer>
+            );
+        }}
+    </Story>
+</Canvas>
+
 <Heading3>Minimising content</Heading3>
 
 For longer filter items, content can be minimised with the `minimisable` prop.

--- a/stories/filter/props-table.tsx
+++ b/stories/filter/props-table.tsx
@@ -98,6 +98,25 @@ const FILTER_ITEM_DATA: ApiTableSectionProps[] = [
                 defaultValue: "true",
             },
             {
+                name: "initialExpanded",
+                description:
+                    "Specifies the initial expand state for the uncontrolled component",
+                propTypes: ["boolean"],
+                defaultValue: "false",
+            },
+            {
+                name: "expanded",
+                description:
+                    "Specifies the expand state for the controlled component",
+                propTypes: ["boolean"],
+            },
+            {
+                name: "onExpandChange",
+                description:
+                    "Called when the expanded state changes (desktop only)",
+                propTypes: ["(expanded: boolean) => void)"],
+            },
+            {
                 name: "showDivider",
                 description:
                     "Specifies if header divider is visible in default mode",

--- a/tests/filter/filter.spec.tsx
+++ b/tests/filter/filter.spec.tsx
@@ -1,0 +1,158 @@
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { Filter } from "../../src";
+
+describe("Filter", () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        global.ResizeObserver = jest.fn().mockImplementation(() => ({
+            observe: jest.fn(),
+            unobserve: jest.fn(),
+            disconnect: jest.fn(),
+        }));
+    });
+
+    it("should render the relevant components correctly on desktop", () => {
+        render(
+            <Filter>
+                <Filter.Item data-testid="item1">{ITEM_CONTENT}</Filter.Item>
+                <Filter.Item data-testid="item2">{ITEM_CONTENT}</Filter.Item>
+            </Filter>
+        );
+
+        const desktop = within(screen.queryByTestId(DESKTOP_TESTID));
+        expect(desktop.getByTestId("item1")).toBeInTheDocument();
+        expect(desktop.getByTestId("item2")).toBeInTheDocument();
+    });
+
+    it("should render the relevant components correctly on mobile", () => {
+        render(
+            <Filter>
+                <Filter.Item data-testid="item1">{ITEM_CONTENT}</Filter.Item>
+                <Filter.Item data-testid="item2">{ITEM_CONTENT}</Filter.Item>
+            </Filter>
+        );
+
+        act(() => {
+            fireEvent.click(screen.getByTestId(MOBILE_SHOW_BUTTON_TESTID));
+        });
+
+        const mobile = within(screen.queryByTestId(MOBILE_TESTID));
+        expect(mobile.getByTestId("item1")).toBeVisible();
+        expect(mobile.getByTestId("item2")).toBeVisible();
+    });
+
+    describe("Filter.Item", () => {
+        it("should render the item correctly", () => {
+            render(
+                <Filter.Item title={ITEM_TITLE}>{ITEM_CONTENT}</Filter.Item>
+            );
+
+            expect(screen.getByText(ITEM_TITLE)).toBeInTheDocument();
+            expect(screen.getByText(ITEM_CONTENT)).toBeInTheDocument();
+        });
+
+        it("should render children specified as render prop correctly", () => {
+            const mockRender = jest.fn(() => (
+                <div data-testid="item1">{ITEM_CONTENT}</div>
+            ));
+            render(<Filter.Item>{mockRender}</Filter.Item>);
+
+            expect(screen.getByTestId("item1")).toBeInTheDocument();
+            expect(mockRender).toBeCalledWith("default", { minimised: false });
+        });
+
+        describe("initialExpanded", () => {
+            it("should be collapsed by default", () => {
+                render(<Filter.Item>{ITEM_CONTENT}</Filter.Item>);
+
+                expect(screen.getByLabelText("Expand")).toBeVisible();
+            });
+
+            it("should be expanded by default when initialExpanded is true", () => {
+                render(
+                    <Filter.Item initialExpanded>{ITEM_CONTENT}</Filter.Item>
+                );
+
+                expect(screen.getByLabelText("Collapse")).toBeVisible();
+            });
+        });
+
+        describe("expanded (controlled component)", () => {
+            it("should be expanded when expanded is true and not update the local state when display is toggled", () => {
+                const mockOnChange = jest.fn();
+                render(
+                    <Filter.Item expanded={false} onExpandChange={mockOnChange}>
+                        {ITEM_CONTENT}
+                    </Filter.Item>
+                );
+
+                act(() => {
+                    fireEvent.click(screen.getByLabelText("Expand"));
+                });
+
+                expect(screen.getByLabelText("Expand")).toBeVisible();
+                expect(mockOnChange).toBeCalledWith(true);
+            });
+
+            it("should be collapsed when expanded is false and not update the local state when display is toggled", () => {
+                const mockOnChange = jest.fn();
+                render(
+                    <Filter.Item expanded={true} onExpandChange={mockOnChange}>
+                        {ITEM_CONTENT}
+                    </Filter.Item>
+                );
+
+                act(() => {
+                    fireEvent.click(screen.getByLabelText("Collapse"));
+                });
+
+                expect(screen.getByLabelText("Collapse")).toBeVisible();
+                expect(mockOnChange).toBeCalledWith(false);
+            });
+        });
+
+        describe("Expand behaviour (uncontrolled component)", () => {
+            it("should expand when display is toggled", () => {
+                const mockOnChange = jest.fn();
+                render(
+                    <Filter.Item onExpandChange={mockOnChange}>
+                        {ITEM_CONTENT}
+                    </Filter.Item>
+                );
+
+                act(() => {
+                    fireEvent.click(screen.getByLabelText("Expand"));
+                });
+
+                expect(screen.getByLabelText("Collapse")).toBeVisible();
+                expect(mockOnChange).toBeCalledWith(true);
+            });
+
+            it("should collapse when display is toggled", () => {
+                const mockOnChange = jest.fn();
+                render(
+                    <Filter.Item initialExpanded onExpandChange={mockOnChange}>
+                        {ITEM_CONTENT}
+                    </Filter.Item>
+                );
+
+                act(() => {
+                    fireEvent.click(screen.getByLabelText("Collapse"));
+                });
+
+                expect(screen.getByLabelText("Expand")).toBeVisible();
+                expect(mockOnChange).toBeCalledWith(false);
+            });
+        });
+    });
+});
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+const DESKTOP_TESTID = "filter-desktop";
+const MOBILE_TESTID = "filter-mobile";
+const MOBILE_SHOW_BUTTON_TESTID = "filter-show-button";
+const ITEM_TITLE = "test title";
+const ITEM_CONTENT = "test body";


### PR DESCRIPTION
**Changes**

- Add `initialExpanded ` prop to set default expanded state
- Also allow consumer to control the expanded state via `expanded` and `onExpandChange` prop
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Add `initialExpanded` to set the initial expanded state in `Filter.Item`
- Support custom handling of the expanded state in `Filter.Item`