### PR TITLE
Support popover position and custom content

### DIFF
--- a/src/popover-v2/popover-trigger.tsx
+++ b/src/popover-v2/popover-trigger.tsx
@@ -2,6 +2,7 @@ import {
     FloatingPortal,
     autoUpdate,
     flip,
+    limitShift,
     offset,
     shift,
     useFloating,
@@ -17,6 +18,7 @@ export const PopoverTrigger = ({
     children,
     popoverContent,
     trigger = "click",
+    position = "top",
     rootNode,
     onPopoverAppear,
     onPopoverDismiss,
@@ -32,9 +34,15 @@ export const PopoverTrigger = ({
     });
     const { refs, floatingStyles } = useFloating({
         open: visible,
-        placement: "top",
+        placement: position,
         whileElementsMounted: autoUpdate,
-        middleware: [offset(16), flip(), shift()],
+        middleware: [
+            offset(16),
+            flip(),
+            shift({
+                limiter: limitShift(),
+            }),
+        ],
     });
 
     // =========================================================================

--- a/src/popover-v2/popover-trigger.tsx
+++ b/src/popover-v2/popover-trigger.tsx
@@ -99,19 +99,26 @@ export const PopoverTrigger = ({
     };
 
     // =========================================================================
-    // RENDER
+    // RENDER FUNCTIONS
     // =========================================================================
+    const renderPopover = () => {
+        if (typeof popoverContent === "function") {
+            return popoverContent();
+        }
+
+        return (
+            <PopoverV2 visible onMobileClose={handlePopoverMobileClose}>
+                {popoverContent}
+            </PopoverV2>
+        );
+    };
+
     return (
         <>
             {visible && (
                 <FloatingPortal root={rootNode}>
                     <div ref={refs.setFloating} style={{ ...floatingStyles }}>
-                        <PopoverV2
-                            visible
-                            onMobileClose={handlePopoverMobileClose}
-                        >
-                            {popoverContent}
-                        </PopoverV2>
+                        {renderPopover()}
                     </div>
                 </FloatingPortal>
             )}

--- a/src/popover-v2/types.ts
+++ b/src/popover-v2/types.ts
@@ -11,10 +11,17 @@ export interface PopoverV2Props {
 
 export type PopoverV2TriggerType = "click" | "hover";
 
+type Position = "top" | "right" | "bottom" | "left";
+type Alignment = "start" | "end";
+type AlignedPosition = `${Position}-${Alignment}`;
+
+export type PopoverV2Position = Position | AlignedPosition;
+
 export interface PopoverV2TriggerProps {
     children: React.ReactNode;
     popoverContent: string | JSX.Element;
     trigger?: PopoverV2TriggerType | undefined;
+    position?: PopoverV2Position | undefined;
     id?: string | undefined;
     className?: string | undefined;
     "data-testid"?: string | undefined;

--- a/src/popover-v2/types.ts
+++ b/src/popover-v2/types.ts
@@ -19,7 +19,7 @@ export type PopoverV2Position = Position | AlignedPosition;
 
 export interface PopoverV2TriggerProps {
     children: React.ReactNode;
-    popoverContent: string | JSX.Element;
+    popoverContent: string | JSX.Element | (() => React.ReactNode);
     trigger?: PopoverV2TriggerType | undefined;
     position?: PopoverV2Position | undefined;
     id?: string | undefined;

--- a/stories/popover-v2/popover.mdx
+++ b/stories/popover-v2/popover.mdx
@@ -30,4 +30,10 @@ The example below illustrates the default behaviour.
 
 <Canvas of={PopoverStories.Appearance} />
 
+<Heading3>Customisation</Heading3>
+
+You can opt out of the default appearance to display custom content such as menus and dialogs.
+
+<Canvas of={PopoverStories.Customisation} />
+
 <PropsTable />

--- a/stories/popover-v2/popover.mdx
+++ b/stories/popover-v2/popover.mdx
@@ -1,5 +1,5 @@
 import { Canvas, Meta } from "@storybook/blocks";
-import { Heading4, Secondary, Title } from "../storybook-common";
+import { Heading3, Heading4, Secondary, Title } from "../storybook-common";
 import * as PopoverStories from "./popover.stories";
 import { PropsTable } from "./props-table";
 
@@ -23,8 +23,10 @@ import { PopoverTrigger } from "@lifesg/react-design-system/popover-v2";
 
 <Heading4>Appearance information</Heading4>
 
--   The `Popover` component automatically positions itself based on the amount of space available. It will always attempt to display itself on top of the trigger component by default
+-   The `Popover` component automatically positions itself based on the amount of space available. It will always attempt to display itself at the preferred position by default
 -   The `Popover` appears as a modal in mobile viewports
+
+The example below illustrates the default behaviour.
 
 <Canvas of={PopoverStories.Appearance} />
 

--- a/stories/popover-v2/popover.stories.tsx
+++ b/stories/popover-v2/popover.stories.tsx
@@ -66,3 +66,19 @@ export const Appearance: StoryObj<Component> = {
         layout: "fullscreen",
     },
 };
+
+export const Customisation: StoryObj<Component> = {
+    render: () => {
+        return (
+            <PopoverTrigger
+                popoverContent={() => (
+                    <div style={{ background: "aliceblue", padding: "1rem" }}>
+                        A custom popover!
+                    </div>
+                )}
+            >
+                <Button.Default>Click me</Button.Default>
+            </PopoverTrigger>
+        );
+    },
+};

--- a/stories/popover-v2/props-table.tsx
+++ b/stories/popover-v2/props-table.tsx
@@ -38,7 +38,7 @@ const POPOVER_TRIGGER_DATA: ApiTableSectionProps[] = [
                         The content of the <code>Popover</code>
                     </>
                 ),
-                propTypes: ["string", "JSX.Element"],
+                propTypes: ["string", "JSX.Element", "() => React.ReactNode"],
                 mandatory: true,
             },
             {

--- a/stories/popover-v2/props-table.tsx
+++ b/stories/popover-v2/props-table.tsx
@@ -56,8 +56,8 @@ const POPOVER_TRIGGER_DATA: ApiTableSectionProps[] = [
                 name: "position",
                 description: (
                     <>
-                        The visual of the <code>Popover</code> in relation to
-                        it&rsquo;s trigger
+                        The visual position of the <code>Popover</code> in
+                        relation to it&rsquo;s trigger
                     </>
                 ),
                 propTypes: [

--- a/stories/popover-v2/props-table.tsx
+++ b/stories/popover-v2/props-table.tsx
@@ -1,14 +1,6 @@
-import React from "react";
-import {
-    ApiTable,
-    DefaultCol,
-    DescriptionCol,
-    NameCol,
-    Section,
-    Table,
-} from "../storybook-common/api-table";
-import { TabAttribute, Tabs } from "../storybook-common/tabs";
+import { ApiTable } from "../storybook-common/api-table";
 import { ApiTableSectionProps } from "../storybook-common/api-table/types";
+import { TabAttribute, Tabs } from "../storybook-common/tabs";
 
 const POPOVER_TRIGGER_DATA: ApiTableSectionProps[] = [
     {
@@ -59,6 +51,30 @@ const POPOVER_TRIGGER_DATA: ApiTableSectionProps[] = [
                 ),
                 propTypes: [`"click"`, `"hover"`],
                 defaultValue: `"click"`,
+            },
+            {
+                name: "position",
+                description: (
+                    <>
+                        The visual of the <code>Popover</code> in relation to
+                        it&rsquo;s trigger
+                    </>
+                ),
+                propTypes: [
+                    `"top"`,
+                    `"top-start"`,
+                    `"top-end"`,
+                    `"bottom"`,
+                    `"bottom-start"`,
+                    `"bottom-end"`,
+                    `"left"`,
+                    `"left-start"`,
+                    `"left-end"`,
+                    `"right"`,
+                    `"right-start"`,
+                    `"right-end"`,
+                ],
+                defaultValue: `"top"`,
             },
             {
                 name: "rootNode",

--- a/stories/storybook-common/api-table/api-table-components.tsx
+++ b/stories/storybook-common/api-table/api-table-components.tsx
@@ -203,6 +203,7 @@ export const DescriptionCol = ({
 
 const PropsContainer = styled.div`
     display: flex;
+    flex-wrap: wrap;
     code {
         :not(:last-child) {
             margin-right: 0.25rem;


### PR DESCRIPTION
**Changes**

- Support custom content: the styling of the popover is awkward as it's in a portal and can't be targeted easily with `styled-components`. Ended up with a render function which is more flexible and can pass down render props if needed in the future
- Support positioning and alignment
- [delete] branch