### PR TITLE
Filter mobile enhancement

### DIFF
--- a/src/filter/filter.styles.tsx
+++ b/src/filter/filter.styles.tsx
@@ -27,6 +27,7 @@ export const MobileContainer = styled.div`
 `;
 
 export const MobileOverlayContainer = styled.div`
+    background-color: ${Color.Neutral[8]};
     height: 100%;
     width: 100%;
 `;

--- a/src/filter/filter.tsx
+++ b/src/filter/filter.tsx
@@ -124,11 +124,11 @@ const FilterBase = ({
                     <StyledFilterIcon /> {toggleFilterButtonLabel}
                 </FilterButton>
                 <Overlay show={visible} disableTransition>
-                    <MobileOverlayContainer>
-                        <MobileContainer
-                            data-testid="filter-mobile"
-                            ref={mobileNodeRef}
-                        >
+                    <MobileOverlayContainer
+                        data-id="filter-mobile"
+                        data-testid="filter-mobile"
+                    >
+                        <MobileContainer ref={mobileNodeRef}>
                             {renderHeader("mobile")}
                             <FilterBody>{renderChildren("mobile")}</FilterBody>
                             <FilterFooter>
@@ -148,7 +148,11 @@ const FilterBase = ({
 
     const renderDesktop = () => {
         return (
-            <DesktopContainer data-testid="filter-desktop" ref={desktopNodeRef}>
+            <DesktopContainer
+                data-id="filter-desktop"
+                data-testid="filter-desktop"
+                ref={desktopNodeRef}
+            >
                 {renderHeader("default")}
                 {renderChildren("default")}
             </DesktopContainer>


### PR DESCRIPTION
**Changes**

use case: to push down the mobile filter modal in certain web views

- added a static identifier to target the mobile container, also added to desktop for consistency
- added the white background to ensure the modal still looks good visually when top or bottom padding is applied
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Add selectors for desktop and mobile containers in `Filter` 

**Additional information**

- You may refer to this [ticket](https://jira.ship.gov.sg/browse/CCUBE-1003)