### PR TITLE
Style html content

### DIFF
--- a/src/alert/alert.style.tsx
+++ b/src/alert/alert.style.tsx
@@ -2,6 +2,7 @@ import styled, { css } from "styled-components";
 import { Color } from "../color/color";
 import { Text, TextStyleHelper } from "../text";
 import { AlertSizeType, AlertType } from "./types";
+import { HtmlContentMixin } from "../shared/html-content/html-content";
 
 // =============================================================================
 // STYLE INTERFACES, transient props are denoted with $
@@ -19,8 +20,6 @@ interface StyleProps {
 export const Wrapper = styled.div<StyleProps>`
     padding: 0.5rem 1rem 0.5rem 0.875rem;
     display: flex;
-    ${TextStyleHelper.getTextStyle("BodySmall", "regular")}
-    color: ${Color.Neutral[1]};
 
     ${(props) => {
         let backgroundColor: string;
@@ -58,47 +57,12 @@ export const Wrapper = styled.div<StyleProps>`
         `;
     }}
 
-    p {
-        margin: 0;
-        ${(props) => {
-            if (props.$sizeType === "small")
-                return css`
-                    ${TextStyleHelper.getTextStyle("H6", "regular")}
-
-                    strong {
-                        ${TextStyleHelper.getTextStyle("H6", "semibold")}
-                    }
-
-                    a {
-                        ${TextStyleHelper.getTextStyle("H6", "semibold")}
-                    }
-                `;
-            else {
-                return css`
-                    ${TextStyleHelper.getTextStyle("H5", "regular")}
-
-                    strong {
-                        ${TextStyleHelper.getTextStyle("H5", "semibold")}
-                    }
-
-                    a {
-                        ${TextStyleHelper.getTextStyle("H5", "semibold")}
-                    }
-                `;
-            }
-        }}
-
-        a {
-            color: ${Color.Primary};
-            text-decoration: none;
-
-            :hover,
-            :active,
-            :focus {
-                color: ${Color.Secondary};
-            }
+    ${(props) => {
+        if (props.$sizeType === "small") {
+            return HtmlContentMixin("H6");
         }
-    }
+        return HtmlContentMixin("BodySmall");
+    }}
 `;
 
 export const AlertIconWrapper = styled.div<StyleProps>`

--- a/src/alert/alert.style.tsx
+++ b/src/alert/alert.style.tsx
@@ -1,8 +1,8 @@
 import styled, { css } from "styled-components";
 import { Color } from "../color/color";
+import { applyHtmlContentStyle } from "../shared/html-content/html-content";
 import { Text, TextStyleHelper } from "../text";
 import { AlertSizeType, AlertType } from "./types";
-import { HtmlContentMixin } from "../shared/html-content/html-content";
 
 // =============================================================================
 // STYLE INTERFACES, transient props are denoted with $
@@ -59,9 +59,9 @@ export const Wrapper = styled.div<StyleProps>`
 
     ${(props) => {
         if (props.$sizeType === "small") {
-            return HtmlContentMixin("H6");
+            return applyHtmlContentStyle("H6");
         }
-        return HtmlContentMixin("BodySmall");
+        return applyHtmlContentStyle("BodySmall");
     }}
 `;
 

--- a/src/file-upload/file-upload.styles.tsx
+++ b/src/file-upload/file-upload.styles.tsx
@@ -3,12 +3,13 @@ import { Alert } from "../alert";
 import { Button } from "../button";
 import { Color } from "../color";
 import { MediaQuery } from "../media";
+import { HtmlContentMixin } from "../shared/html-content/html-content";
 import { Text, TextStyleHelper } from "../text";
 
 // =============================================================================
 // STYLING
 // =============================================================================
-export const TitleContainer = styled.div`
+export const TextContainer = styled.div`
     display: flex;
     flex-direction: column;
     margin-bottom: 2rem;
@@ -18,9 +19,19 @@ export const Title = styled(Text.H4)`
     margin-bottom: 0.5rem;
 `;
 
+export const TitleContainer = styled.div`
+    ${HtmlContentMixin("Body")}
+`;
+
 export const Description = styled(Text.BodySmall)`
     margin-bottom: 0;
     color: ${Color.Neutral[3]};
+`;
+
+export const DescriptionContainer = styled.div`
+    ${HtmlContentMixin("BodySmall", {
+        textColor: Color.Neutral[3],
+    })}
 `;
 
 export const WarningAlert = styled(Alert)`

--- a/src/file-upload/file-upload.styles.tsx
+++ b/src/file-upload/file-upload.styles.tsx
@@ -3,7 +3,7 @@ import { Alert } from "../alert";
 import { Button } from "../button";
 import { Color } from "../color";
 import { MediaQuery } from "../media";
-import { HtmlContentMixin } from "../shared/html-content/html-content";
+import { applyHtmlContentStyle } from "../shared/html-content/html-content";
 import { Text, TextStyleHelper } from "../text";
 
 // =============================================================================
@@ -20,7 +20,7 @@ export const Title = styled(Text.H4)`
 `;
 
 export const TitleContainer = styled.div`
-    ${HtmlContentMixin("Body")}
+    ${applyHtmlContentStyle("Body")}
 `;
 
 export const Description = styled(Text.BodySmall)`
@@ -29,7 +29,7 @@ export const Description = styled(Text.BodySmall)`
 `;
 
 export const DescriptionContainer = styled.div`
-    ${HtmlContentMixin("BodySmall", {
+    ${applyHtmlContentStyle("BodySmall", {
         textColor: Color.Neutral[3],
     })}
 `;

--- a/src/file-upload/file-upload.tsx
+++ b/src/file-upload/file-upload.tsx
@@ -4,7 +4,9 @@ import { DropzoneElement, FileUploadDropzone } from "./dropzone";
 import { FileList } from "./file-list";
 import {
     Description,
+    DescriptionContainer,
     ErrorAlert,
+    TextContainer,
     Title,
     TitleContainer,
     UploadButton,
@@ -102,7 +104,7 @@ export const FileUpload = ({
             return <Title weight="regular">{title}</Title>;
         }
 
-        return <div>{title}</div>;
+        return <TitleContainer>{title}</TitleContainer>;
     };
 
     const renderDescription = () => {
@@ -114,7 +116,7 @@ export const FileUpload = ({
             return <Description weight="regular">{description}</Description>;
         }
 
-        return <div>{description}</div>;
+        return <DescriptionContainer>{description}</DescriptionContainer>;
     };
 
     return (
@@ -133,10 +135,10 @@ export const FileUpload = ({
                 disabled={disabled || reachedMaxFiles() || readOnly}
             >
                 {(title || description) && (
-                    <TitleContainer>
+                    <TextContainer>
                         {renderTitle()}
                         {renderDescription()}
-                    </TitleContainer>
+                    </TextContainer>
                 )}
                 {warning && (
                     <WarningAlert type="warning">{warning}</WarningAlert>

--- a/src/popover-v2/popover.styles.tsx
+++ b/src/popover-v2/popover.styles.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import { Card } from "../card";
 import { MediaQuery } from "../media";
 import { ModalBox } from "../modal/modal-box";
-import { HtmlContentMixin } from "../shared/html-content/html-content";
+import { applyHtmlContentStyle } from "../shared/html-content/html-content";
 
 // =============================================================================
 // STYLING
@@ -14,7 +14,7 @@ export const PopoverContainer = styled.div`
 `;
 
 export const PopoverCard = styled(Card)`
-    ${HtmlContentMixin("BodySmall")}
+    ${applyHtmlContentStyle("BodySmall")}
 
     ${MediaQuery.MaxWidth.mobileL} {
         display: none;

--- a/src/popover-v2/popover.styles.tsx
+++ b/src/popover-v2/popover.styles.tsx
@@ -31,4 +31,6 @@ export const ContentWrapper = styled.div`
     ::-webkit-scrollbar {
         display: none; /* Chrome/Safari/Webkit */
     }
+
+    ${applyHtmlContentStyle("BodySmall")}
 `;

--- a/src/popover-v2/popover.styles.tsx
+++ b/src/popover-v2/popover.styles.tsx
@@ -1,9 +1,8 @@
 import styled from "styled-components";
 import { Card } from "../card";
-import { Color } from "../color";
 import { MediaQuery } from "../media";
 import { ModalBox } from "../modal/modal-box";
-import { TextStyleHelper } from "../text";
+import { HtmlContentMixin } from "../shared/html-content/html-content";
 
 // =============================================================================
 // STYLING
@@ -15,25 +14,10 @@ export const PopoverContainer = styled.div`
 `;
 
 export const PopoverCard = styled(Card)`
-    ${TextStyleHelper.getTextStyle("BodySmall", "regular")}
+    ${HtmlContentMixin("BodySmall")}
 
     ${MediaQuery.MaxWidth.mobileL} {
         display: none;
-    }
-
-    a {
-        color: ${Color.Primary};
-        text-decoration: none;
-
-        :hover,
-        :active,
-        :focus {
-            color: ${Color.Secondary};
-
-            svg {
-                color: ${Color.Secondary};
-            }
-        }
     }
 `;
 

--- a/src/shared/html-content/html-content.ts
+++ b/src/shared/html-content/html-content.ts
@@ -1,0 +1,52 @@
+import { css } from "styled-components";
+import { Color } from "../../color";
+import { TextLinkSizeType, TextSizeType, TextStyleHelper } from "../../text";
+
+export const HtmlContentMixin = (
+    textStyle: TextSizeType | TextLinkSizeType
+) => css`
+    // Text
+    ${TextStyleHelper.getTextStyle(textStyle, "regular")}
+    color: ${Color.Neutral[1]};
+
+    a,
+    strong {
+        ${TextStyleHelper.getTextStyle(textStyle, "semibold")}
+    }
+
+    p {
+        margin: 0;
+    }
+
+    // Link styling
+    a {
+        color: ${Color.Primary};
+        text-decoration: none;
+
+        :hover,
+        :active,
+        :focus {
+            color: ${Color.Secondary};
+
+            svg {
+                color: ${Color.Secondary};
+            }
+        }
+    }
+
+    // List styling
+    ul,
+    ol {
+        margin: 0;
+        padding: 0;
+        margin-left: 2.5rem;
+    }
+
+    ol {
+        list-style: decimal;
+    }
+
+    ul {
+        list-style: disc;
+    }
+`;

--- a/src/shared/html-content/html-content.ts
+++ b/src/shared/html-content/html-content.ts
@@ -2,51 +2,60 @@ import { css } from "styled-components";
 import { Color } from "../../color";
 import { TextLinkSizeType, TextSizeType, TextStyleHelper } from "../../text";
 
+interface HtmlContentMixinOptions {
+    textColor?: string | ((props: any) => string);
+}
+
 export const HtmlContentMixin = (
-    textStyle: TextSizeType | TextLinkSizeType
-) => css`
-    // Text
-    ${TextStyleHelper.getTextStyle(textStyle, "regular")}
-    color: ${Color.Neutral[1]};
+    textStyle: TextSizeType | TextLinkSizeType,
+    options?: HtmlContentMixinOptions
+) => {
+    const { textColor = Color.Neutral[1] } = options || {};
 
-    a,
-    strong {
-        ${TextStyleHelper.getTextStyle(textStyle, "semibold")}
-    }
+    return css`
+        // Text
+        ${TextStyleHelper.getTextStyle(textStyle, "regular")}
+        color: ${textColor};
 
-    p {
-        margin: 0;
-    }
+        a,
+        strong {
+            ${TextStyleHelper.getTextStyle(textStyle, "semibold")}
+        }
 
-    // Link styling
-    a {
-        color: ${Color.Primary};
-        text-decoration: none;
+        p {
+            margin: 0;
+        }
 
-        :hover,
-        :active,
-        :focus {
-            color: ${Color.Secondary};
+        // Link styling
+        a {
+            color: ${Color.Primary};
+            text-decoration: none;
 
-            svg {
+            :hover,
+            :active,
+            :focus {
                 color: ${Color.Secondary};
+
+                svg {
+                    color: ${Color.Secondary};
+                }
             }
         }
-    }
 
-    // List styling
-    ul,
-    ol {
-        margin: 0;
-        padding: 0;
-        margin-left: 2.5rem;
-    }
+        // List styling
+        ul,
+        ol {
+            margin: 0;
+            padding: 0;
+            margin-left: 2.5rem;
+        }
 
-    ol {
-        list-style: decimal;
-    }
+        ol {
+            list-style: decimal;
+        }
 
-    ul {
-        list-style: disc;
-    }
-`;
+        ul {
+            list-style: disc;
+        }
+    `;
+};

--- a/src/shared/html-content/html-content.ts
+++ b/src/shared/html-content/html-content.ts
@@ -2,13 +2,13 @@ import { css } from "styled-components";
 import { Color } from "../../color";
 import { TextLinkSizeType, TextSizeType, TextStyleHelper } from "../../text";
 
-interface HtmlContentMixinOptions {
+interface HtmlContentStyleOptions {
     textColor?: string | ((props: any) => string);
 }
 
-export const HtmlContentMixin = (
+export const applyHtmlContentStyle = (
     textStyle: TextSizeType | TextLinkSizeType,
-    options?: HtmlContentMixinOptions
+    options?: HtmlContentStyleOptions
 ) => {
     const { textColor = Color.Neutral[1] } = options || {};
 

--- a/stories/alert/alert.stories.tsx
+++ b/stories/alert/alert.stories.tsx
@@ -84,6 +84,15 @@ export const WithBoldText: StoryObj<Component> = {
                     </a>
                     &nbsp;to direct users to some external source.
                 </p>
+                <br />
+                <p>You can list bullet points:</p>
+                <ul>
+                    <li>List item</li>
+                </ul>
+                <p>Or display numbered lists:</p>
+                <ol>
+                    <li>List item</li>
+                </ol>
             </Alert>
         );
     },

--- a/stories/file-upload/file-upload.mdx
+++ b/stories/file-upload/file-upload.mdx
@@ -56,6 +56,12 @@ the flexibility to reorder items after uploading them.
 
 <Canvas of={FileUploadStories.ReadonlyState} />
 
+<Heading3>Default text styling</Heading3>
+
+The title and description support styling for commonly used markup such as `<strong>` or `<a>`.
+
+<Canvas of={FileUploadStories.TextStyling} />
+
 <Secondary>Component API</Secondary>
 
 <PropsTable />

--- a/stories/file-upload/file-upload.stories.tsx
+++ b/stories/file-upload/file-upload.stories.tsx
@@ -310,3 +310,63 @@ export const ReadonlyState: StoryObj<Component> = {
         );
     },
 };
+
+export const TextStyling: StoryObj<Component> = {
+    render: (args) => {
+        const [fileItems, setFileItems] = useState([]);
+        const handleChange = (files) => {
+            const newFileItems = files.map((file) => {
+                return {
+                    id: SimpleIdGenerator.generate(),
+                    name: file.name,
+                    size: file.size,
+                    type: file.type,
+                };
+            });
+            setFileItems((prevItems) => {
+                return prevItems.concat(newFileItems);
+            });
+        };
+        const handleDelete = (fileItem) => {
+            const newArr = [...fileItems];
+            newArr.splice(newArr.indexOf(fileItem), 1);
+            setFileItems(newArr);
+        };
+        return (
+            <FileUpload
+                fileItems={fileItems}
+                onChange={handleChange}
+                onDelete={handleDelete}
+                title={
+                    <>
+                        <p>
+                            You can add <strong>bold text</strong>, <a>links</a>{" "}
+                            and list items to the title:
+                        </p>
+                        <ul>
+                            <li>List item</li>
+                        </ul>
+                        <ol>
+                            <li>List item</li>
+                        </ol>
+                    </>
+                }
+                description={
+                    <>
+                        <p>
+                            You can also add <strong>bold text</strong>,{" "}
+                            <a>links</a> and list items to the description:
+                        </p>
+                        <ul>
+                            <li>List item</li>
+                        </ul>
+                        <ol>
+                            <li>List item</li>
+                        </ol>
+                    </>
+                }
+                {...args}
+            />
+        );
+    },
+};

--- a/stories/popover-v2/popover.mdx
+++ b/stories/popover-v2/popover.mdx
@@ -1,5 +1,5 @@
 import { Canvas, Meta } from "@storybook/blocks";
-import { Heading4, Secondary, Title } from "../storybook-common";
+import { Heading3, Heading4, Secondary, Title } from "../storybook-common";
 import * as PopoverStories from "./popover.stories";
 import { PropsTable } from "./props-table";
 
@@ -27,5 +27,11 @@ import { PopoverTrigger } from "@lifesg/react-design-system/popover-v2";
 -   The `Popover` appears as a modal in mobile viewports
 
 <Canvas of={PopoverStories.Appearance} />
+
+<Heading3>Default styling</Heading3>
+
+The component comes with basic styling for commonly used markup such as `<strong>` or `<a>`.
+
+<Canvas of={PopoverStories.DefaultStyling} />
 
 <PropsTable />

--- a/stories/popover-v2/popover.stories.tsx
+++ b/stories/popover-v2/popover.stories.tsx
@@ -33,6 +33,34 @@ export const HoverInteraction: StoryObj<Component> = {
     },
 };
 
+export const DefaultStyling: StoryObj<Component> = {
+    render: () => {
+        return (
+            <PopoverTrigger
+                popoverContent={
+                    <>
+                        <p>
+                            You can add <strong>bold text</strong> and{" "}
+                            <a>links</a>.
+                        </p>
+                        <br />
+                        <p>You can list bullet points:</p>
+                        <ul>
+                            <li>List item</li>
+                        </ul>
+                        <p>Or display numbered lists:</p>
+                        <ol>
+                            <li>List item</li>
+                        </ol>
+                    </>
+                }
+            >
+                <Button.Default>Click me</Button.Default>
+            </PopoverTrigger>
+        );
+    },
+};
+
 export const Appearance: StoryObj<Component> = {
     render: () => {
         return (


### PR DESCRIPTION
**Changes**

- add styling for html list in Alert and FileUpload title and description
- extract common style for html markup like `strong`, `a` and `li` and apply to Alert, FileUpload and PopoverV2
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Support styling for html `li` in `Alert`, `FileUpload` and `Popover` text