### PR TITLE
Slider: isolate z-index on component level

### DIFF
--- a/src/input-range-slider/input-range-slider.styles.ts
+++ b/src/input-range-slider/input-range-slider.styles.ts
@@ -18,6 +18,10 @@ interface ThumbStyleProps {
 // =============================================================================
 // STYLING
 // =============================================================================
+export const Wrapper = styled.div`
+    isolation: isolate;
+`;
+
 export const LabelContainer = styled.div`
     margin-top: 0.25rem;
     display: flex;

--- a/src/input-range-slider/input-range-slider.tsx
+++ b/src/input-range-slider/input-range-slider.tsx
@@ -7,6 +7,7 @@ import {
     Slider,
     SliderThumb,
     SliderTrack,
+    Wrapper,
 } from "./input-range-slider.styles";
 import { InputRangeSliderProps } from "./types";
 
@@ -132,7 +133,7 @@ export const InputRangeSlider = ({
     };
 
     return (
-        <div {...otherProps}>
+        <Wrapper {...otherProps}>
             <Slider
                 step={step}
                 min={min}
@@ -178,6 +179,6 @@ export const InputRangeSlider = ({
                     <div>{formatLabel(max)}</div>
                 </LabelContainer>
             )}
-        </div>
+        </Wrapper>
     );
 };


### PR DESCRIPTION
**Changes**

- create new stacking context to prevent thumb from overlapping other elements on the page unintentionally
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

Bug fix
- Fix thumb controls potentially overlapping other elements in slider components