### PR TITLE
Fix date range overflow within narrow parent container

### DIFF
--- a/src/date-range-input/date-range-input.style.tsx
+++ b/src/date-range-input/date-range-input.style.tsx
@@ -1,21 +1,35 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { InputWrapper } from "../shared/input-wrapper/input-wrapper";
 
-export const MOBILE_WRAP_WIDTH = 374;
+// =============================================================================
+// STYLE INTERFACE
+// =============================================================================
+interface StyleProps {
+    $wrap: boolean;
+}
 
-export const Container = styled(InputWrapper)`
-    @media screen and (max-width: ${MOBILE_WRAP_WIDTH}px) {
-        padding: 0.75rem 1rem;
-    }
+export const MOBILE_WRAP_WIDTH = 320;
+
+// =============================================================================
+// STYLING
+// =============================================================================
+export const Container = styled(InputWrapper)<StyleProps>`
+    ${(props) =>
+        props.$wrap &&
+        css`
+            padding: 0.75rem 1rem;
+        `}
 `;
 
-export const InputContainer = styled.div`
+export const InputContainer = styled.div<StyleProps>`
     display: flex;
     align-items: center;
     height: calc(3rem - 2px); // exclude top and bottom borders
     width: 100%;
 
-    @media screen and (max-width: ${MOBILE_WRAP_WIDTH}px) {
-        height: fit-content;
-    }
+    ${(props) =>
+        props.$wrap &&
+        css`
+            height: fit-content;
+        `}
 `;

--- a/src/date-range-input/date-range-input.tsx
+++ b/src/date-range-input/date-range-input.tsx
@@ -13,7 +13,7 @@ import {
     StandaloneDateInput,
     StandaloneDateInputRef,
 } from "../shared/standalone-date-input/standalone-date-input";
