### PR TITLE
Add MyLegacy theme

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,8 +2,8 @@ import { withThemes } from "@react-theming/storybook-addon";
 import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport";
 import { addDecorator } from "@storybook/react";
 import pretty from "pretty";
+import { BaseTheme, BookingSGTheme, MyLegacyTheme, RBSTheme } from "src/theme";
 import { ThemeProvider } from "styled-components";
-import { BaseTheme, BookingSGTheme, RBSTheme } from "src/theme";
 
 export const parameters = {
     viewport: {
@@ -36,6 +36,7 @@ export const parameters = {
 const themes = [
     { ...BaseTheme, name: "LifeSG" },
     { ...BookingSGTheme, name: "BookingSG" },
+    { ...MyLegacyTheme, name: "MyLegacy" },
     { ...RBSTheme, name: "RBS" },
 ];
 

--- a/src/spec/color-spec/mylegacy-color-set.ts
+++ b/src/spec/color-spec/mylegacy-color-set.ts
@@ -1,0 +1,72 @@
+import { ColorSet, ValidationTypes } from "../../color/types";
+
+export const MyLegacyColorSet: ColorSet = {
+    Brand: {
+        1: "#24588D",
+        2: "#FFC166",
+        3: "#F58E8B",
+        4: "#F9B5B2",
+        5: "#FDDDD7",
+        6: "#FFEEEA",
+    },
+    Primary: "#0C7BB3",
+    PrimaryDark: "#066391",
+    Secondary: "#066391",
+    Accent: {
+        Dark: {
+            1: "#4B539F",
+            2: "#6D74B1",
+            3: "#959BC5",
+        },
+        Light: {
+            1: "#229AD6",
+            2: "#8DD4F7",
+            3: "#A4DDF9",
+            4: "#BBE5FA",
+            5: "#E8F4FA",
+            6: "#F7FBFC",
+        },
+    },
+    Neutral: {
+        1: "#282828",
+        2: "#424242",
+        3: "#686868",
+        4: "#A4A4A4",
+        5: "#E0E4E5",
+        6: "#ECEFEF",
+        7: "#F8F8F8",
+        8: "#FFFFFF",
+    },
+    Validation: {
+        Green: {
+            Text: "#1A5230", // Validation Text
+            Icon: "#2A854E",
+            Border: "#7DDBA3",
+            Background: "#E1FAEB", // Validation Background
+        },
+        Orange: {
+            Text: "#693D07", // Validation Text
+            Icon: "#CF7911",
+            Border: "#F9CB77",
+            Background: "#FCF2E6", // Validation Background
+            Badge: "#F57F17", // Orange Badge Notification
+        },
+        Red: {
+            Text: "#8F0E0E", // Validation Text
+            Icon: "#CB2213",
+            Border: "#DC6363",
+            Background: "#FAF0F0", // Validation Background
+        },
+        Blue: {
+            Text: "#064D70", // Validation Text
+            Icon: " #066391",
+            Border: "#84B7DB",
+            Background: "#E8F4FA", // Validation Background
+        },
+    } as ValidationTypes,
+    Shadow: {
+        Accent: "rgba(34, 154, 214, 0.6)",
+        Red: "rgba(203, 34, 19, 0.5)",
+        Elevation: "rgba(75, 83, 159, 0.24)",
+    },
+};

--- a/src/theme/color-theme-helper.ts
+++ b/src/theme/color-theme-helper.ts
@@ -1,6 +1,7 @@
 import { ColorSet } from "../color/types";
 import { BaseColorSet } from "../spec/color-spec/base-color-set";
 import { BookingSGColorSet } from "../spec/color-spec/bookingsg-color-set";
+import { MyLegacyColorSet } from "../spec/color-spec/mylegacy-color-set";
 import { RBSColorSet } from "../spec/color-spec/rbs-color-set";
 import { getCollection, getValue } from "./helper";
 import {
@@ -19,6 +20,7 @@ const ColorSpec: ThemeCollectionSpec<ColorCollectionsMap, ColorScheme> = {
         base: BaseColorSet,
         bookingsg: BookingSGColorSet,
         rbs: RBSColorSet,
+        mylegacy: MyLegacyColorSet,
     },
     defaultValue: "base",
 };

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -21,4 +21,11 @@ export const RBSTheme: ThemeSpec = {
     [ThemeContextKeys.resourceScheme]: "rbs",
 };
 
+export const MyLegacyTheme: ThemeSpec = {
+    [ThemeContextKeys.colorScheme]: "mylegacy",
+    [ThemeContextKeys.textStyleScheme]: "base",
+    [ThemeContextKeys.designTokenScheme]: "base",
+    [ThemeContextKeys.resourceScheme]: "base",
+};
+
 export * from "./types";

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -7,7 +7,7 @@ export type ThemeLayout = "normal";
 // =============================================================================
 // COLOR THEMES
 // =============================================================================
-export type ColorScheme = "base" | "bookingsg" | "rbs";
+export type ColorScheme = "base" | "bookingsg" | "rbs" | "mylegacy";
 export type ColorCollectionsMap = {
     [key in ColorScheme]: ColorSet;
 };

--- a/stories/color/base-color.stories.mdx
+++ b/stories/color/base-color.stories.mdx
@@ -22,7 +22,7 @@ This will be the palette used when the `colorScheme` is `"base"`.
 ```tsx
 const theme: ThemeSpec = {
     colorScheme: "base",
-	...other specifications
+    // ...other specifications
 };
 ```
 

--- a/stories/color/bsg-color.stories.mdx
+++ b/stories/color/bsg-color.stories.mdx
@@ -22,7 +22,7 @@ This will be the palette used when the `colorScheme` is `"bookingsg"`.
 ```tsx
 const theme: ThemeSpec = {
     colorScheme: "bookingsg",
-	...other specifications
+    // ...other specifications
 };
 ```
 

--- a/stories/color/mylegacy-color.stories.mdx
+++ b/stories/color/mylegacy-color.stories.mdx
@@ -1,0 +1,56 @@
+import { Meta } from "@storybook/addon-docs";
+import {
+    Heading3,
+    Heading4,
+    PreviewBox,
+    Secondary,
+    StoryContainer,
+    Title,
+} from "../storybook-common";
+import { Text } from "src/text";
+import { ColorPalette } from "./doc-color-palette";
+import { MyLegacyColorSet } from "src/spec/color-spec/mylegacy-color-set";
+
+<Meta title="General/Color/MyLegacy Color" />
+
+<Title>MyLegacy Colors</Title>
+
+<Secondary>Overview</Secondary>
+
+This will be the palette used when the `colorScheme` is `"mylegacy"`.
+
+```tsx
+const theme: ThemeSpec = {
+    colorScheme: "mylegacy",
+    // ...other specifications
+};
+```
+
+<Secondary>Colors</Secondary>
+
+<ColorPalette set={MyLegacyColorSet.Brand} category="Brand" />
+<ColorPalette
+    set={{
+        Primary: MyLegacyColorSet.Primary,
+        PrimaryDark: MyLegacyColorSet.PrimaryDark,
+        Secondary: MyLegacyColorSet.Secondary,
+    }}
+/>
+<ColorPalette set={MyLegacyColorSet.Neutral} category="Neutral" />
+
+<ColorPalette set={MyLegacyColorSet.Accent.Dark} category="Accent.Dark" />
+
+<ColorPalette set={MyLegacyColorSet.Accent.Light} category="Accent.Light" />
+
+<br />
+
+<Text.H3>Validation</Text.H3>
+
+<PreviewBox>
+    <code>{"Color.Validation.<color>"}</code>
+</PreviewBox>
+
+<ColorPalette set={MyLegacyColorSet.Validation.Green} category="Green" />
+<ColorPalette set={MyLegacyColorSet.Validation.Orange} category="Orange" />
+<ColorPalette set={MyLegacyColorSet.Validation.Red} category="Red" />
+<ColorPalette set={MyLegacyColorSet.Validation.Blue} category="Blue" />


### PR DESCRIPTION
**Changes**

- Add new color scheme and new theme for MyLegacy
- Add color story and add to theme options in Storybook canvas panel
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Introduce MyLegacy theme

**Additional information**

- You may refer to this [Figma](https://www.figma.com/file/us90jOpWBahsqK2VAluPvD/Flagship-Design-System?type=design&node-id=10573%3A76668&mode=dev)
- Not a 1:1 mapping
    - Secondary follows PrimaryDark
    - For colours that are not defined (i.e. Brand 3-6, Accent Dark), we fallback to the existing LifeSG palette
    - Maintenance banner and overlay theming are not needed for now
- Have run through with designers to eyeball the changes across components