### PR TITLE
Specified N1 colour for text in alert boxes

### DIFF
--- a/src/alert/alert.style.tsx
+++ b/src/alert/alert.style.tsx
@@ -20,6 +20,7 @@ export const Wrapper = styled.div<StyleProps>`
     padding: 0.5rem 1rem 0.5rem 0.875rem;
     display: flex;
     ${TextStyleHelper.getTextStyle("BodySmall", "regular")}
+    color: ${Color.Neutral[1]};
 
     ${(props) => {
         let backgroundColor: string;
@@ -53,8 +54,7 @@ export const Wrapper = styled.div<StyleProps>`
 
         return css`
             background: ${backgroundColor};
-            border-left: 2pt solid ${borderColor};
-            color: ${Color.Neutral[1]};
+            border-left: 2px solid ${borderColor};
         `;
     }}
 

--- a/src/alert/alert.style.tsx
+++ b/src/alert/alert.style.tsx
@@ -54,6 +54,7 @@ export const Wrapper = styled.div<StyleProps>`
         return css`
             background: ${backgroundColor};
             border-left: 2pt solid ${borderColor};
+            color: ${Color.Neutral[1]};
         `;
     }}
 

--- a/tests/alert/alert.spec.tsx
+++ b/tests/alert/alert.spec.tsx
@@ -31,7 +31,7 @@ describe("Alert", () => {
 
                 expect(screen.getByText(DEFAULT_TEXT)).toHaveStyle({
                     backgroundColor,
-                    borderColor: `2pt solid ${borderColor}`,
+                    borderColor: `2px solid ${borderColor}`,
                 });
             }
         );


### PR DESCRIPTION
**Changes**
Changed colour of body text in alert boxes to N1. 
Previously was #484848 (inherited from SGDS CSS styling since no colour was specified).

- [delete] branch

**Additional information**

- Was raised by Karling on Slack (25 Oct)

