### PR TITLE
Update broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ const App = () => {
 export default App;
 ```
 
-For more information on the usage of themes, you can visit our [documentation](https://designsystem.life.gov.sg/react/index.html?path=/docs/getting-started-themes--page) about it.
+For more information on the usage of themes, you can visit our [documentation](https://designsystem.life.gov.sg/react/index.html?path=/docs/getting-started-themes--docs) about it.
 
 <br />
 
@@ -67,7 +67,7 @@ import { Button } from "@lifesg/react-design-system/button";
 import { Button } from "@lifesg/react-design-system";
 ```
 
-To see the full suite of components available, visit our [Storybook documentation](https://designsystem.life.gov.sg/react/index.html?path=/story/getting-started-installation--page).
+To see the full suite of components available, visit our [Storybook documentation](https://designsystem.life.gov.sg/react/index.html?path=/docs/getting-started-installation--docs).
 
 <br />
 

--- a/stories/data-table/props-table.tsx
+++ b/stories/data-table/props-table.tsx
@@ -69,7 +69,7 @@ const DATA: ApiTableSectionProps[] = [
                 name: "emptyView",
                 description: "Override props for the empty view display",
                 propTypes: (
-                    <a href="./?path=/docs/modules-errordisplay--docs">
+                    <a href="https://designsystem.life.gov.sg/react/index.html?path=/docs/modules-errordisplay--docs">
                         ErrorDisplayAttributes
                     </a>
                 ),

--- a/stories/divider/props-table.tsx
+++ b/stories/divider/props-table.tsx
@@ -52,7 +52,7 @@ const DATA: ApiTableSectionProps[] = [
                     <>
                         Refer to{" "}
                         <a
-                            href="./?path=/docs/getting-started-layout-column-divs--docs"
+                            href="https://designsystem.life.gov.sg/react/index.html?path=/docs/getting-started-layout-column-divs--docs"
                             rel="noreferrer"
                             target="_blank"
                         >
@@ -75,7 +75,7 @@ const DATA: ApiTableSectionProps[] = [
                     <>
                         Refer to{" "}
                         <a
-                            href="./?path=/docs/getting-started-layout-column-divs--docs"
+                            href="https://designsystem.life.gov.sg/react/index.html?path=/docs/getting-started-layout-column-divs--docs"
                             rel="noreferrer"
                             target="_blank"
                         >
@@ -98,7 +98,7 @@ const DATA: ApiTableSectionProps[] = [
                     <>
                         Refer to{" "}
                         <a
-                            href="./?path=/docs/getting-started-layout-column-divs--docs"
+                            href="https://designsystem.life.gov.sg/react/index.html?path=/docs/getting-started-layout-column-divs--docs"
                             rel="noreferrer"
                             target="_blank"
                         >

--- a/stories/footer/props-table.tsx
+++ b/stories/footer/props-table.tsx
@@ -104,7 +104,7 @@ const DATA: ApiTableSectionProps[] = [
                     <>
                         This component also inherits props from&nbsp;
                         <a
-                            href="./?path=/docs/general-text-introduction--docs"
+                            href="https://designsystem.life.gov.sg/react/index.html?path=/docs/general-text-introduction--docs"
                             rel="noreferrer"
                             target="_blank"
                         >
@@ -143,7 +143,7 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: (
                     <>
                         <a
-                            href="./?path=/docs/general-text-introduction--docs"
+                            href="https://designsystem.life.gov.sg/react/index.html?path=/docs/general-text-introduction--docs"
                             rel="noreferrer"
                             target="_blank"
                         >
@@ -168,7 +168,7 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: (
                     <>
                         <a
-                            href="./?path=/docs/general-text-introduction--docs"
+                            href="https://designsystem.life.gov.sg/react/index.html?path=/docs/general-text-introduction--docs"
                             rel="noreferrer"
                             target="_blank"
                         >
@@ -193,7 +193,7 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: (
                     <>
                         <a
-                            href="./?path=/docs/general-text-introduction--docs"
+                            href="https://designsystem.life.gov.sg/react/index.html?path=/docs/general-text-introduction--docs"
                             rel="noreferrer"
                             target="_blank"
                         >

--- a/stories/form/form-input-group/props-table.tsx
+++ b/stories/form/form-input-group/props-table.tsx
@@ -13,7 +13,7 @@ const DATA: ApiTableSectionProps[] = [
                     <>
                         This also inherits props from&nbsp;
                         <a
-                            href="./?path=/docs/form-input--docs#component-api"
+                            href="https://designsystem.life.gov.sg/react/index.html?path=/docs/form-input--docs#component-api"
                             rel="noreferrer"
                         >
                             Input

--- a/stories/form/form-masked-input/props-table.tsx
+++ b/stories/form/form-masked-input/props-table.tsx
@@ -13,7 +13,7 @@ const DATA: ApiTableSectionProps[] = [
                     <>
                         This also inherits props from&nbsp;
                         <a
-                            href="./?path=/docs/form-input--docs#component-api"
+                            href="https://designsystem.life.gov.sg/react/index.html?path=/docs/form-input--docs#component-api"
                             rel="noreferrer"
                         >
                             Input

--- a/stories/getting-started/themes-props-table.tsx
+++ b/stories/getting-started/themes-props-table.tsx
@@ -101,7 +101,7 @@ const DATA: ApiTableSectionProps[] = [
                     <>
                         The attributes to modify the text style. For the
                         different keys available, refer to the text sizes&nbsp;
-                        <a href="./?path=/docs/general-text-introduction--docs#static">
+                        <a href="https://designsystem.life.gov.sg/react/index.html?path=/docs/general-text-introduction--docs#static">
                             specification
                         </a>
                         .

--- a/stories/navbar/props-table.tsx
+++ b/stories/navbar/props-table.tsx
@@ -183,7 +183,7 @@ const DATA: ApiTableSectionProps[] = [
                     <>
                         This also inherits props from&nbsp;
                         <a
-                            href="./?path=/docs/general-text-introduction--docs#component-api"
+                            href="https://designsystem.life.gov.sg/react/index.html?path=/docs/general-text-introduction--docs#component-api"
                             rel="noreferrer"
                             target="_blank"
                         >
@@ -258,7 +258,7 @@ const DATA: ApiTableSectionProps[] = [
                 description: "The props for the action button",
                 propTypes: (
                     <>
-                        <a href="./?path=/docs/general-button--docs#component-api">
+                        <a href="https://designsystem.life.gov.sg/react/index.html?path=/docs/general-button--docs#component-api">
                             <code>ButtonProps</code>
                         </a>
                         &nbsp;

--- a/stories/notification-banner/props-table.tsx
+++ b/stories/notification-banner/props-table.tsx
@@ -66,7 +66,7 @@ const LINK_DATA: ApiTableSectionProps[] = [
                     <>
                         This component also inherits props from&nbsp;
                         <a
-                            href="./?path=/docs/general-text-introduction--docs#component-api"
+                            href="https://designsystem.life.gov.sg/react/index.html?path=/docs/general-text-introduction--docs#component-api"
                             target="_blank"
                             rel="noreferrer"
                         >
@@ -105,7 +105,7 @@ const HOC_DATA: ApiTableSectionProps[] = [
                 propTypes: (
                     <>
                         <a
-                            href="./?path=/docs/general-text-introduction--docs#component-api"
+                            href="https://designsystem.life.gov.sg/react/index.html?path=/docs/general-text-introduction--docs#component-api"
                             target="_blank"
                             rel="noreferrer"
                         >
@@ -113,7 +113,7 @@ const HOC_DATA: ApiTableSectionProps[] = [
                         </a>
                         &nbsp;
                         <a
-                            href="./?path=/docs/general-text-introduction--docs#component-api"
+                            href="https://designsystem.life.gov.sg/react/index.html?path=/docs/general-text-introduction--docs#component-api"
                             target="_blank"
                             rel="noreferrer"
                         >

--- a/stories/otp-input/props-table.tsx
+++ b/stories/otp-input/props-table.tsx
@@ -9,7 +9,7 @@ const DATA: ApiTableSectionProps[] = [
                 name: "actionButtonProps",
                 description: "The call to action custom button props",
                 propTypes: (
-                    <a href="./?path=/docs/general-button--docs#component-api">
+                    <a href="https://designsystem.life.gov.sg/react/index.html?path=/docs/general-button--docs#component-api">
                         ButtonProps
                     </a>
                 ),


### PR DESCRIPTION
**Changes**

- Update links in README.md broken by Storybook 7 upgrade
- The links in the prop tables still aren't working, `./?path=<url>` only works locally. As a (temporary) workaround, have hardcoded them. Looking into the [link addon](https://storybook.js.org/addons/@storybook/addon-links)
- [delete] branch