-import { DateHelper, DateInputHelper } from "../util";
+import { DateHelper, DateInputHelper, useContainerQuery } from "../util";
 import { useStateActions } from "../util/use-state-actions";
 import {
     Container,
@@ -163,6 +163,10 @@ export const DateRangeInput = ({
     const endInputRef = useRef<StandaloneDateInputRef>();
     const isMobile = useMediaQuery({
         maxWidth: MediaWidths.mobileL,
+    });
+    const shouldWrap = useContainerQuery({
+        maxWidth: MOBILE_WRAP_WIDTH,
+        targetRef: nodeRef,
     });
 
     // show button if it is mobile view
@@ -455,6 +459,7 @@ export const DateRangeInput = ({
             $disabled={disabled}
             $readOnly={readOnly}
             $error={error}
+            $wrap={shouldWrap}
             id={id}
             data-testid={otherProps["data-testid"]}
             onBlur={handleNodeBlur}
@@ -463,10 +468,10 @@ export const DateRangeInput = ({
         >
             <RangeInputInnerContainer
                 currentActive={currentFocus}
-                minWidthBeforeWrap={MOBILE_WRAP_WIDTH}
+                wrap={shouldWrap}
                 error={error}
             >
-                <InputContainer>
+                <InputContainer $wrap={shouldWrap}>
                     <StandaloneDateInput
                         ref={startInputRef}
                         placeholder="From"
@@ -481,7 +486,7 @@ export const DateRangeInput = ({
                         onBlur={handleStartInputBlur}
                     />
                 </InputContainer>
-                <InputContainer>
+                <InputContainer $wrap={shouldWrap}>
                     <StandaloneDateInput
                         ref={endInputRef}
                         placeholder="To"

--- a/src/shared/range-input-inner-container/range-input-inner-container.styles.tsx
+++ b/src/shared/range-input-inner-container/range-input-inner-container.styles.tsx
@@ -6,7 +6,7 @@ import { Color } from "../../color";
 // STYLE INTERFACE
 // =============================================================================
 interface GeneralStyleProps {
-    $minWidthBeforeWrap?: number;
+    $wrap?: boolean;
 }
 
 interface IndicatorStyleProps extends GeneralStyleProps {
@@ -18,10 +18,6 @@ interface IndicatorStyleProps extends GeneralStyleProps {
 // STYLING
 // =============================================================================
 
-const getDynamicMediaWidthQuery = (width: number) => {
-    return `@media screen and (max-width: ${width}px)`;
-};
-
 export const Wrapper = styled.div<GeneralStyleProps>`
     position: relative;
     height: 100%;
@@ -29,30 +25,39 @@ export const Wrapper = styled.div<GeneralStyleProps>`
     flex: 1;
 
     ${(props) => {
-        if (props.$minWidthBeforeWrap) {
+        if (props.$wrap) {
             return css`
-                ${getDynamicMediaWidthQuery(props.$minWidthBeforeWrap)} {
-                    /* Parent container need to provide space */
-                    flex-wrap: wrap;
+                /* Parent container need to provide space */
+                flex-wrap: wrap;
 
-                    [data-id="range-container-elem1-container"],
-                    [data-id="range-container-elem2-container"] {
-                        // 100% - Icon size - 2padding
-                        max-width: calc(100% - 1.125rem - 1rem);
-                        flex: unset;
-                    }
+                [data-id="range-container-elem1-container"],
+                [data-id="range-container-elem2-container"] {
+                    // 100% - Icon size - 2padding
+                    max-width: calc(100% - 1.125rem - 1rem);
+                    flex: unset;
+                }
 
-                    [data-id="range-container-elem2-container"] {
-                        margin-top: 0.5rem;
-                    }
+                [data-id="range-container-elem2-container"] {
+                    margin-top: 0.5rem;
                 }
             `;
         }
     }}
 `;
 
+export const Break = styled.div<GeneralStyleProps>`
+    width: 100%; // Force next flex item to break to next line
+    display: none;
+    ${(props) => {
+        if (props.$wrap) {
+            return css`
+                display: block;
+            `;
+        }
+    }}
+`;
+
 export const ElementContainer = styled.div`
-    height: 100%;
     display: flex;
     flex: 1;
     align-items: center;
@@ -99,11 +104,9 @@ export const Indicator = styled.div<IndicatorStyleProps>`
     }}
 
     ${(props) => {
-        if (props.$minWidthBeforeWrap) {
+        if (props.$wrap) {
             return css`
-                ${getDynamicMediaWidthQuery(props.$minWidthBeforeWrap)} {
-                    display: none;
-                }
+                display: none;
             `;
         }
     }}

--- a/src/shared/range-input-inner-container/range-input-inner-container.styles.tsx
+++ b/src/shared/range-input-inner-container/range-input-inner-container.styles.tsx
@@ -45,16 +45,8 @@ export const Wrapper = styled.div<GeneralStyleProps>`
     }}
 `;
 
-export const Break = styled.div<GeneralStyleProps>`
+export const Break = styled.div`
     width: 100%; // Force next flex item to break to next line
-    display: none;
-    ${(props) => {
-        if (props.$wrap) {
-            return css`
-                display: block;
-            `;
-        }
-    }}
 `;
 
 export const ElementContainer = styled.div`

--- a/src/shared/range-input-inner-container/range-input-inner-container.tsx
+++ b/src/shared/range-input-inner-container/range-input-inner-container.tsx
@@ -1,5 +1,6 @@
 import {
     ArrowRight,
+    Break,
     ElementContainer,
     Indicator,
     Wrapper,
@@ -15,7 +16,7 @@ export const RangeInputInnerContainer = ({
     currentActive,
     error,
     className,
-    minWidthBeforeWrap,
+    wrap,
 }: RangeInputInnerContainerProps) => {
     // =========================================================================
     // CONST, STATE
@@ -26,11 +27,12 @@ export const RangeInputInnerContainer = ({
     // RENDER FUNCTIONS
     // =========================================================================
     return (
-        <Wrapper className={className} $minWidthBeforeWrap={minWidthBeforeWrap}>
+        <Wrapper className={className} $wrap={wrap}>
             <ElementContainer data-id="range-container-elem1-container">
                 {elem1}
             </ElementContainer>
             <ArrowRight />
+            <Break $wrap={wrap} />
             <ElementContainer data-id="range-container-elem2-container">
                 {elem2}
             </ElementContainer>
@@ -38,7 +40,7 @@ export const RangeInputInnerContainer = ({
                 data-id="range-container-indicator"
                 $position={currentActive}
                 $error={error}
-                $minWidthBeforeWrap={minWidthBeforeWrap}
+                $wrap={wrap}
             />
         </Wrapper>
     );

--- a/src/shared/range-input-inner-container/range-input-inner-container.tsx
+++ b/src/shared/range-input-inner-container/range-input-inner-container.tsx
@@ -32,7 +32,7 @@ export const RangeInputInnerContainer = ({
                 {elem1}
             </ElementContainer>
             <ArrowRight />
-            <Break $wrap={wrap} />
+            {wrap && <Break />}
             <ElementContainer data-id="range-container-elem2-container">
                 {elem2}
             </ElementContainer>

--- a/src/shared/range-input-inner-container/types.ts
+++ b/src/shared/range-input-inner-container/types.ts
@@ -8,9 +8,5 @@ export interface RangeInputInnerContainerProps {
     children: [JSX.Element, JSX.Element];
     currentActive: "start" | "end" | "none";
     className?: string | undefined;
-    /**
-     * Defines the min width (inclusive) before the layout
-     * wraps (in px), if not defined, no wrap will occur
-     */
-    minWidthBeforeWrap?: number | undefined;
+    wrap?: boolean | undefined;
 }

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -3,5 +3,6 @@ export * from "./date-helper";
 export * from "./date-input-helper";
 export * from "./simple-id-generator";
 export * from "./string-helper";
+export * from "./use-container-query";
 export * from "./use-next-input-state";
 export * from "./use-state-ref";

--- a/src/util/use-container-query.tsx
+++ b/src/util/use-container-query.tsx
@@ -1,0 +1,34 @@
+import { RefObject, useCallback, useState } from "react";
+import { useResizeDetector } from "react-resize-detector";
+
+interface Options<T> {
+    maxWidth: number;
+    targetRef?: RefObject<T>;
+}
+
+/**
+ * Detect if container width satisfies the breakpoint
+ */
+export const useContainerQuery = <T extends HTMLElement>({
+    maxWidth,
+    targetRef,
+}: Options<T>): boolean => {
+    const [belowBreakpoint, setBelowBreakpoint] = useState(false);
+
+    const handleResize = useCallback(
+        (width) => {
+            setBelowBreakpoint(width <= maxWidth);
+        },
+        [maxWidth]
+    );
+
+    useResizeDetector<T>({
+        targetRef,
+        refreshMode: "throttle",
+        refreshRate: 300,
+        handleHeight: false,
+        onResize: handleResize,
+    });
+
+    return belowBreakpoint;
+};


### PR DESCRIPTION
Resolves #344

**Changes**

- Set date range field to wrap based on its actual width instead of media query
- Using code to detect the changes and toggle wrapping as we don't have access to css container queries
- Also fixes an issue on grid layout (see screenshot below)
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Fix value overflow in `DateRangeInput` on smaller device widths

<img width="292" alt="Screenshot 2023-10-31 at 5 58 13 PM" src="https://github.com/LifeSG/react-design-system/assets/16853062/496bf7e6-85ec-4aa4-9504-c08253056a7c">
