### PR TITLE
Fix NestedMultiSelect error when selected key path does not match options

### DIFF
--- a/src/input-nested-multi-select/input-nested-multi-select.tsx
+++ b/src/input-nested-multi-select/input-nested-multi-select.tsx
@@ -263,9 +263,14 @@ export const InputNestedMultiSelect = <V1, V2, V3>({
             }
 
             const item = items.find((item) => item.key === currentKey);
+
+            if (!item) {
+                return undefined;
+            }
+
             const { label, value, subItems } = item;
 
-            if (!item || !nextKeyPath.length) {
+            if (!nextKeyPath.length) {
                 const result = {
                     label,
                     value,


### PR DESCRIPTION
**Changes**

Caused when attempting to destructure the item when it's undefined since it's not found in the options list. Addresses this error encountered in [this PR](https://github.com/LifeSG/web-frontend-engine/pull/193#issuecomment-1864738880)

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

Bug fix
- Fix error in `NestedMultiSelect` when selected key path does not match any option