### PR TITLE
Add Divider component

### DIFF
--- a/src/divider/divider.style.tsx
+++ b/src/divider/divider.style.tsx
@@ -1,6 +1,5 @@
 import styled, { css } from "styled-components";
 import { Color } from "../color/color";
-import { Layout } from "../layout";
 import { DividerLineStyleType } from "./types";
 
 // =============================================================================
@@ -15,22 +14,23 @@ interface StyleProps {
 // =============================================================================
 // STYLING
 // =============================================================================
-export const Line = styled.hr<StyleProps>`
+const commonStyles = css`
     width: 100%;
-    background-color: transparent;
     margin: 0;
-    height: unset;
     border: none;
+`;
+
+export const Line = styled.hr<StyleProps>`
+    ${commonStyles}
     ${(props) => {
         return css`
-            border-top-width: ${props.$thickness}px;
-            border-top-style: ${props.$lineStyle} !important; // Prevent modification easily
-            border-top-color: ${props.$color || Color.Neutral[5]};
+            height: ${props.$thickness}px;
+            background-color: ${props.$color || Color.Neutral[5]};
         `;
     }}
 `;
 
-const dashedLineStyle = (props: StyleProps) => {
+const dashedLineStyle = () => (props: StyleProps) => {
     let color;
 
     if (props.$color && typeof props.$color === "function") {
@@ -44,21 +44,14 @@ const dashedLineStyle = (props: StyleProps) => {
     const strokeWidth = thickness + 1; // best fit
 
     return css`
-        display: block;
-        width: 100%;
+        ${commonStyles}
         background-color: transparent;
-        margin: 0;
         height: ${thickness}px;
-        border: none;
         background-repeat: repeat-x;
         background-image: url('data:image/svg+xml,<svg width="8" height="${thickness}" viewBox="0 0 8 1" xmlns="http://www.w3.org/2000/svg"><line x1="2" y1="1" x2="8" y2="1" stroke="${encodedColor}" stroke-width="${strokeWidth}" stroke-dasharray="4 4" /></svg>');
     `;
 };
 
-export const DashedLineFlex = styled.div<StyleProps>`
-    ${(props) => dashedLineStyle(props)}
-`;
-
-export const DashedLineGrid = styled(Layout.ColDiv)<StyleProps>`
-    ${(props) => dashedLineStyle(props)}
+export const DashedLine = styled.hr<StyleProps>`
+    ${dashedLineStyle}
 `;

--- a/src/divider/divider.style.tsx
+++ b/src/divider/divider.style.tsx
@@ -14,22 +14,6 @@ interface StyleProps {
 // =============================================================================
 // STYLING
 // =============================================================================
-const commonStyles = css`
-    width: 100%;
-    margin: 0;
-    border: none;
-`;
-
-export const Line = styled.hr<StyleProps>`
-    ${commonStyles}
-    ${(props) => {
-        return css`
-            height: ${props.$thickness}px;
-            background-color: ${props.$color || Color.Neutral[5]};
-        `;
-    }}
-`;
-
 const dashedLineStyle = () => (props: StyleProps) => {
     let color;
 
@@ -44,14 +28,28 @@ const dashedLineStyle = () => (props: StyleProps) => {
     const strokeWidth = thickness + 1; // best fit
 
     return css`
-        ${commonStyles}
         background-color: transparent;
         height: ${thickness}px;
         background-repeat: repeat-x;
-        background-image: url('data:image/svg+xml,<svg width="8" height="${thickness}" viewBox="0 0 8 1" xmlns="http://www.w3.org/2000/svg"><line x1="2" y1="1" x2="8" y2="1" stroke="${encodedColor}" stroke-width="${strokeWidth}" stroke-dasharray="4 4" /></svg>');
+        background-image: url('data:image/svg+xml,<svg width="8" height="${thickness}" viewBox="0 0 8 1" xmlns="http://www.w3.org/2000/svg"><line x1="2" y1="1" x2="6" y2="1" stroke="${encodedColor}" stroke-width="${strokeWidth}" stroke-dasharray="4 4" /></svg>');
     `;
 };
 
-export const DashedLine = styled.hr<StyleProps>`
-    ${dashedLineStyle}
+export const Line = styled.hr<StyleProps>`
+    width: 100%;
+    margin: 0;
+    border: none;
+    ${(props) => {
+        switch (props.$lineStyle) {
+            case "dashed":
+                return css`
+                    ${dashedLineStyle}
+                `;
+            case "solid":
+                return css`
+                    height: ${props.$thickness}px;
+                    background-color: ${props.$color || Color.Neutral[5]};
+                `;
+        }
+    }}
 `;

--- a/src/divider/divider.style.tsx
+++ b/src/divider/divider.style.tsx
@@ -1,5 +1,6 @@
 import styled, { css } from "styled-components";
 import { Color } from "../color/color";
+import { Layout } from "../layout";
 import { DividerLineStyleType } from "./types";
 
 // =============================================================================
@@ -27,4 +28,37 @@ export const Line = styled.hr<StyleProps>`
             border-top-color: ${props.$color || Color.Neutral[5]};
         `;
     }}
+`;
+
+const dashedLineStyle = (props: StyleProps) => {
+    let color;
+
+    if (props.$color && typeof props.$color === "function") {
+        color = props.$color(props);
+    } else {
+        color = props.$color || Color.Neutral[5](props);
+    }
+
+    const encodedColor = encodeURIComponent(color);
+    const thickness = props.$thickness || 1;
+    const strokeWidth = thickness + 1; // best fit
+
+    return css`
+        display: block;
+        width: 100%;
+        background-color: transparent;
+        margin: 0;
+        height: ${thickness}px;
+        border: none;
+        background-repeat: repeat-x;
+        background-image: url('data:image/svg+xml,<svg width="8" height="${thickness}" viewBox="0 0 8 1" xmlns="http://www.w3.org/2000/svg"><line x1="2" y1="1" x2="8" y2="1" stroke="${encodedColor}" stroke-width="${strokeWidth}" stroke-dasharray="4 4" /></svg>');
+    `;
+};
+
+export const DashedLineFlex = styled.div<StyleProps>`
+    ${(props) => dashedLineStyle(props)}
+`;
+
+export const DashedLineGrid = styled(Layout.ColDiv)<StyleProps>`
+    ${(props) => dashedLineStyle(props)}
 `;

--- a/src/divider/divider.style.tsx
+++ b/src/divider/divider.style.tsx
@@ -1,0 +1,30 @@
+import styled, { css } from "styled-components";
+import { Color } from "../color/color";
+import { DividerLineStyleType } from "./types";
+
+// =============================================================================
+// STYLE INTERFACES
+// =============================================================================
+interface StyleProps {
+    $thickness: number;
+    $color?: string | ((props: any) => string);
+    $lineStyle?: DividerLineStyleType;
+}
+
+// =============================================================================
+// STYLING
+// =============================================================================
+export const Line = styled.hr<StyleProps>`
+    width: 100%;
+    background-color: transparent;
+    margin: 0;
+    height: unset;
+    border: none;
+    ${(props) => {
+        return css`
+            border-top-width: ${props.$thickness}px;
+            border-top-style: ${props.$lineStyle} !important; // Prevent modification easily
+            border-top-color: ${props.$color || Color.Neutral[5]};
+        `;
+    }}
+`;

--- a/src/divider/divider.tsx
+++ b/src/divider/divider.tsx
@@ -1,0 +1,44 @@
+import { ColDiv } from "../layout/col-div";
+import { Line } from "./divider.style";
+import { DividerProps } from "./types";
+
+export const Divider = ({
+    thickness = 1,
+    lineStyle = "solid",
+    layoutType = "flex",
+    color,
+    className,
+    mobileCols = 4,
+    tabletCols = 8,
+    desktopCols = 12,
+    ...otherProps
+}: DividerProps) => {
+    switch (layoutType) {
+        case "flex":
+            return (
+                <Line
+                    className={className}
+                    $thickness={thickness}
+                    $lineStyle={lineStyle}
+                    $color={color}
+                    {...otherProps}
+                />
+            );
+        case "grid":
+            return (
+                <ColDiv
+                    className={className}
+                    mobileCols={mobileCols}
+                    tabletCols={tabletCols}
+                    desktopCols={desktopCols}
+                    {...otherProps}
+                >
+                    <Line
+                        $thickness={thickness}
+                        $lineStyle={lineStyle}
+                        $color={color}
+                    />
+                </ColDiv>
+            );
+    }
+};

--- a/src/divider/divider.tsx
+++ b/src/divider/divider.tsx
@@ -1,5 +1,5 @@
 import { ColDiv } from "../layout/col-div";
-import { DashedLineFlex, DashedLineGrid, Line } from "./divider.style";
+import { DashedLine, Line } from "./divider.style";
 import { DividerProps } from "./types";
 
 export const Divider = ({
@@ -13,70 +13,42 @@ export const Divider = ({
     desktopCols = 12,
     ...otherProps
 }: DividerProps) => {
-    // =========================================================================
-    // RENDER FUNCTIONS
-    // =========================================================================
-    const renderForGridLayout = () => {
-        switch (lineStyle) {
-            case "dashed":
-                return (
-                    <DashedLineGrid
-                        className={className}
-                        mobileCols={mobileCols}
-                        tabletCols={tabletCols}
-                        desktopCols={desktopCols}
-                        $thickness={thickness}
-                        $lineStyle={lineStyle}
-                        $color={color}
-                        {...otherProps}
-                    />
-                );
-            case "solid":
-                return (
-                    <ColDiv
-                        className={className}
-                        mobileCols={mobileCols}
-                        tabletCols={tabletCols}
-                        desktopCols={desktopCols}
-                        {...otherProps}
-                    >
-                        <Line
-                            $thickness={thickness}
-                            $lineStyle={lineStyle}
-                            $color={color}
-                            data-id="divider"
-                        />
-                    </ColDiv>
-                );
-        }
-    };
+    let LineComponent;
 
-    const renderForFlexLayout = () => {
-        let LineComponent;
-
-        switch (lineStyle) {
-            case "dashed":
-                LineComponent = DashedLineFlex;
-                break;
-            case "solid":
-                LineComponent = Line;
-        }
-
-        return (
-            <LineComponent
-                className={className}
-                $thickness={thickness}
-                $lineStyle={lineStyle}
-                $color={color}
-                {...otherProps}
-            />
-        );
-    };
+    switch (lineStyle) {
+        case "dashed":
+            LineComponent = DashedLine;
+            break;
+        case "solid":
+            LineComponent = Line;
+    }
 
     switch (layoutType) {
         case "flex":
-            return renderForFlexLayout();
+            return (
+                <LineComponent
+                    className={className}
+                    $thickness={thickness}
+                    $lineStyle={lineStyle}
+                    $color={color}
+                    {...otherProps}
+                />
+            );
         case "grid":
-            return renderForGridLayout();
+            return (
+                <ColDiv
+                    className={className}
+                    mobileCols={mobileCols}
+                    tabletCols={tabletCols}
+                    desktopCols={desktopCols}
+                    {...otherProps}
+                >
+                    <LineComponent
+                        $thickness={thickness}
+                        $lineStyle={lineStyle}
+                        $color={color}
+                    />
+                </ColDiv>
+            );
     }
 };

--- a/src/divider/divider.tsx
+++ b/src/divider/divider.tsx
@@ -1,5 +1,5 @@
 import { ColDiv } from "../layout/col-div";
-import { DashedLine, Line } from "./divider.style";
+import { Line } from "./divider.style";
 import { DividerProps } from "./types";
 
 export const Divider = ({
@@ -13,20 +13,10 @@ export const Divider = ({
     desktopCols = 12,
     ...otherProps
 }: DividerProps) => {
-    let LineComponent;
-
-    switch (lineStyle) {
-        case "dashed":
-            LineComponent = DashedLine;
-            break;
-        case "solid":
-            LineComponent = Line;
-    }
-
     switch (layoutType) {
         case "flex":
             return (
-                <LineComponent
+                <Line
                     className={className}
                     $thickness={thickness}
                     $lineStyle={lineStyle}
@@ -43,7 +33,7 @@ export const Divider = ({
                     desktopCols={desktopCols}
                     {...otherProps}
                 >
-                    <LineComponent
+                    <Line
                         $thickness={thickness}
                         $lineStyle={lineStyle}
                         $color={color}

--- a/src/divider/divider.tsx
+++ b/src/divider/divider.tsx
@@ -37,6 +37,7 @@ export const Divider = ({
                         $thickness={thickness}
                         $lineStyle={lineStyle}
                         $color={color}
+                        data-id="divider"
                     />
                 </ColDiv>
             );

--- a/src/divider/divider.tsx
+++ b/src/divider/divider.tsx
@@ -1,5 +1,5 @@
 import { ColDiv } from "../layout/col-div";
-import { Line } from "./divider.style";
+import { DashedLineFlex, DashedLineGrid, Line } from "./divider.style";
 import { DividerProps } from "./types";
 
 export const Divider = ({
@@ -13,33 +13,70 @@ export const Divider = ({
     desktopCols = 12,
     ...otherProps
 }: DividerProps) => {
-    switch (layoutType) {
-        case "flex":
-            return (
-                <Line
-                    className={className}
-                    $thickness={thickness}
-                    $lineStyle={lineStyle}
-                    $color={color}
-                    {...otherProps}
-                />
-            );
-        case "grid":
-            return (
-                <ColDiv
-                    className={className}
-                    mobileCols={mobileCols}
-                    tabletCols={tabletCols}
-                    desktopCols={desktopCols}
-                    {...otherProps}
-                >
-                    <Line
+    // =========================================================================
+    // RENDER FUNCTIONS
+    // =========================================================================
+    const renderForGridLayout = () => {
+        switch (lineStyle) {
+            case "dashed":
+                return (
+                    <DashedLineGrid
+                        className={className}
+                        mobileCols={mobileCols}
+                        tabletCols={tabletCols}
+                        desktopCols={desktopCols}
                         $thickness={thickness}
                         $lineStyle={lineStyle}
                         $color={color}
-                        data-id="divider"
+                        {...otherProps}
                     />
-                </ColDiv>
-            );
+                );
+            case "solid":
+                return (
+                    <ColDiv
+                        className={className}
+                        mobileCols={mobileCols}
+                        tabletCols={tabletCols}
+                        desktopCols={desktopCols}
+                        {...otherProps}
+                    >
+                        <Line
+                            $thickness={thickness}
+                            $lineStyle={lineStyle}
+                            $color={color}
+                            data-id="divider"
+                        />
+                    </ColDiv>
+                );
+        }
+    };
+
+    const renderForFlexLayout = () => {
+        let LineComponent;
+
+        switch (lineStyle) {
+            case "dashed":
+                LineComponent = DashedLineFlex;
+                break;
+            case "solid":
+                LineComponent = Line;
+        }
+
+        return (
+            <LineComponent
+                className={className}
+                $thickness={thickness}
+                $lineStyle={lineStyle}
+                $color={color}
+                {...otherProps}
+            />
+        );
+    };
+
+    switch (layoutType) {
+        case "flex":
+            return renderForFlexLayout();
+        case "grid":
+            return renderForGridLayout();
     }
 };

--- a/src/divider/index.ts
+++ b/src/divider/index.ts
@@ -1,0 +1,2 @@
+export * from "./divider";
+export * from "./types";

--- a/src/divider/types.ts
+++ b/src/divider/types.ts
@@ -1,0 +1,13 @@
+import { ColDivProps } from "../layout/types";
+
+export type DividerLineStyleType = "solid" | "dashed";
+type DividerLayoutType = "flex" | "grid";
+
+export interface DividerProps extends ColDivProps {
+    /** The thickness of the Divider in px */
+    thickness?: number | undefined;
+    /** The line display style type. Values: "solid" | "dashed" */
+    lineStyle?: DividerLineStyleType | undefined;
+    /** The layout type. Values: "flex" | "grid" */
+    layoutType?: DividerLayoutType | undefined;
+}

--- a/src/divider/types.ts
+++ b/src/divider/types.ts
@@ -1,13 +1,17 @@
-import { ColDivProps } from "../layout/types";
+import { ColProps } from "../layout/types";
 
 export type DividerLineStyleType = "solid" | "dashed";
 type DividerLayoutType = "flex" | "grid";
 
-export interface DividerProps extends ColDivProps {
+export interface DividerProps
+    extends ColProps,
+        Omit<React.HTMLAttributes<HTMLElement>, "color"> {
     /** The thickness of the Divider in px */
     thickness?: number | undefined;
     /** The line display style type. Values: "solid" | "dashed" */
     lineStyle?: DividerLineStyleType | undefined;
     /** The layout type. Values: "flex" | "grid" */
     layoutType?: DividerLayoutType | undefined;
+    /** The line color */
+    color?: string | ((props: unknown) => string) | undefined;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export * from "./data-table";
 export * from "./date-input";
 export * from "./date-range-input";
 export * from "./design-token";
+export * from "./divider";
 export * from "./drawer";
 export * from "./error-display";
 export * from "./feedback-rating";

--- a/src/layout/types.ts
+++ b/src/layout/types.ts
@@ -27,8 +27,7 @@ type TabletColRange = TabletCol | 9;
 type DesktopCol = TabletCol | 9 | 10 | 11 | 12;
 type DesktopColRange = DesktopCol | 13;
 
-export interface ColDivProps extends React.HTMLAttributes<HTMLDivElement> {
-    "data-testid"?: string | undefined;
+export interface ColProps {
     /**
      * Specifies the number of columns to be span across in mobile viewports.
      * If an array is specified, the format is as such [startCol, endCol].
@@ -57,4 +56,10 @@ export interface ColDivProps extends React.HTMLAttributes<HTMLDivElement> {
      * column.
      */
     desktopCols?: DesktopCol | [DesktopColRange, DesktopColRange] | undefined;
+}
+
+export interface ColDivProps
+    extends React.HTMLAttributes<HTMLDivElement>,
+        ColProps {
+    "data-testid"?: string | undefined;
 }

--- a/stories/divider/divider.stories.mdx
+++ b/stories/divider/divider.stories.mdx
@@ -27,10 +27,9 @@ import { Divider } from "@lifesg/react-design-system/divider";
     <Story name="Divider">
         <Wrapper type="flex-column">
             <DisplayText>Standard divider</DisplayText>
-            <Divider />
-            <br />
+            <Divider style={{ marginBottom: "1.5rem" }} />
             <DisplayText>Dashed styled divider</DisplayText>
-            <Divider lineStyle="dashed" />
+            <Divider lineStyle="dashed" style={{ marginBottom: "1.5rem" }} />
         </Wrapper>
     </Story>
 </Canvas>
@@ -44,21 +43,27 @@ will enable you to make use of the grid column props.
 <Canvas>
     <Story name="Using in grid layout">
         <Layout.Content type="grid" style={{ padding: "5rem" }}>
-            <DisplayText>Standard divider (grid layout)</DisplayText>
-            <Divider layoutType="grid" />
-            <br />
-            <DisplayText>Dashed divider (grid layout)</DisplayText>
-            <Divider layoutType="grid" lineStyle="dashed" />
-            <br />
-            <DisplayText>
-                With custom grid column props (grid layout)
-            </DisplayText>
+            <DisplayText>Dividers in the grid layout</DisplayText>
+            <Divider layoutType="grid" style={{ marginBottom: "1.5rem" }} />
+            <Divider
+                layoutType="grid"
+                lineStyle="dashed"
+                style={{ marginBottom: "1.5rem" }}
+            />
+            <DisplayText>With custom grid column props</DisplayText>
             <Divider
                 layoutType="grid"
                 mobileCols={3}
                 tabletCols={4}
                 desktopCols={5}
-                style={{ marginBottom: "2rem" }}
+            />
+            <br />
+            <Divider
+                layoutType="grid"
+                lineStyle="dashed"
+                mobileCols={3}
+                tabletCols={4}
+                desktopCols={5}
             />
         </Layout.Content>
     </Story>
@@ -66,8 +71,7 @@ will enable you to make use of the grid column props.
 
 <Heading3>Customisations</Heading3>
 
-Apart from implementing your own style via [Styled Components](https://styled-components.com/docs) or using style classes,
-there are props provided to enable basic customisations.
+Props like `color` and `thickness` makes it easier to customise the `Divider`.
 
 <Canvas>
     <Story name="Customisations">
@@ -76,7 +80,13 @@ there are props provided to enable basic customisations.
             <Divider
                 layoutType="grid"
                 color="red"
-                style={{ marginBottom: "2rem" }}
+                style={{ marginBottom: "1.5rem" }}
+            />
+            <Divider
+                layoutType="grid"
+                lineStyle="dashed"
+                color="red"
+                style={{ marginBottom: "1.5rem" }}
             />
             <DisplayText>
                 Changing the color (Using the Color component)
@@ -84,37 +94,29 @@ there are props provided to enable basic customisations.
             <Divider
                 layoutType="grid"
                 color={Color.Primary}
-                style={{ marginBottom: "2rem" }}
+                style={{ marginBottom: "1.5rem" }}
+            />
+            <Divider
+                layoutType="grid"
+                lineStyle="dashed"
+                color={Color.Primary}
+                style={{ marginBottom: "1.5rem" }}
             />
             <DisplayText>Changing the thickness</DisplayText>
             <Divider
                 layoutType="grid"
                 thickness={5}
-                style={{ marginBottom: "2rem" }}
+                style={{ marginBottom: "1.5rem" }}
+            />
+            <Divider
+                layoutType="grid"
+                lineStyle="dashed"
+                thickness={5}
+                style={{ marginBottom: "1.5rem" }}
             />
         </Layout.Content>
     </Story>
 </Canvas>
-
-<Heading4>Via the Styled Components method</Heading4>
-
-```tsx
-import { Divider } from "@lifesg/react-design-system/divider";
-import styled from "styled-components";
-
-export const StyledDivider = styled(Divider)`
-    border-top-width: 5px;
-    border-top-color: #097123;
-`;
-
-// If intending to use with layoutType = "grid"
-export const StyledDivider = styled(Divider)`
-    [data-id="divider"] {
-        border-top-width: 5px;
-        border-top-color: #097123;
-    }
-`;
-```
 
 <Secondary>Component API</Secondary>
 

--- a/stories/divider/divider.stories.mdx
+++ b/stories/divider/divider.stories.mdx
@@ -1,0 +1,101 @@
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Divider } from "src/divider";
+import { Layout } from "src/layout";
+import { Text } from "src/text";
+import { Secondary, Heading3, Heading4, Title } from "../storybook-common";
+import { DisplayText, Wrapper } from "./doc-elements";
+import { PropsTable } from "./props-table";
+
+<Meta
+    title="General/Divider"
+    component={Divider}
+    parameters={{ layout: "fullscreen" }}
+/>
+
+<Title>Divider</Title>
+
+<Secondary>Overview</Secondary>
+
+A component that renders a horizontal line.
+
+```tsx
+import { Divider } from "@lifesg/react-design-system/divider";
+```
+
+<Canvas>
+    <Story name="Divider">
+        <Wrapper type="flex-column">
+            <DisplayText>Standard divider</DisplayText>
+            <Divider />
+            <br />
+            <DisplayText>Dashed styled divider</DisplayText>
+            <Divider lineStyle="dashed" />
+        </Wrapper>
+    </Story>
+</Canvas>
+
+<Heading3>Using in grid layouts</Heading3>
+
+When rendering in grid layouts, you will need to specify the `layoutType` correctly
+to allow the `Divider` to span across the full width of it's parent container. Doing so
+will enable you to make use of the grid column props.
+
+<Canvas>
+    <Story name="Using in grid layout">
+        <Layout.Content type="grid" style={{ padding: "5rem" }}>
+            <DisplayText>Standard divider (grid layout)</DisplayText>
+            <Divider layoutType="grid" />
+            <br />
+            <DisplayText>Dashed divider (grid layout)</DisplayText>
+            <Divider layoutType="grid" lineStyle="dashed" />
+            <br />
+            <DisplayText>
+                With custom grid column props (grid layout)
+            </DisplayText>
+            <Divider
+                layoutType="grid"
+                mobileCols={3}
+                tabletCols={4}
+                desktopCols={5}
+                style={{ marginBottom: "2rem" }}
+            />
+        </Layout.Content>
+    </Story>
+</Canvas>
+
+<Heading3>Customisations</Heading3>
+
+Apart from implementing your own style via [Styled Components](https://styled-components.com/docs) or using style classes,
+there are props provided to enable basic customisations.
+
+<Canvas>
+    <Story name="Customisations">
+        <Layout.Content type="grid" style={{ padding: "5rem" }}>
+            <DisplayText>Changing the color</DisplayText>
+            <Divider
+                layoutType="grid"
+                color="red"
+                style={{ marginBottom: "2rem" }}
+            />
+            <DisplayText>Changing the thickness</DisplayText>
+            <Divider
+                layoutType="grid"
+                thickness={5}
+                style={{ marginBottom: "2rem" }}
+            />
+        </Layout.Content>
+    </Story>
+</Canvas>
+
+<Heading4>Via the Styled Components method</Heading4>
+
+```tsx
+export const StyledDivider = styled(Divider)`
+    border-top-width: 5px;
+    border-top-color: #097123;
+`;
+```
+
+<Secondary>Component API</Secondary>
+
+<PropsTable />

--- a/stories/divider/divider.stories.mdx
+++ b/stories/divider/divider.stories.mdx
@@ -1,4 +1,5 @@
 import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Color } from "src/color";
 import { Divider } from "src/divider";
 import { Layout } from "src/layout";
 import { Text } from "src/text";
@@ -71,10 +72,18 @@ there are props provided to enable basic customisations.
 <Canvas>
     <Story name="Customisations">
         <Layout.Content type="grid" style={{ padding: "5rem" }}>
-            <DisplayText>Changing the color</DisplayText>
+            <DisplayText>Changing the color (pure string)</DisplayText>
             <Divider
                 layoutType="grid"
                 color="red"
+                style={{ marginBottom: "2rem" }}
+            />
+            <DisplayText>
+                Changing the color (Using the Color component)
+            </DisplayText>
+            <Divider
+                layoutType="grid"
+                color={Color.Primary}
                 style={{ marginBottom: "2rem" }}
             />
             <DisplayText>Changing the thickness</DisplayText>
@@ -90,9 +99,20 @@ there are props provided to enable basic customisations.
 <Heading4>Via the Styled Components method</Heading4>
 
 ```tsx
+import { Divider } from "@lifesg/react-design-system/divider";
+import styled from "styled-components";
+
 export const StyledDivider = styled(Divider)`
     border-top-width: 5px;
     border-top-color: #097123;
+`;
+
+// If intending to use with layoutType = "grid"
+export const StyledDivider = styled(Divider)`
+    [data-id="divider"] {
+        border-top-width: 5px;
+        border-top-color: #097123;
+    }
 `;
 ```
 

--- a/stories/divider/divider.stories.mdx
+++ b/stories/divider/divider.stories.mdx
@@ -53,17 +53,17 @@ will enable you to make use of the grid column props.
             <DisplayText>With custom grid column props</DisplayText>
             <Divider
                 layoutType="grid"
-                mobileCols={3}
-                tabletCols={4}
-                desktopCols={5}
+                mobileCols={[1, 3]}
+                tabletCols={[1, 4]}
+                desktopCols={[1, 5]}
+                style={{ marginBottom: "1.5rem" }}
             />
-            <br />
             <Divider
                 layoutType="grid"
                 lineStyle="dashed"
-                mobileCols={3}
-                tabletCols={4}
-                desktopCols={5}
+                mobileCols={[1, 3]}
+                tabletCols={[1, 4]}
+                desktopCols={[1, 5]}
             />
         </Layout.Content>
     </Story>

--- a/stories/divider/doc-elements.tsx
+++ b/stories/divider/doc-elements.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import styled from "styled-components";
+import { Layout } from "../../src/layout";
+import { Text } from "../../src/text";
+
+export const Wrapper = styled(Layout.Content)`
+    padding: 5rem;
+`;
+
+export const TextComponent = styled(Text.Body)`
+    margin-bottom: 1rem;
+`;
+
+export const DisplayText = ({ children }: { children: JSX.Element }) => {
+    return (
+        <Layout.ColDiv desktopCols={12} tabletCols={8} mobileCols={4}>
+            <TextComponent>{children}</TextComponent>
+        </Layout.ColDiv>
+    );
+};

--- a/stories/divider/props-table.tsx
+++ b/stories/divider/props-table.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { ApiTable, code } from "../storybook-common/api-table";
+import { ApiTableSectionProps } from "../storybook-common/api-table/types";
+
+const DATA: ApiTableSectionProps[] = [
+    {
+        attributes: [
+            {
+                name: "",
+                description: (
+                    <>
+                        This component also inherits props from&nbsp;
+                        <a
+                            href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement"
+                            rel="noreferrer"
+                            target="_blank"
+                        >
+                            HTMLDivElement
+                        </a>
+                        .
+                        <br />
+                        <br />
+                        Additionally, it also inherits the column props
+                        from&nbsp;
+                        <a
+                            href="/?path=/docs/getting-started-layout-column-divs--column-divs"
+                            rel="noreferrer"
+                            target="_blank"
+                        >
+                            ColDiv
+                        </a>
+                        &nbsp;which can be helpful when using with{" "}
+                        {code(`"grid"`)} layout type
+                    </>
+                ),
+            },
+            {
+                name: "thickness",
+                description: (
+                    <>The thickness/height of the {code("Divider")} in px</>
+                ),
+                propTypes: ["number"],
+                defaultValue: "1",
+            },
+            {
+                name: "lineStyle",
+                description: <>The style type for the {code("Divider")} line</>,
+                propTypes: [`"solid"`, `"dashed"`],
+                defaultValue: `"solid"`,
+            },
+            {
+                name: "layoutType",
+                description: <>The style type for the {code("Divider")} line</>,
+                propTypes: [`"flex"`, `"grid"`],
+                defaultValue: `"flex"`,
+            },
+        ],
+    },
+];
+
+export const PropsTable = () => <ApiTable sections={DATA} />;

--- a/stories/divider/props-table.tsx
+++ b/stories/divider/props-table.tsx
@@ -11,26 +11,12 @@ const DATA: ApiTableSectionProps[] = [
                     <>
                         This component also inherits props from&nbsp;
                         <a
-                            href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement"
+                            href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
                             rel="noreferrer"
                             target="_blank"
                         >
-                            HTMLDivElement
+                            HTMLElement
                         </a>
-                        .
-                        <br />
-                        <br />
-                        Additionally, it also inherits the column props
-                        from&nbsp;
-                        <a
-                            href="/?path=/docs/getting-started-layout-column-divs--column-divs"
-                            rel="noreferrer"
-                            target="_blank"
-                        >
-                            ColDiv
-                        </a>
-                        &nbsp;which can be helpful when using with{" "}
-                        {code(`"grid"`)} layout type
                     </>
                 ),
             },
@@ -53,6 +39,81 @@ const DATA: ApiTableSectionProps[] = [
                 description: <>The style type for the {code("Divider")} line</>,
                 propTypes: [`"flex"`, `"grid"`],
                 defaultValue: `"flex"`,
+            },
+            {
+                name: "color",
+                description: <>The color for the {code("Divider")} line</>,
+                propTypes: ["string", "(props: unknown) => string"],
+            },
+            // Copied from `layout/col-div-props-table.tsx`
+            {
+                name: "mobileCols",
+                description: (
+                    <>
+                        Refer to{" "}
+                        <a
+                            href="/?path=/docs/getting-started-layout-column-divs--column-divs#component-api"
+                            rel="noreferrer"
+                            target="_blank"
+                        >
+                            ColDiv
+                        </a>
+                        &nbsp; for more details
+                        <br />
+                        <em>
+                            Note: This works only if you are using the
+                            {code(`"grid"`)} layout type
+                        </em>
+                    </>
+                ),
+                propTypes: [`number`, `number[]`],
+                defaultValue: "4",
+            },
+            {
+                name: "tabletCols",
+                description: (
+                    <>
+                        Refer to{" "}
+                        <a
+                            href="/?path=/docs/getting-started-layout-column-divs--column-divs#component-api"
+                            rel="noreferrer"
+                            target="_blank"
+                        >
+                            ColDiv
+                        </a>
+                        &nbsp; for more details
+                        <br />
+                        <em>
+                            Note: This works only if you are using the
+                            {code(`"grid"`)} layout type
+                        </em>
+                    </>
+                ),
+                propTypes: [`number`, `number[]`],
+                defaultValue: "8",
+            },
+            {
+                name: "desktopCols",
+                description: (
+                    <>
+                        Refer to{" "}
+                        <a
+                            href="/?path=/docs/getting-started-layout-column-divs--column-divs#component-api"
+                            rel="noreferrer"
+                            target="_blank"
+                        >
+                            ColDiv
+                        </a>
+                        &nbsp; for more details
+                        <br />
+                        <em>
+                            Note: This works only if you are using the
+                            {code(`"grid"`)} layout type
+                        </em>
+                    </>
+                ),
+                propTypes: [`number`, `number[]`],
+                defaultValue: "12",
             },
         ],
     },


### PR DESCRIPTION
**Changes**
- Add Divider component
- Had to introduce own props since the props for horizontal rule html component are deprecated
- Use svg for dashed style due to specific requirements that UX needs

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Add `Divider` component to enable rendering of horizontal rules or dividers in pages

**Additional information**

- You may refer to this [ticket](https://jira.ship.gov.sg/browse/CCUBE-491)
- [Figma](https://figma.fun/q4fP3U)
