### PR TITLE
Fix ErrorDisplay lighthouse warning

### DIFF
--- a/src/error-display/error-display-data.tsx
+++ b/src/error-display/error-display-data.tsx
@@ -1,17 +1,19 @@
 import { ResourceScheme } from "../theme/types";
 import { renderDescriptionWithProps } from "./error-display-helper-comp";
-import { ImagePathAttributes, imgAttributeHelper } from "./helper";
+import { ErrorDisplayHelper } from "./helper";
 import {
     ErrorDisplayType,
     InactivityAdditionalAttributes,
     MaintenanceAdditionalAttributes,
 } from "./types";
 
+const { imgAttributeHelper } = ErrorDisplayHelper;
+
 // =============================================================================
 // IMAGE PATHS
 // =============================================================================
 
-const ImgPaths: Record<string, ImagePathAttributes> = {
+const ImgPaths: Record<string, ErrorDisplayHelper.ImagePathAttributes> = {
     "400": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/400.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/400@2x.png",
@@ -140,7 +142,7 @@ const ImgPaths: Record<string, ImagePathAttributes> = {
     },
 };
 
-const BsgImgPaths: Record<string, ImagePathAttributes> = {
+const BsgImgPaths: Record<string, ErrorDisplayHelper.ImagePathAttributes> = {
     "400": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/bsg/400.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/bsg/400@2x.png",

--- a/src/error-display/error-display-data.tsx
+++ b/src/error-display/error-display-data.tsx
@@ -1,6 +1,6 @@
-import { MediaWidths } from "../spec/media-spec";
 import { ResourceScheme } from "../theme/types";
 import { renderDescriptionWithProps } from "./error-display-helper-comp";
+import { ImagePathAttributes, imgAttributeHelper } from "./helper";
 import {
     ErrorDisplayType,
     InactivityAdditionalAttributes,
@@ -10,102 +10,133 @@ import {
 // =============================================================================
 // IMAGE PATHS
 // =============================================================================
-interface ImagePathAttributes {
-    base: string;
-    md: string;
-    lg: string;
-}
 
 const ImgPaths: Record<string, ImagePathAttributes> = {
     "400": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/400.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/400@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/400@3x.png",
+        width: 400,
+        height: 280,
     },
     "403": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/403.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/403@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/403@3x.png",
+        width: 400,
+        height: 280,
     },
     "404": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/404.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/404@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/404@3x.png",
+        width: 400,
+        height: 280,
     },
     "408": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/408.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/408@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/408@3x.png",
+        width: 400,
+        height: 280,
     },
     "500": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/generic-error.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/generic-error@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/generic-error@3x.png",
+        width: 400,
+        height: 280,
     },
     "502": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/502.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/502@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/502@3x.png",
+        width: 400,
+        height: 280,
     },
     "503": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/503.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/503@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/503@3x.png",
+        width: 400,
+        height: 280,
     },
     "504": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/504.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/504@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/504@3x.png",
+        width: 400,
+        height: 280,
     },
     confirmation: {
         base: "https://assets.life.gov.sg/react-design-system/img/error/confirmation.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/confirmation@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/confirmation@3x.png",
+        width: 400,
+        height: 280,
     },
     "insufficient-credits": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/insuffcient-credit.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/insuffcient-credit@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/insuffcient-credit@3x.png",
+        width: 400,
+        height: 280,
     },
     inactivity: {
         base: "https://assets.life.gov.sg/react-design-system/img/error/inactivity.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/inactivity@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/inactivity@3x.png",
+        width: 400,
+        height: 280,
     },
     "link-error": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/link-error.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/link-error@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/link-error@3x.png",
+        width: 400,
+        height: 280,
     },
     logout: {
         base: "https://assets.life.gov.sg/react-design-system/img/error/logout.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/logout@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/logout@3x.png",
+        width: 400,
+        height: 280,
     },
     "no-item-found": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/no-item-found.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/no-item-found@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/no-item-found@3x.png",
+        width: 400,
+        height: 280,
     },
     "payment-unsuccessful": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/payment-unsuccessful.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/payment-unsuccessful@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/payment-unsuccessful@3x.png",
+        width: 400,
+        height: 281,
     },
     "transfer-unsuccessful": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/transfer-unsuccessful.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/transfer-unsuccessful@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/transfer-unsuccessful@3x.png",
