### PR TITLE
Support interactive content in toggle sublabel

### DIFF
--- a/src/toggle/toggle.styles.tsx
+++ b/src/toggle/toggle.styles.tsx
@@ -134,6 +134,7 @@ export const TextContainer = styled.div`
     display: flex;
     flex-direction: column;
     overflow-wrap: anywhere;
+    width: 100%;
 `;
 
 export const Label = styled.label<LabelStyleProps>`

--- a/src/toggle/toggle.styles.tsx
+++ b/src/toggle/toggle.styles.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from "styled-components";
 import { Color } from "../color";
-import { Text, TextStyle, TextStyleHelper, TextWeight } from "../text";
+import { TextStyleHelper } from "../text";
 import { ToggleStyleType } from "./types";
 
 // =============================================================================
@@ -32,6 +32,7 @@ export const Container = styled.div<ContainerStyleProps>`
     border-style: solid;
     cursor: ${(props) => (props.$disabled ? "not-allowed" : "pointer")};
     padding: 0.6875rem 1rem;
+    isolation: isolate;
 
     // Content positioning style
     ${(props) => {
@@ -166,6 +167,9 @@ export const Label = styled.label<LabelStyleProps>`
 export const SubLabel = styled.div<LabelStyleProps>`
     ${TextStyleHelper.getTextStyle("BodySmall", "regular")}
     margin-top: 0.5rem;
+
+    z-index: 1; // forces sublabel to render above the input
+    pointer-events: none; // to allow click events to be passed to the input
 
     strong,
     b {

--- a/src/toggle/toggle.tsx
+++ b/src/toggle/toggle.tsx
@@ -112,7 +112,11 @@ export const Toggle = ({
         }
 
         return (
-            <SubLabel $disabled={disabled} $selected={selected}>
+            <SubLabel
+                data-id="toggle-sublabel"
+                $disabled={disabled}
+                $selected={selected}
+            >
                 {component}
             </SubLabel>
         );

--- a/stories/toggle/toggle.mdx
+++ b/stories/toggle/toggle.mdx
@@ -41,6 +41,13 @@ Click on the links to see the variants in depth.
 
 <br />
 
+<Heading3>Interactive sublabel</Heading3>
+
+By default, clicking on the sublabel will activate the `Toggle`. If you require interactive content such as links,
+you may opt out of this behaviour as such:
+
+<Canvas of={ToggleStories.InteractiveSublabel} />
+
 <Secondary>Component API</Secondary>
 
 <PropsTable />

--- a/stories/toggle/toggle.stories.tsx
+++ b/stories/toggle/toggle.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { Text } from "src/text";
 import { Toggle } from "src/toggle";
 import { Headings, SimpleContainer, Wrapper } from "./doc-elements";
 
@@ -51,6 +52,35 @@ export const Behaviours: StoryObj<Component> = {
                     </Toggle>
                 </li>
             </SimpleContainer>
+        );
+    },
+};
+
+export const InteractiveSublabel: StoryObj<Component> = {
+    render: () => {
+        return (
+            <Toggle
+                indicator
+                subLabel={() => (
+                    <div>
+                        Clicking here toggles the button.
+                        <div style={{ pointerEvents: "auto" }}>
+                            Clicking here does not and{" "}
+                            <Text.Hyperlink.Small
+                                href="https://example.com"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                external
+                            >
+                                this link
+                            </Text.Hyperlink.Small>{" "}
+                            is accessible
+                        </div>
+                    </div>
+                )}
+            >
+                Hello
+            </Toggle>
         );
     },
 };


### PR DESCRIPTION
**Changes**

- sublabel changes
  - because the toggle `input` is absolutely positioned, it covers the sublabel and prevents clicks from being registered on the sublabel element
  - this change makes the sublabel render above the input instead, with `pointer-events: none` so clicks are passed to `input` by default
  - then when click events are needed on the sublabel, this can be reversed with `pointer-events: auto`
- style changes
  - let TextContainer take up the full width, so that contents can grow when the toggle is vertically arranged
  - add selector for sublabel
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Support interactive content in `Toggle` sublabel

**Additional information**

Added a story to the main page as an example for developers