### PR TITLE
Add loading and error displays to `MaskedInput`

### DIFF
--- a/src/masked-input/masked-input.style.tsx
+++ b/src/masked-input/masked-input.style.tsx
@@ -49,7 +49,7 @@ export const IconContainer = styled.div<IconProps>`
 export const LoadingWrapper = styled.div`
     display: flex;
     align-items: center;
-    height: calc(3rem - 2px);
+    height: 3rem;
 `;
 
 export const LoadingLabel = styled(Text.Body)`
@@ -94,7 +94,7 @@ export const ErrorLabel = styled(Text.Body)`
 
 export const ClickableErrorWrapper = styled.button`
     width: 100%;
-    height: calc(3rem - 2px);
+    height: 3rem;
     display: flex;
     justify-content: space-between;
     align-items: center;

--- a/src/masked-input/masked-input.style.tsx
+++ b/src/masked-input/masked-input.style.tsx
@@ -1,6 +1,9 @@
 import styled from "styled-components";
 import { Color } from "../color";
 import { InputGroup } from "../input-group";
+import { Text, TextStyleHelper } from "../text";
+import { ComponentLoadingSpinner } from "../shared/component-loading-spinner/component-loading-spinner";
+import { ExclamationTriangleIcon } from "@lifesg/react-icons/exclamation-triangle";
 
 interface InputGroupWrapperProps {
     readOnly: boolean;
@@ -37,5 +40,73 @@ export const IconContainer = styled.div<IconProps>`
     svg {
         width: 1.125rem;
         height: 1.125rem;
+    }
+`;
+
+// -----------------------------------------------------------------------------
+// LOADING DISPLAY
+// -----------------------------------------------------------------------------
+export const LoadingWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    height: calc(3rem - 2px);
+`;
+
+export const LoadingLabel = styled(Text.Body)`
+    color: ${Color.Neutral[3]};
+`;
+
+export const Spinner = styled(ComponentLoadingSpinner)`
+    margin-right: 0.5rem;
+    #inner1,
+    #inner2,
+    #inner3,
+    #inner4 {
+        border-color: ${Color.Neutral[3]} transparent transparent transparent;
+    }
+`;
+
+// -----------------------------------------------------------------------------
+// ERROR DISPLAY
+// -----------------------------------------------------------------------------
+
+export const TryAgainLabel = styled(Text.Body)`
+    color: ${Color.Primary};
+    text-decoration: underline;
+`;
+
+export const ErrorTextContainer = styled.div`
+    display: flex;
+    align-items: center;
+    margin-right: 0.5rem;
+`;
+
+export const ErrorIcon = styled(ExclamationTriangleIcon)`
+    color: ${Color.Validation.Orange.Icon};
+    margin-right: 0.5rem;
+    height: 1.125rem;
+    width: 1.125rem;
+`;
+
+export const ErrorLabel = styled(Text.Body)`
+    color: ${Color.Validation.Orange.Text};
+`;
+
+export const ClickableErrorWrapper = styled.button`
+    width: 100%;
+    height: calc(3rem - 2px);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+
+    :hover,
+    :active,
+    :focus {
+        ${TryAgainLabel} {
+            color: ${Color.Secondary};
+        }
     }
 `;

--- a/src/masked-input/masked-input.tsx
+++ b/src/masked-input/masked-input.tsx
@@ -63,13 +63,15 @@ const Component = (
     // =============================================================================
 
     const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
-        setIsMasked(false);
+        triggerMaskUnmaskCallbacks();
         onFocus && onFocus(event);
+        setIsMasked(false);
     };
 
     const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-        setIsMasked(true);
+        triggerMaskUnmaskCallbacks();
         onBlur && onBlur(event);
+        setIsMasked(true);
     };
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -95,17 +97,20 @@ const Component = (
         readOnly && onTryAgain && onTryAgain();
     };
 
+    const handleToggleMask = () => {
+        triggerMaskUnmaskCallbacks();
+        setIsMasked(!isMasked);
+    };
+
     // =============================================================================
     // HELPER FUNCTIONS
     // =============================================================================
-    const toggleMasking = () => {
+    const triggerMaskUnmaskCallbacks = () => {
         if (isMasked) {
             onUnmask && onUnmask();
         } else {
             onMask && onMask();
         }
-
-        setIsMasked(!isMasked);
     };
 
     const getValue = () => {
@@ -174,7 +179,7 @@ const Component = (
             !isEmptyReadOnlyState && (
                 <IconContainer
                     data-testid={`icon-${isMasked ? "masked" : "unmasked"}`}
-                    onClick={!isDisabled ? toggleMasking : undefined}
+                    onClick={!isDisabled ? handleToggleMask : undefined}
                     $isDisabled={isDisabled}
                     $inactiveColor={maskIconInactiveColor}
                     $activeColor={maskIconActiveColor}
@@ -231,7 +236,7 @@ const Component = (
                 }}
                 onFocus={!readOnly ? handleFocus : undefined}
                 onBlur={!readOnly ? handleBlur : undefined}
-                onClick={readOnly ? toggleMasking : undefined}
+                onClick={readOnly ? handleToggleMask : undefined}
                 onChange={handleChange}
                 value={getValue()}
                 readOnly={readOnly}

--- a/src/masked-input/masked-input.tsx
+++ b/src/masked-input/masked-input.tsx
@@ -63,15 +63,13 @@ const Component = (
     // =============================================================================
 
     const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
-        triggerMaskUnmaskCallbacks();
+        toggleMasking(false);
         onFocus && onFocus(event);
-        setIsMasked(false);
     };
 
     const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-        triggerMaskUnmaskCallbacks();
+        toggleMasking(true);
         onBlur && onBlur(event);
-        setIsMasked(true);
     };
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -98,18 +96,18 @@ const Component = (
     };
 
     const handleToggleMask = () => {
-        triggerMaskUnmaskCallbacks();
-        setIsMasked(!isMasked);
+        toggleMasking(!isMasked);
     };
 
     // =============================================================================
     // HELPER FUNCTIONS
     // =============================================================================
-    const triggerMaskUnmaskCallbacks = () => {
-        if (isMasked) {
-            onUnmask && onUnmask();
-        } else {
+    const toggleMasking = (mask: boolean) => {
+        setIsMasked(mask);
+        if (mask) {
             onMask && onMask();
+        } else {
+            onUnmask && onUnmask();
         }
     };
 

--- a/src/masked-input/types.ts
+++ b/src/masked-input/types.ts
@@ -10,10 +10,16 @@ export interface MaskedInputProps extends InputProps {
     iconActiveColor?: string | undefined;
     iconInactiveColor?: string | undefined;
     maskChar?: string | undefined;
-    onMask?: (() => void) | undefined;
-    onUnmask?: (() => void) | undefined;
     disableMask?: boolean | undefined;
     transformInput?: "uppercase" | "lowercase" | undefined;
+    /** Specifies if a loading spinner should appear when unmasking happens */
+    renderLoadingOnUnmask?: boolean | undefined;
+    /** Specifies if there is an error during unmasking */
+    unmaskError?: boolean | undefined;
+    onMask?: (() => void) | undefined;
+    onUnmask?: (() => void) | undefined;
+    /** The callback function when the "Try again" button is clicked in error state */
+    onTryAgain?: (() => void) | undefined;
 }
 
 /** To be exposed for Form component inheritance */

--- a/src/masked-input/types.ts
+++ b/src/masked-input/types.ts
@@ -1,5 +1,6 @@
 import { InputProps } from "../input/types";
 
+export type MaskedInputLoadState = "loading" | "fail" | "success";
 export interface MaskedInputProps extends InputProps {
     maskRange?: number[] | undefined;
     unmaskRange?: number[] | undefined;
@@ -12,10 +13,14 @@ export interface MaskedInputProps extends InputProps {
     maskChar?: string | undefined;
     disableMask?: boolean | undefined;
     transformInput?: "uppercase" | "lowercase" | undefined;
-    /** Specifies if a loading spinner should appear when unmasking happens */
-    renderLoadingOnUnmask?: boolean | undefined;
-    /** Specifies if there is an error during unmasking */
-    unmaskError?: boolean | undefined;
+    /**
+     * Specifies the state of the component when there is a
+     * loading behaviour. Note that this only applies if
+     * the component is in `readOnly` mode.
+     *
+     * Values: "loading" | "fail" | "success"
+     */
+    loadState?: MaskedInputLoadState | undefined;
     onMask?: (() => void) | undefined;
     onUnmask?: (() => void) | undefined;
     /** The callback function when the "Try again" button is clicked in error state */

--- a/src/shared/component-loading-spinner/component-loading-spinner.tsx
+++ b/src/shared/component-loading-spinner/component-loading-spinner.tsx
@@ -31,21 +31,25 @@ export const ComponentLoadingSpinner = ({
                 id="inner1"
                 $size={size - borderWidth}
                 $borderWidth={borderWidth}
+                $color={color}
             />
             <InnerRing2
                 id="inner2"
                 $size={size - borderWidth}
                 $borderWidth={borderWidth}
+                $color={color}
             />
             <InnerRing3
                 id="inner3"
                 $size={size - borderWidth}
                 $borderWidth={borderWidth}
+                $color={color}
             />
             <InnerRing4
                 id="inner4"
                 $size={size - borderWidth}
                 $borderWidth={borderWidth}
+                $color={color}
             />
         </OuterRing>
     );

--- a/stories/form/form-masked-input/form-masked-input.mdx
+++ b/stories/form/form-masked-input/form-masked-input.mdx
@@ -23,7 +23,8 @@ In some cases where the unmasking requires an asynchronous process, you might wa
 a loading indicator for the users. As such this component comes with a loading display. Here is
 an example of how you can set things up.
 
-> Note: You will have to handle the masking and unmasking manually to ensure the value changes
+> Note: This only applies if the component is in `readOnly` mode.
+> You will also have to handle the masking and unmasking manually to ensure the value changes
 > are being reflected accurately
 
 <Canvas of={FormMaskedInputStories.LoadingDisplay} />

--- a/stories/form/form-masked-input/form-masked-input.mdx
+++ b/stories/form/form-masked-input/form-masked-input.mdx
@@ -24,7 +24,7 @@ a loading indicator for the users. As such this component comes with a loading d
 an example of how you can set things up.
 
 > Note: This only applies if the component is in `readOnly` mode.
-> You will also have to handle the masking and unmasking manually to ensure the value changes
+> You may also have to handle the masking and unmasking manually to ensure the value changes
 > are being reflected accurately
 
 <Canvas of={FormMaskedInputStories.LoadingDisplay} />

--- a/stories/form/form-masked-input/form-masked-input.mdx
+++ b/stories/form/form-masked-input/form-masked-input.mdx
@@ -17,6 +17,17 @@ import { Form } from "@lifesg/react-design-system/form";
 
 <Canvas of={FormMaskedInputStories.Default} />
 
+<Heading3>Loading display</Heading3>
+
+In some cases where the unmasking requires an asynchronous process, you might want to display
+a loading indicator for the users. As such this component comes with a loading display. Here is
+an example of how you can set things up.
+
+> Note: You will have to handle the masking and unmasking manually to ensure the value changes
+> are being reflected accurately
+
+<Canvas of={FormMaskedInputStories.LoadingDisplay} />
+
 <Heading3>Masking</Heading3>
 
 You are able to specify the range of index to mask or unmask, the regex to mask or customize the masking logic by passing in a maskTransformer.

--- a/stories/form/form-masked-input/form-masked-input.stories.tsx
+++ b/stories/form/form-masked-input/form-masked-input.stories.tsx
@@ -6,6 +6,7 @@ import { Layout } from "src/layout";
 import { MaskedInput } from "src/masked-input";
 import { StoryContainer } from "../../storybook-common";
 import { Container } from "../shared-doc-elements";
+import { useState } from "react";
 
 type Component = typeof Form.MaskedInput;
 type StandaloneComponent = typeof MaskedInput;
@@ -65,6 +66,47 @@ export const Default: StoryObj<Component> = {
                     />
                 </Container>
             </StoryContainer>
+        );
+    },
+};
+
+export const LoadingDisplay: StoryObj<Component> = {
+    render: () => {
+        const DEFAULT_VALUE = "S•••567D";
+        const [value, setValue] = useState<string>(DEFAULT_VALUE);
+        const [attempt, setAttempt] = useState<number>(0);
+        const [hasError, setHasError] = useState<boolean>(false);
+
+        const handleUnmask = () => {
+            setHasError(false);
+            const currentAttempt = attempt + 1;
+            setTimeout(() => {
+                const errorCondition =
+                    currentAttempt < 3 || currentAttempt % 2 === 0;
+                setHasError(errorCondition);
+
+                if (!errorCondition) {
+                    setValue("S1234567D");
+                }
+            }, 500);
+            setAttempt(currentAttempt);
+        };
+
+        const handleMask = () => {
+            setValue(DEFAULT_VALUE);
+        };
+
+        return (
+            <Form.MaskedInput
+                label="This simulates an async unmasking behaviour"
+                value={value}
+                readOnly
+                renderLoadingOnUnmask
+                unmaskError={hasError}
+                onUnmask={handleUnmask}
+                onMask={handleMask}
+                onTryAgain={handleUnmask}
+            />
         );
     },
 };

--- a/stories/form/form-masked-input/form-masked-input.stories.tsx
+++ b/stories/form/form-masked-input/form-masked-input.stories.tsx
@@ -3,7 +3,7 @@ import { ToggleOffFillIcon } from "@lifesg/react-icons/toggle-off-fill";
 import type { Meta, StoryObj } from "@storybook/react";
 import { Form } from "src/form";
 import { Layout } from "src/layout";
-import { MaskedInput } from "src/masked-input";
+import { MaskedInput, MaskedInputLoadState } from "src/masked-input";
 import { StoryContainer } from "../../storybook-common";
 import { Container } from "../shared-doc-elements";
 import { useState } from "react";
@@ -75,18 +75,25 @@ export const LoadingDisplay: StoryObj<Component> = {
         const DEFAULT_VALUE = "S•••567D";
         const [value, setValue] = useState<string>(DEFAULT_VALUE);
         const [attempt, setAttempt] = useState<number>(0);
-        const [hasError, setHasError] = useState<boolean>(false);
+        const [loadState, setLoadState] =
+            useState<MaskedInputLoadState>(undefined);
 
         const handleUnmask = () => {
-            setHasError(false);
+            setLoadState("loading");
+            /**
+             * NOTE: This is to simulate an async action
+             * that fails for the first 2 attempts and fails
+             * on every even number occurrence
+             */
             const currentAttempt = attempt + 1;
             setTimeout(() => {
                 const errorCondition =
                     currentAttempt < 3 || currentAttempt % 2 === 0;
-                setHasError(errorCondition);
+                setLoadState("fail");
 
                 if (!errorCondition) {
                     setValue("S1234567D");
+                    setLoadState("success");
                 }
             }, 500);
             setAttempt(currentAttempt);
@@ -101,8 +108,7 @@ export const LoadingDisplay: StoryObj<Component> = {
                 label="This simulates an async unmasking behaviour"
                 value={value}
                 readOnly
-                renderLoadingOnUnmask
-                unmaskError={hasError}
+                loadState={loadState}
                 onUnmask={handleUnmask}
                 onMask={handleMask}
                 onTryAgain={handleUnmask}

--- a/stories/form/form-masked-input/props-table.tsx
+++ b/stories/form/form-masked-input/props-table.tsx
@@ -88,6 +88,23 @@ const DATA: ApiTableSectionProps[] = [
                     "Specifies whether the input value is to be transformed into uppercase or lowercase format",
                 propTypes: ["uppercase", "lowercase"],
             },
+            {
+                name: "renderLoadingOnUnmask",
+                description:
+                    "Specifies if a loading spinner should appear when unmasking happens",
+                propTypes: ["boolean"],
+            },
+            {
+                name: "unmaskError",
+                description: "Specifies if there is an error during unmasking",
+                propTypes: ["boolean"],
+            },
+            {
+                name: "onTryAgain",
+                description:
+                    "The callback function when the 'Try again' button is clicked in error state",
+                propTypes: ["() => void"],
+            },
         ],
     },
     ...SHARED_FORM_PROPS_DATA,

--- a/stories/form/form-masked-input/props-table.tsx
+++ b/stories/form/form-masked-input/props-table.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ApiTable } from "../../storybook-common/api-table";
+import { ApiTable, code } from "../../storybook-common/api-table";
 import { ApiTableSectionProps } from "../../storybook-common/api-table/types";
 import { SHARED_FORM_PROPS_DATA } from "../shared-props-data";
 
@@ -89,20 +89,25 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["uppercase", "lowercase"],
             },
             {
-                name: "renderLoadingOnUnmask",
-                description:
-                    "Specifies if a loading spinner should appear when unmasking happens",
-                propTypes: ["boolean"],
-            },
-            {
-                name: "unmaskError",
-                description: "Specifies if there is an error during unmasking",
-                propTypes: ["boolean"],
+                name: "loadState",
+                description: (
+                    <>
+                        Specifies the state of the component when there is
+                        loading behaviour. Note that the load state only applies
+                        if the component is in {code("readOnly")} mode.
+                    </>
+                ),
+                propTypes: [`"loading"`, `"fail"`, `"success"`],
             },
             {
                 name: "onTryAgain",
-                description:
-                    "The callback function when the 'Try again' button is clicked in error state",
+                description: (
+                    <>
+                        The callback function when the &lsquo;Try again&rsquo;
+                        button is clicked in error state. Only applies if the
+                        component is in {code("readOnly")} mode.
+                    </>
+                ),
                 propTypes: ["() => void"],
             },
         ],

--- a/tests/masked-input/masked-input.spec.tsx
+++ b/tests/masked-input/masked-input.spec.tsx
@@ -1,0 +1,101 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { MaskedInput } from "../../src/masked-input";
+
+describe("MaskedInput", () => {
+    describe("Renders", () => {
+        it("should render the masked value based on the mask range", () => {
+            render(<MaskedInput value="S1234567D" maskRange={[2, 5]} />);
+
+            expect(screen.getByDisplayValue("S1••••67D")).toBeInTheDocument();
+            expect(screen.getByTestId("icon-masked")).toBeInTheDocument();
+        });
+
+        it("should render the unmasked value when the unmasked icon is clicked", () => {
+            render(<MaskedInput value="S1234567D" maskRange={[2, 5]} />);
+            const icon = screen.getByTestId("icon-masked");
+
+            act(() => {
+                fireEvent.click(icon);
+            });
+
+            expect(screen.getByDisplayValue("S1234567D")).toBeInTheDocument();
+            expect(
+                screen.queryByDisplayValue("S1••••67D")
+            ).not.toBeInTheDocument();
+            expect(screen.getByTestId("icon-unmasked")).toBeInTheDocument();
+            expect(screen.queryByTestId("icon-masked")).not.toBeInTheDocument();
+        });
+
+        it("should render the correct masked value based on the mask transformer", () => {
+            render(
+                <MaskedInput
+                    value="S1234567D"
+                    maskTransformer={(value) => value.replace(/\D/g, "*")}
+                />
+            );
+            expect(screen.getByDisplayValue("*1234567*")).toBeInTheDocument();
+        });
+
+        it("should render the error display if there is an unmaskError", () => {
+            const mockTryAgainFn = jest.fn();
+
+            render(
+                <MaskedInput
+                    value="S1234567D"
+                    unmaskError
+                    onTryAgain={mockTryAgainFn}
+                />
+            );
+
+            expect(
+                screen.queryByTestId("masked-input-masked")
+            ).not.toBeInTheDocument();
+            expect(screen.getByText("Error")).toBeInTheDocument();
+            expect(screen.getByText("Try again?")).toBeInTheDocument();
+
+            fireEvent.click(screen.getByTestId("try-again-button"));
+            expect(mockTryAgainFn).toBeCalled();
+        });
+    });
+
+    describe("Event callbacks", () => {
+        it("should fire the onMask and onUnmask callbacks when the masked or unmasked icon is clicked", () => {
+            const maskFn = jest.fn();
+            const unmaskFn = jest.fn();
+
+            render(
+                <MaskedInput
+                    value="S1234567D"
+                    onMask={maskFn}
+                    onUnmask={unmaskFn}
+                    readOnly
+                />
+            );
+
+            act(() => {
+                fireEvent.click(screen.getByTestId("icon-masked"));
+                expect(unmaskFn).toBeCalled();
+            });
+
+            act(() => {
+                fireEvent.click(screen.getByTestId("icon-unmasked"));
+                expect(maskFn).toBeCalled();
+            });
+        });
+
+        it("should fire the onTryAgain callback when the try again button is clicked", () => {
+            const tryAgainFn = jest.fn();
+
+            render(
+                <MaskedInput
+                    value="S1234567D"
+                    unmaskError
+                    onTryAgain={tryAgainFn}
+                />
+            );
+
+            fireEvent.click(screen.getByTestId("try-again-button"));
+            expect(tryAgainFn).toBeCalled();
+        });
+    });
+});

--- a/tests/masked-input/masked-input.spec.tsx
+++ b/tests/masked-input/masked-input.spec.tsx
@@ -36,25 +36,38 @@ describe("MaskedInput", () => {
             expect(screen.getByDisplayValue("*1234567*")).toBeInTheDocument();
         });
 
-        it("should render the error display if there is an unmaskError", () => {
-            const mockTryAgainFn = jest.fn();
-
+        it("should render the loading display if the component is in loading state", () => {
             render(
-                <MaskedInput
-                    value="S1234567D"
-                    unmaskError
-                    onTryAgain={mockTryAgainFn}
-                />
+                <MaskedInput value="S1234567D" loadState="loading" readOnly />
             );
+
+            expect(
+                screen.queryByTestId("masked-input-masked")
+            ).not.toBeInTheDocument();
+            expect(screen.getByText("Retrieving...")).toBeInTheDocument();
+        });
+
+        it("should render the error display if there is an error", () => {
+            render(<MaskedInput value="S1234567D" loadState="fail" readOnly />);
 
             expect(
                 screen.queryByTestId("masked-input-masked")
             ).not.toBeInTheDocument();
             expect(screen.getByText("Error")).toBeInTheDocument();
             expect(screen.getByText("Try again?")).toBeInTheDocument();
+        });
 
-            fireEvent.click(screen.getByTestId("try-again-button"));
-            expect(mockTryAgainFn).toBeCalled();
+        it("should not render the loading display if the component is in loading state but not in readOnly mode", () => {
+            render(<MaskedInput value="S1234567D" loadState="loading" />);
+
+            expect(screen.queryByText("Retrieving...")).not.toBeInTheDocument();
+        });
+
+        it("should not render the error display if the component is in loading state but not in readOnly mode", () => {
+            render(<MaskedInput value="S1234567D" loadState="fail" />);
+
+            expect(screen.queryByText("Error")).not.toBeInTheDocument();
+            expect(screen.queryByText("Try again?")).not.toBeInTheDocument();
         });
     });
 
@@ -89,7 +102,8 @@ describe("MaskedInput", () => {
             render(
                 <MaskedInput
                     value="S1234567D"
-                    unmaskError
+                    loadState="fail"
+                    readOnly
                     onTryAgain={tryAgainFn}
                 />
             );

--- a/tests/masked-input/masked-input.spec.tsx
+++ b/tests/masked-input/masked-input.spec.tsx
@@ -72,6 +72,41 @@ describe("MaskedInput", () => {
     });
 
     describe("Event callbacks", () => {
+        it("should fire the onUnmask callback and the onFocus callback if specified, when the input is focused", () => {
+            const unmaskFn = jest.fn();
+            const focusFn = jest.fn();
+
+            render(
+                <MaskedInput
+                    value="S1234567D"
+                    onFocus={focusFn}
+                    onUnmask={unmaskFn}
+                />
+            );
+
+            fireEvent.focus(screen.getByTestId("input"));
+            expect(unmaskFn).toBeCalled();
+            expect(focusFn).toBeCalled();
+        });
+
+        it("should fire the onMask callback and the onBlur callback if specified, when the input is blurred", () => {
+            const maskFn = jest.fn();
+            const blurFn = jest.fn();
+
+            render(
+                <MaskedInput
+                    value="S1234567D"
+                    onBlur={blurFn}
+                    onMask={maskFn}
+                />
+            );
+
+            fireEvent.focus(screen.getByTestId("input"));
+            fireEvent.blur(screen.getByTestId("input"));
+            expect(maskFn).toBeCalled();
+            expect(blurFn).toBeCalled();
+        });
+
         it("should fire the onMask and onUnmask callbacks when the masked or unmasked icon is clicked", () => {
             const maskFn = jest.fn();
             const unmaskFn = jest.fn();


### PR DESCRIPTION
**Changes**
- Add loading and error displays to `MaskedInput` to support async unmasking

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Add loading and error displays to `MaskedInput` for asynchronous operations when unmasking

**Additional information**

- You may refer to this [ticket](https://jira.ship.gov.sg/browse/CCUBE-922)
- [Figma](https://www.figma.com/file/us90jOpWBahsqK2VAluPvD/Flagship-Design-System?type=design&node-id=13345-121509&mode=design&t=ak65r4MKhJrM1Xtv-0)
