### PR TITLE
Box container icon and font size fix

### DIFF
--- a/src/box-container/box-container.styles.tsx
+++ b/src/box-container/box-container.styles.tsx
@@ -4,6 +4,7 @@ import { animated } from "react-spring";
 import styled, { css } from "styled-components";
 import { Color } from "../color";
 import { MediaQuery } from "../media";
+import { TextStyleHelper } from "../text/helper";
 import { Text } from "../text/text";
 import { Transition } from "../transition";
 import { BoxContainerDisplayState } from "./types";
@@ -50,6 +51,7 @@ export const Header = styled.div`
 
     ${MediaQuery.MaxWidth.mobileL} {
         padding: 1rem 1.25rem;
+        display: block;
     }
 `;
 

--- a/src/box-container/box-container.styles.tsx
+++ b/src/box-container/box-container.styles.tsx
@@ -4,7 +4,6 @@ import { animated } from "react-spring";
 import styled, { css } from "styled-components";
 import { Color } from "../color";
 import { MediaQuery } from "../media";
-import { TextStyleHelper } from "../text/helper";
 import { Text } from "../text/text";
 import { Transition } from "../transition";
 import { BoxContainerDisplayState } from "./types";
@@ -51,7 +50,6 @@ export const Header = styled.div`
 
     ${MediaQuery.MaxWidth.mobileL} {
         padding: 1rem 1.25rem;
-        display: block;
     }
 `;
 

--- a/src/box-container/box-container.styles.tsx
+++ b/src/box-container/box-container.styles.tsx
@@ -62,11 +62,6 @@ export const LabelText = styled(Text.H3)`
     flex: 1;
     align-items: center;
     margin-right: 1rem;
-
-    ${MediaQuery.MaxWidth.mobileL} {
-        ${TextStyleHelper.getTextStyle("BodySmall", "semibold")}
-        display: flex;
-    }
 `;
 
 export const LabelWrapper = styled.div`

--- a/src/box-container/box-container.styles.tsx
+++ b/src/box-container/box-container.styles.tsx
@@ -4,7 +4,6 @@ import { animated } from "react-spring";
 import styled, { css } from "styled-components";
 import { Color } from "../color";
 import { MediaQuery } from "../media";
-import { TextStyleHelper } from "../text/helper";
 import { Text } from "../text/text";
 import { Transition } from "../transition";
 import { BoxContainerDisplayState } from "./types";
@@ -59,7 +58,6 @@ export const LabelText = styled(Text.H3)`
     word-wrap: break-word;
     overflow-wrap: anywhere;
     display: flex;
-    flex: 1;
     align-items: center;
     margin-right: 1rem;
 `;

--- a/src/box-container/box-container.tsx
+++ b/src/box-container/box-container.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { useResizeDetector } from "react-resize-detector";
+import { useMediaQuery } from "react-responsive";
 import { useSpring } from "react-spring";
+import { MediaWidths } from "../media";
 import {
     AlertIcon,
     CallToActionContainer,
@@ -36,6 +38,9 @@ export const BoxContainer = ({
     );
     const resizeDetector = useResizeDetector();
     const childRef = resizeDetector.ref;
+    const isMobile = useMediaQuery({
+        maxWidth: MediaWidths.mobileL,
+    });
 
     // =============================================================================
     // EVENT HANDLERS
@@ -119,6 +124,7 @@ export const BoxContainer = ({
                         {title}
                     </LabelText>
                     {renderDisplayIcon()}
+                    {isMobile && renderHandleIcon()}
                 </LabelWrapper>
                 {callToActionComponent && (
                     <CallToActionContainer
@@ -129,7 +135,7 @@ export const BoxContainer = ({
                     </CallToActionContainer>
                 )}
 
-                {renderHandleIcon()}
+                {!isMobile && renderHandleIcon()}
             </Header>
             {renderChildContent()}
         </Container>

--- a/src/box-container/box-container.tsx
+++ b/src/box-container/box-container.tsx
@@ -1,8 +1,6 @@
 import { useState } from "react";
 import { useResizeDetector } from "react-resize-detector";
-import { useMediaQuery } from "react-responsive";
 import { useSpring } from "react-spring";
-import { MediaWidths } from "../media";
 import {
     AlertIcon,
     CallToActionContainer,
@@ -38,9 +36,6 @@ export const BoxContainer = ({
     );
     const resizeDetector = useResizeDetector();
     const childRef = resizeDetector.ref;
-    const isMobile = useMediaQuery({
-        maxWidth: MediaWidths.mobileL,
-    });
 
     // =============================================================================
     // EVENT HANDLERS
@@ -124,7 +119,6 @@ export const BoxContainer = ({
                         {title}
                     </LabelText>
                     {renderDisplayIcon()}
-                    {isMobile && renderHandleIcon()}
                 </LabelWrapper>
                 {callToActionComponent && (
                     <CallToActionContainer
@@ -135,7 +129,7 @@ export const BoxContainer = ({
                     </CallToActionContainer>
                 )}
 
-                {!isMobile && renderHandleIcon()}
+                {renderHandleIcon()}
             </Header>
             {renderChildContent()}
         </Container>

--- a/stories/box-container/box-container.stories.tsx
+++ b/stories/box-container/box-container.stories.tsx
@@ -53,10 +53,7 @@ export const WithDisplayState: StoryObj<Component> = {
     render: () => {
         return (
             <>
-                <BoxContainer
-                    title="This comes with an error icon"
-                    displayState="error"
-                >
+                <BoxContainer title="Error icon" displayState="error">
                     <div style={{ padding: "2rem" }}>
                         <Text.Body>
                             Lorem ipsum dolor sit amet, consectetur adipiscing

--- a/stories/box-container/box-container.stories.tsx
+++ b/stories/box-container/box-container.stories.tsx
@@ -53,7 +53,10 @@ export const WithDisplayState: StoryObj<Component> = {
     render: () => {
         return (
             <>
-                <BoxContainer title="Error icon" displayState="error">
+                <BoxContainer
+                    title="This comes with an error icon"
+                    displayState="error"
+                >
                     <div style={{ padding: "2rem" }}>
                         <Text.Body>
                             Lorem ipsum dolor sit amet, consectetur adipiscing


### PR DESCRIPTION
**Changes**
- Set title to H3 in mobile view
- Move icon closer to short title in mobile view
- Have a short title in box container storybook to demonstrate the icon placement between short and long title in mobile view.

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**
- Fix Box container icon and font size in mobile view

**Additional information**

- You may refer to this [ticket](https://jira.ship.gov.sg/browse/MOL-14994)
- [Figma](https://www.figma.com/file/us90jOpWBahsqK2VAluPvD/Flagship-Design-System?type=design&node-id=17788-20077&mode=design&t=IWrULsA2u4ZCWbCS-0)