+        width: 400,
+        height: 280,
     },
     "unsupported-browser": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/generic-error.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/generic-error@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/generic-error@3x.png",
+        width: 400,
+        height: 280,
     },
     warning: {
         base: "https://assets.life.gov.sg/react-design-system/img/error/warning.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/warning@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/warning@3x.png",
+        width: 400,
+        height: 280,
     },
 };
 
@@ -114,103 +145,128 @@ const BsgImgPaths: Record<string, ImagePathAttributes> = {
         base: "https://assets.life.gov.sg/react-design-system/img/error/bsg/400.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/bsg/400@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/bsg/400@3x.png",
+        width: 400,
+        height: 215,
     },
     "403": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/bsg/403.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/bsg/403@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/bsg/403@3x.png",
+        width: 400,
+        height: 254,
     },
     "404": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/bsg/404.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/bsg/404@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/bsg/404@3x.png",
+        width: 400,
+        height: 319,
     },
     "408": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/bsg/408.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/bsg/408@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/bsg/408@3x.png",
+        width: 400,
+        height: 330,
     },
     "500": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/bsg/generic-error.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/bsg/generic-error@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/bsg/generic-error@3x.png",
+        width: 400,
+        height: 232,
     },
     "502": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/bsg/502.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/bsg/502@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/bsg/502@3x.png",
+        width: 400,
+        height: 215,
     },
     "503": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/bsg/503.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/bsg/503@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/bsg/503@3x.png",
+        width: 400,
+        height: 191,
     },
     "504": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/bsg/504.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/bsg/504@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/bsg/504@3x.png",
+        width: 400,
+        height: 261,
     },
     confirmation: {
         base: "https://assets.life.gov.sg/react-design-system/img/error/bsg/confirmation.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/bsg/confirmation@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/bsg/confirmation@3x.png",
+        width: 400,
+        height: 280,
     },
     "insufficient-credits": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/bsg/insuffcient-credit.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/bsg/insuffcient-credit@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/bsg/insuffcient-credit@3x.png",
+        width: 400,
+        height: 280,
     },
     inactivity: {
         base: "https://assets.life.gov.sg/react-design-system/img/error/bsg/inactivity.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/bsg/inactivity@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/bsg/inactivity@3x.png",
+        width: 400,
+        height: 276,
     },
     "link-error": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/bsg/link-error.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/bsg/link-error@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/bsg/link-error@3x.png",
+        width: 400,
+        height: 280,
     },
     logout: {
         base: "https://assets.life.gov.sg/react-design-system/img/error/bsg/logout.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/bsg/logout@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/bsg/logout@3x.png",
+        width: 400,
+        height: 280,
     },
     "no-item-found": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/bsg/no-item-found.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/bsg/no-item-found@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/bsg/no-item-found@3x.png",
+        width: 400,
+        height: 290,
     },
     "payment-unsuccessful": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/bsg/payment-unsuccessful.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/bsg/payment-unsuccessful@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/bsg/payment-unsuccessful@3x.png",
+        width: 400,
+        height: 280,
     },
     "transfer-unsuccessful": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/bsg/transfer-unsuccessful.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/bsg/transfer-unsuccessful@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/bsg/transfer-unsuccessful@3x.png",
+        width: 400,
+        height: 280,
     },
     "unsupported-browser": {
         base: "https://assets.life.gov.sg/react-design-system/img/error/bsg/generic-error.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/bsg/generic-error@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/bsg/generic-error@3x.png",
+        width: 400,
+        height: 232,
     },
     warning: {
         base: "https://assets.life.gov.sg/react-design-system/img/error/bsg/warning.png",
         md: "https://assets.life.gov.sg/react-design-system/img/error/bsg/warning@2x.png",
         lg: "https://assets.life.gov.sg/react-design-system/img/error/bsg/warning@3x.png",
+        width: 400,
+        height: 280,
     },
-};
-
-const imgAttributeHelper = (
-    pathAttributes: ImagePathAttributes
-): React.ImgHTMLAttributes<HTMLImageElement> => {
-    const { base, md, lg } = pathAttributes;
-    return {
-        srcSet: `${base} 400w, ${md} 800w, ${lg} 1200w`,
-        src: lg,
-        sizes: `(max-width: ${MediaWidths.mobileL}px) 400px, (max-width: ${MediaWidths.tablet}px) 800px, 1200px`,
-    };
 };
 
 // =============================================================================

