### PR TITLE
Fix TimeSlotBarWeek bugs

### DIFF
--- a/src/time-slot-bar-week/time-slot-bar-week-days.tsx
+++ b/src/time-slot-bar-week/time-slot-bar-week-days.tsx
@@ -86,7 +86,6 @@ export const TimeSlotBarWeekDays = ({
     const numberOfCells = Math.ceil(
         DateHelper.getTimeDiffInMinutes(minStartTime, maxEndTime) / interval
     );
-    console.log(minStartTime, maxEndTime, numberOfCells);
 
     // React spring animation configuration
     const { height: actualHeight, ref: cellsRef } = useResizeDetector();

--- a/src/time-slot-bar-week/time-slot-bar-week-days.tsx
+++ b/src/time-slot-bar-week/time-slot-bar-week-days.tsx
@@ -86,11 +86,12 @@ export const TimeSlotBarWeekDays = ({
     const numberOfCells = Math.ceil(
         DateHelper.getTimeDiffInMinutes(minStartTime, maxEndTime) / interval
     );
+    console.log(minStartTime, maxEndTime, numberOfCells);
 
     // React spring animation configuration
     const { height: actualHeight, ref: cellsRef } = useResizeDetector();
     const height = maxVisibleCellHeight
-        ? expandAll
+        ? actualHeight < maxVisibleCellHeight || expandAll
             ? actualHeight
             : maxVisibleCellHeight
         : actualHeight;
@@ -316,7 +317,9 @@ export const TimeSlotBarWeekDays = ({
                 }
                 break;
         }
-        return cellsArray.filter((slot) => !isEmpty(slot));
+        return cellsArray.filter(
+            (slot) => !isEmpty(slot) && slot.cellLength > 0
+        );
     }
 
     // =============================================================================


### PR DESCRIPTION
**Changes**
- Fixed timeslot cell wrapper following `maxVisibleCellHeight` even when actual height is lower
- Added `cellLength` > 0 check to prevent empty cells from being rendered (possible when input slot doesn't follow proper HH:mm format)

- [delete] branch

**Changelog entry**
- Fix TimeSlotBarWeek height being increased to `maxVisibleCellHeight` when actual height is lower