### PR TITLE
[MISC][WL] retain horizontal gap in uneditable section

### DIFF
--- a/src/uneditable-section/uneditable-section.styles.tsx
+++ b/src/uneditable-section/uneditable-section.styles.tsx
@@ -9,7 +9,8 @@ export const Wrapper = styled(Layout.Section)`
 `;
 
 export const Container = styled(Layout.Container)`
-    padding: 2rem 0;
+    padding-top: 2rem;
+    padding-bottom: 2rem;
 `;
 
 export const Title = styled(Text.H3)`

--- a/src/uneditable-section/uneditable-section.styles.tsx
+++ b/src/uneditable-section/uneditable-section.styles.tsx
@@ -4,11 +4,8 @@ import { Color } from "../color";
 import { MediaQuery } from "../media";
 import { Text } from "../text";
 
-export const Wrapper = styled(Layout.Section)`
+export const Wrapper = styled(Layout.Content)`
     background: ${Color.Neutral[7]};
-`;
-
-export const Container = styled(Layout.Container)`
     padding-top: 2rem;
     padding-bottom: 2rem;
 `;

--- a/src/uneditable-section/uneditable-section.tsx
+++ b/src/uneditable-section/uneditable-section.tsx
@@ -1,7 +1,6 @@
 import { UneditableSectionItem } from "./section-item";
 import { UneditableSectionProps } from "./types";
 import {
-    Container,
     CustomSection,
     Description,
     GridUl,
@@ -58,8 +57,8 @@ export const UneditableSectionBase = ({
     };
 
     return (
-        <Wrapper {...otherProps}>
-            <Container type="grid">{renderChildren()}</Container>
+        <Wrapper {...otherProps} type="grid">
+            {renderChildren()}
         </Wrapper>
     );
 };


### PR DESCRIPTION
**Changes**
- Restore `0.75rem` horizontal padding in `UneditableSection` inner container
- This allows the contents to be aligned with the rest of the `Layout.Container` layouts
 
<!-- Remove if not required -->
**Changelog entry**
- Align UneditableSection content with rest of `Layout.Container` layouts