### PR TITLE
[MOL-13885][TK] remove isMobile from withButton

### DIFF
--- a/src/date-input/date-input.tsx
+++ b/src/date-input/date-input.tsx
@@ -46,12 +46,9 @@ export const DateInput = ({
     const nodeRef = useRef<HTMLDivElement>(null);
     const calendarRef = useRef<InternalCalendarRef>();
     const inputRef = useRef<StandaloneDateInputRef>();
-    const isMobile = useMediaQuery({
-        maxWidth: MediaWidths.mobileL,
-    });
 
     // show button if it is mobile view
-    const withButton = _withButton || isMobile;
+    const withButton = _withButton;
 
     // =============================================================================
     // EFFECTS

--- a/src/date-input/date-input.tsx
+++ b/src/date-input/date-input.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from "react";
-import { useMediaQuery } from "react-responsive";
 import {
     CalendarAction,
     InternalCalendarRef,
@@ -9,7 +8,6 @@ import {
     StandaloneDateInput,
     StandaloneDateInputRef,
 } from "../shared/standalone-date-input/standalone-date-input";
-import { MediaWidths } from "../spec/media-spec";
 import { DateInputHelper } from "../util";
 import { Container } from "./date-input.style";
 import { DateInputProps } from "./types";
@@ -25,7 +23,7 @@ export const DateInput = ({
     onFocus,
     onBlur,
     onYearMonthDisplayChange,
-    withButton: _withButton = true,
+    withButton = true,
     readOnly,
     id,
     allowDisabledSelection,
@@ -46,10 +44,6 @@ export const DateInput = ({
     const nodeRef = useRef<HTMLDivElement>(null);
     const calendarRef = useRef<InternalCalendarRef>();
     const inputRef = useRef<StandaloneDateInputRef>();
-
-    // show button if it is mobile view
-    const withButton = _withButton;
-
     // =============================================================================
     // EFFECTS
     // =============================================================================

--- a/stories/form/form-date-input/props-table.tsx
+++ b/stories/form/form-date-input/props-table.tsx
@@ -112,7 +112,6 @@ const DATA: ApiTableSectionProps[] = [
                         Specifies if the {quote("Done")} and {quote("Cancel")}{" "}
                         action buttons should be rendered
                         <br />
-                        <b>Note: It appears by default in mobile viewports</b>
                     </>
                 ),
                 propTypes: ["boolean"],

--- a/stories/form/form-date-input/props-table.tsx
+++ b/stories/form/form-date-input/props-table.tsx
@@ -111,7 +111,6 @@ const DATA: ApiTableSectionProps[] = [
                     <>
                         Specifies if the {quote("Done")} and {quote("Cancel")}{" "}
                         action buttons should be rendered
-                        <br />
                     </>
                 ),
                 propTypes: ["boolean"],


### PR DESCRIPTION
**Changes**
 iPhone Safari keyboard done dismisses the keyboard even after a valid value is input. After discussion with DS parties, to remove done and cancel button for date input without buttons variant for mobile.

- [keep | delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Remove isMobile function in date-input

**Additional information**

- You may refer to the comments on 9 oct in this [ticket](https://jira.ship.gov.sg/browse/MOL-13885)
