### PR TITLE
Misc theme fixes

### DIFF
--- a/src/countdown-timer/countdown-timer.style.tsx
+++ b/src/countdown-timer/countdown-timer.style.tsx
@@ -62,7 +62,7 @@ export const FixedCountdown = styled(BaseCountdown)`
             /* style object will be converted to px */
             ${{ top: $top, left: $left, right: $right }}
             box-shadow: 0px 0px 4px 1px
-                ${$warn ? Color.Brand[2] : Color.Accent.Light[2]};
+                ${$warn ? Color.Validation.Red.Border : Color.Accent.Light[2]};
 
             ${MediaQuery.MaxWidth.mobileL} {
                 left: 0;

--- a/src/error-display/error-display.tsx
+++ b/src/error-display/error-display.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { useTheme } from "styled-components";
+import { BaseTheme } from "../theme";
 import { getErrorDisplayData } from "./error-display-data";
 import {
     ActionButton,
@@ -9,7 +11,6 @@ import {
     Title,
 } from "./error-display.style";
 import { ErrorDisplayProps, MaintenanceAdditionalAttributes } from "./types";
-import { useTheme } from "styled-components";
 
 export const ErrorDisplay = ({
     type,
@@ -28,7 +29,7 @@ export const ErrorDisplay = ({
     const theme = useTheme();
     const defaultAssets = getErrorDisplayData(
         type,
-        illustrationScheme || theme.resourceScheme
+        illustrationScheme || (theme || BaseTheme).resourceScheme
     );
 
     const testId = otherProps["data-testid"] || "error-display";


### PR DESCRIPTION
**Changes**

- Theme-related bug fixes
  - CountdownTimer was using `Color.Brand[2]` as the box shadow in the warning state, this works for LifeSG/BSG as the colour is red but not for RBS which is purple. Switched to the standard error color instead.
  - If ErrorDisplay is not wrapped in a ThemeProvider context, `theme` is undefined and attempting to access `theme.resourceScheme` results in an error. Added a fallback to BaseTheme.
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

Bug fix
- Fix mismatched box shadow when using other themes in `CountdownTimer`
- Fix error when `ErrorDisplay` is used without a ThemeProvider
