### PR TITLE
Fix unscrollable page when overlay is unmounted

### DIFF
--- a/src/overlay/overlay.tsx
+++ b/src/overlay/overlay.tsx
@@ -40,7 +40,12 @@ export const Overlay = ({
         addStylesheetForDocumentBody();
         setRootElement(getRootElement());
 
-        return () => removeOverlay();
+        return () => {
+            removeOverlay();
+            if (getOverlayOrder().length < 1) {
+                applyBodyStyleClass("remove");
+            }
+        };
     }, []);
 
     useEffect(() => {


### PR DESCRIPTION
**Changes**

If the modal is conditionally rendered instead of toggling the show prop, the page becomes unscrollable

This was because I left out the cleanup on unmount in [this related PR](https://github.com/LifeSG/react-design-system/pull/351)

- [delete] branch

**Additional information**

- Will cherry pick this commit to v2.2.0 branch after approval