### PR TITLE
[CCUBE-681][DV] DateInput component - NaN display

### DIFF
--- a/src/shared/standalone-date-input/standalone-date-input.tsx
+++ b/src/shared/standalone-date-input/standalone-date-input.tsx
@@ -276,7 +276,7 @@ export const Component = (
         if (!stringVal) {
             return [undefined, undefined, undefined];
         } else {
-            const day = dayjs(stringVal, "YYYY-MM-DD");
+            const day = dayjs(stringVal);
 
             return [
                 StringHelper.padValue(day.date().toString()),

--- a/src/shared/standalone-date-input/standalone-date-input.tsx
+++ b/src/shared/standalone-date-input/standalone-date-input.tsx
@@ -276,7 +276,7 @@ export const Component = (
         if (!stringVal) {
             return [undefined, undefined, undefined];
         } else {
-            const day = dayjs(stringVal);
+            const day = dayjs(new Date(stringVal));
 
             return [
                 StringHelper.padValue(day.date().toString()),


### PR DESCRIPTION
Currently if the year has less than 4 digits, the input will display NaN, refer to image attached
To parse the date value so that the date will be displayed instead of NaN, even if the year has less than 4 digits