--- a/src/error-display/helper.ts
+++ b/src/error-display/helper.ts
@@ -1,22 +1,37 @@
 import { MediaWidths } from "../spec/media-spec";
 
-export interface ImagePathAttributes {
-    base: string;
-    md: string;
-    lg: string;
-    width: number;
-    height: number;
-}
+export namespace ErrorDisplayHelper {
+    export interface ImagePathAttributes {
+        /** base sized image path */
+        base: string;
 
-export const imgAttributeHelper = (
-    pathAttributes: ImagePathAttributes
-): React.ImgHTMLAttributes<HTMLImageElement> => {
-    const { base, md, lg, width, height } = pathAttributes;
-    return {
-        srcSet: `${base} 400w, ${md} 800w, ${lg} 1200w`,
-        src: lg,
-        sizes: `(max-width: ${MediaWidths.mobileL}px) 400px, (max-width: ${MediaWidths.tablet}px) 800px, 1200px`,
-        width,
-        height,
+        /** medium sized image path */
+        md: string;
+
+        /** large sized image path */
+        lg: string;
+
+        /** used with `height` to determine the aspect ratio for layout purposes */
+        width: number;
+
+        /** used with `width` to determine the aspect ratio for layout purposes */
+        height: number;
+    }
+
+    /**
+     * returns the html attributes required for the img element
+     * @param {ImagePathAttributes} pathAttributes
+     */
+    export const imgAttributeHelper = (
+        pathAttributes: ImagePathAttributes
+    ): React.ImgHTMLAttributes<HTMLImageElement> => {
+        const { base, md, lg, width, height } = pathAttributes;
+        return {
+            srcSet: `${base} 400w, ${md} 800w, ${lg} 1200w`,
+            src: lg,
+            sizes: `(max-width: ${MediaWidths.mobileL}px) 400px, (max-width: ${MediaWidths.tablet}px) 800px, 1200px`,
+            width,
+            height,
+        };
     };
-};
+}

--- a/src/error-display/helper.ts
+++ b/src/error-display/helper.ts
@@ -1,0 +1,22 @@
+import { MediaWidths } from "../spec/media-spec";
+
+export interface ImagePathAttributes {
+    base: string;
+    md: string;
+    lg: string;
+    width: number;
+    height: number;
+}
+
+export const imgAttributeHelper = (
+    pathAttributes: ImagePathAttributes
+): React.ImgHTMLAttributes<HTMLImageElement> => {
+    const { base, md, lg, width, height } = pathAttributes;
+    return {
+        srcSet: `${base} 400w, ${md} 800w, ${lg} 1200w`,
+        src: lg,
+        sizes: `(max-width: ${MediaWidths.mobileL}px) 400px, (max-width: ${MediaWidths.tablet}px) 800px, 1200px`,
+        width,
+        height,
+    };
+};

--- a/src/error-display/index.ts
+++ b/src/error-display/index.ts
@@ -1,2 +1,3 @@
 export * from "./error-display";
+export * from "./helper";
 export * from "./types";


### PR DESCRIPTION
**Changes**
- add width and height for all preset images in ErrorDisplay
- export `imgAttributeHelper` to allow consumers to generate the same attributes

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Add width and height attributes to ErrorDisplay image to fix lighthouse warning

**Additional information**
This PR fixes the following warning from lighthouse:
![image](https://github.com/LifeSG/react-design-system/assets/53549383/747349da-d2bc-471d-80b6-5f217985f0e4)

- this also prevents jumping of layouts when the image takes a longer time to load.
- do note that lighthouse does not show this warning if the image is in an iframe - use the [direct iframe url](https://www.life.gov.sg/react/iframe.html?args=&id=modules-errordisplay--default&viewMode=story) to trigger the warning

further reading here: [1](https://web.dev/articles/optimize-cls?utm_source=lighthouse&utm_medium=devtools#modern_best_practice_for_setting_image_dimensions) [2](https://www.smashingmagazine.com/2020/03/setting-height-width-images-important-again/) [3](https://jakearchibald.com/2022/img-aspect-ratio/#width--height-presentational-hints)

- You may refer to this [ticket](https://jira.ship.gov.sg/browse/MOL-14604)
