### PR TITLE
Add masked field in uneditable section

### DIFF
--- a/src/masked-input/masked-input.tsx
+++ b/src/masked-input/masked-input.tsx
@@ -15,6 +15,7 @@ import {
 } from "./masked-input.style";
 import { MaskedInputProps } from "./types";
 import { isEmpty } from "lodash";
+import { StringHelper } from "../util";
 
 const Component = (
     {
@@ -117,50 +118,14 @@ const Component = (
         }
 
         return isMasked && !disableMask
-            ? maskValue(updatedValue?.toString())
+            ? StringHelper.maskValue(updatedValue?.toString(), {
+                  maskChar,
+                  maskRange,
+                  unmaskRange,
+                  maskRegex,
+                  maskTransformer,
+              })
             : updatedValue;
-    };
-
-    const maskValue = (value: string): string => {
-        if (!value) {
-            return value;
-        }
-
-        if (maskRange) {
-            const { startIndex, endIndex } = determineStartAndEndIndex(
-                maskRange[0],
-                maskRange[1]
-            );
-            return (
-                value.substring(0, startIndex) +
-                maskChar.repeat(
-                    value.substring(startIndex, endIndex + 1).length
-                ) +
-                value.substring(endIndex + 1)
-            );
-        } else if (unmaskRange) {
-            const { startIndex, endIndex } = determineStartAndEndIndex(
-                unmaskRange[0],
-                unmaskRange[1]
-            );
-            return (
-                maskChar.repeat(value.substring(0, startIndex).length) +
-                value.substring(startIndex, endIndex + 1) +
-                maskChar.repeat(value.substring(endIndex + 1).length)
-            );
-        } else if (maskRegex) {
-            return value.replace(maskRegex, maskChar);
-        } else if (maskTransformer) {
-            return maskTransformer(value);
-        }
-
-        return value;
-    };
-
-    const determineStartAndEndIndex = (index0: number, index1: number) => {
-        return index0 < index1
-            ? { startIndex: index0, endIndex: index1 }
-            : { startIndex: index1, endIndex: index0 };
     };
 
     const shouldDisableMasking = () =>

--- a/src/masked-input/types.ts
+++ b/src/masked-input/types.ts
@@ -1,16 +1,20 @@
 import { InputProps } from "../input/types";
 
 export type MaskedInputLoadState = "loading" | "fail" | "success";
-export interface MaskedInputProps extends InputProps {
+
+export interface MaskAttributeProps {
     maskRange?: number[] | undefined;
     unmaskRange?: number[] | undefined;
     maskRegex?: RegExp | undefined;
     maskTransformer?: ((value: string) => string) | undefined;
+    maskChar?: string | undefined;
+}
+
+export interface MaskedInputProps extends InputProps, MaskAttributeProps {
     iconMask?: JSX.Element;
     iconUnmask?: JSX.Element;
     iconActiveColor?: string | undefined;
     iconInactiveColor?: string | undefined;
-    maskChar?: string | undefined;
     disableMask?: boolean | undefined;
     transformInput?: "uppercase" | "lowercase" | undefined;
     /**

--- a/src/uneditable-section/section-item.styles.tsx
+++ b/src/uneditable-section/section-item.styles.tsx
@@ -1,6 +1,10 @@
 import styled, { css } from "styled-components";
-import { UneditableSectionItemDisplayWidth } from "./types";
+import { Color } from "../color";
 import { MediaQuery } from "../media";
+import { ComponentLoadingSpinner } from "../shared/component-loading-spinner/component-loading-spinner";
+import { Text } from "../text";
+import { UneditableSectionItemDisplayWidth } from "./types";
+import { ExclamationTriangleIcon } from "@lifesg/react-icons/exclamation-triangle";
 
 // =============================================================================
 // STYLING INTERFACES
@@ -36,4 +40,64 @@ export const Container = styled.li<ContainerStyleProps>`
     ${MediaQuery.MaxWidth.mobileL} {
         grid-column: auto / span 4;
     }
+`;
+
+export const IconContainer = styled.div`
+    display: flex;
+    height: 100%;
+    align-items: center;
+    justify-content: center;
+    color: ${Color.Primary};
+    margin-left: 0.5rem;
+
+    svg {
+        width: 1.125rem;
+        height: 1.125rem;
+    }
+`;
+
+export const Clickable = styled.button`
+    border: none;
+    background: transparent;
+    padding: 0;
+    display: flex;
+    cursor: pointer;
+    align-items: center;
+`;
+
+// -----------------------------------------------------------------------------
+// LOADING DISPLAY
+// -----------------------------------------------------------------------------
+export const LoadingLabel = styled(Text.Body)`
+    color: ${Color.Neutral[3]};
+`;
+
+export const Spinner = styled(ComponentLoadingSpinner)`
+    margin-right: 0.5rem;
+    #inner1,
+    #inner2,
+    #inner3,
+    #inner4 {
+        border-color: ${Color.Neutral[3]} transparent transparent transparent;
+    }
+`;
+
+// -----------------------------------------------------------------------------
+// ERROR DISPLAY
+// -----------------------------------------------------------------------------
+export const ErrorIcon = styled(ExclamationTriangleIcon)`
+    color: ${Color.Validation.Orange.Icon};
+    margin-right: 0.5rem;
+    height: 1.125rem;
+    width: 1.125rem;
+`;
+
+export const ErrorLabel = styled(Text.Body)`
+    color: ${Color.Validation.Orange.Text};
+`;
+
+export const TryAgainLabel = styled(Text.Body)`
+    color: ${Color.Primary};
+    text-decoration: underline;
+    margin-left: 0.5rem;
 `;

--- a/src/uneditable-section/section-item.styles.tsx
+++ b/src/uneditable-section/section-item.styles.tsx
@@ -1,10 +1,10 @@
+import { ExclamationTriangleIcon } from "@lifesg/react-icons/exclamation-triangle";
 import styled, { css } from "styled-components";
 import { Color } from "../color";
 import { MediaQuery } from "../media";
 import { ComponentLoadingSpinner } from "../shared/component-loading-spinner/component-loading-spinner";
-import { Text } from "../text";
+import { TextStyleHelper } from "../text";
 import { UneditableSectionItemDisplayWidth } from "./types";
-import { ExclamationTriangleIcon } from "@lifesg/react-icons/exclamation-triangle";
 
 // =============================================================================
 // STYLING INTERFACES
@@ -57,18 +57,26 @@ export const IconContainer = styled.div`
 `;
 
 export const Clickable = styled.button`
+    ${TextStyleHelper.getTextStyle("Body", "regular")}
     border: none;
     background: transparent;
     padding: 0;
     display: flex;
     cursor: pointer;
     align-items: center;
+    overflow-wrap: anywhere;
+    text-align: left;
+
+    span {
+        overflow-wrap: anywhere;
+        text-align: left;
+    }
 `;
 
 // -----------------------------------------------------------------------------
 // LOADING DISPLAY
 // -----------------------------------------------------------------------------
-export const LoadingLabel = styled(Text.Body)`
+export const LoadingLabel = styled.span`
     color: ${Color.Neutral[3]};
 `;
 
@@ -92,11 +100,12 @@ export const ErrorIcon = styled(ExclamationTriangleIcon)`
     width: 1.125rem;
 `;
 
-export const ErrorLabel = styled(Text.Body)`
+export const ErrorLabel = styled.span`
     color: ${Color.Validation.Orange.Text};
 `;
 
-export const TryAgainLabel = styled(Text.Body)`
+export const TryAgainLabel = styled.span`
+    ${TextStyleHelper.getTextStyle("Body", "semibold")}
     color: ${Color.Primary};
     text-decoration: underline;
     margin-left: 0.5rem;

--- a/src/uneditable-section/section-item.tsx
+++ b/src/uneditable-section/section-item.tsx
@@ -19,7 +19,8 @@ import { Text } from "../text";
 import { StringHelper } from "../util/string-helper";
 import { useEffect, useState } from "react";
 
-interface Props extends UneditableSectionItemProps {
+export interface UneditableSectionItemComponentProps
+    extends UneditableSectionItemProps {
     onMask?: (() => void) | undefined;
     onUnmask?: (() => void) | undefined;
     onTryAgain?: (() => void) | undefined;
@@ -40,7 +41,7 @@ export const UneditableSectionItem = ({
     onMask,
     onUnmask,
     onTryAgain,
-}: Props) => {
+}: UneditableSectionItemComponentProps) => {
     // =========================================================================
     // CONST, STATE, REF
     // =========================================================================

--- a/src/uneditable-section/section-item.tsx
+++ b/src/uneditable-section/section-item.tsx
@@ -1,17 +1,166 @@
-import { UneditableSectionItemProps } from "./types";
-import { Container } from "./section-item.styles";
+import { EyeIcon } from "@lifesg/react-icons/eye";
+import { EyeSlashIcon } from "@lifesg/react-icons/eye-slash";
+import {
+    UneditableSectionItemMaskState,
+    UneditableSectionItemProps,
+} from "./types";
+import {
+    Clickable,
+    Container,
+    ErrorIcon,
+    ErrorLabel,
+    IconContainer,
+    LoadingLabel,
+    Spinner,
+    TryAgainLabel,
+} from "./section-item.styles";
 import { FormLabel } from "../form/form-label";
 import { Text } from "../text";
+import { StringHelper } from "../util/string-helper";
+import { useEffect, useState } from "react";
+
+interface Props extends UneditableSectionItemProps {
+    onMask?: (() => void) | undefined;
+    onUnmask?: (() => void) | undefined;
+    onTryAgain?: (() => void) | undefined;
+}
 
 export const UneditableSectionItem = ({
     label,
     value,
     displayWidth = "full",
-}: UneditableSectionItemProps) => {
+    maskState,
+    maskLoadingState,
+    maskChar = "•",
+    maskRange,
+    unmaskRange,
+    maskRegex,
+    disableMaskUnmask,
+    maskTransformer,
+    onMask,
+    onUnmask,
+    onTryAgain,
+}: Props) => {
+    // =========================================================================
+    // CONST, STATE, REF
+    // =========================================================================
+    const [displayMaskState, setMaskState] = useState<
+        UneditableSectionItemMaskState | undefined
+    >(maskState);
+
+    // =========================================================================
+    // EFFECTS
+    // =========================================================================
+    useEffect(() => {
+        setMaskState(maskState);
+    }, [maskState]);
+
+    // =========================================================================
+    // EVENT HANDLERS
+    // =========================================================================
+    const handleClickableClick = () => {
+        if (maskLoadingState === "fail") {
+            if (onTryAgain) onTryAgain();
+        }
+
+        switch (displayMaskState) {
+            case "masked": {
+                if (onUnmask) {
+                    onUnmask();
+                }
+                setMaskState("unmasked");
+                break;
+            }
+            case "unmasked": {
+                if (onMask) {
+                    onMask();
+                }
+                setMaskState("masked");
+                break;
+            }
+        }
+    };
+
+    // =========================================================================
+    // HELPER FUNCTIONS
+    // =========================================================================
+    const getMaskedValue = () => {
+        return StringHelper.maskValue(value, {
+            maskChar,
+            maskRange,
+            unmaskRange,
+            maskRegex,
+            maskTransformer,
+        });
+    };
+
+    // =========================================================================
+    // RENDER FUNCTIONS
+    // =========================================================================
+    const renderMaskingState = () => {
+        switch (maskLoadingState) {
+            case "fail":
+                return (
+                    <>
+                        <ErrorIcon />
+                        <ErrorLabel>Error</ErrorLabel>
+                        <TryAgainLabel weight="semibold">
+                            Try again?
+                        </TryAgainLabel>
+                    </>
+                );
+            case "loading":
+                return (
+                    <>
+                        <Spinner />
+                        <LoadingLabel>Retrieving...</LoadingLabel>
+                    </>
+                );
+            default:
+                return (
+                    <>
+                        <Text.Body>
+                            {displayMaskState === "masked"
+                                ? getMaskedValue()
+                                : value}
+                        </Text.Body>
+                        <IconContainer>
+                            {displayMaskState === "masked" ? (
+                                <EyeIcon data-testid="masked-icon" />
+                            ) : (
+                                <EyeSlashIcon data-testid="unmasked-icon" />
+                            )}
+                        </IconContainer>
+                    </>
+                );
+        }
+    };
+
+    const renderContent = () => {
+        if (!displayMaskState) {
+            return <Text.Body>{value}</Text.Body>;
+        }
+
+        if (disableMaskUnmask) {
+            return <Text.Body>{getMaskedValue()}</Text.Body>;
+        }
+
+        return (
+            <Clickable
+                data-testid="clickable-label"
+                onClick={handleClickableClick}
+                aria-busy={maskLoadingState === "loading"}
+                aria-live="polite"
+            >
+                {renderMaskingState()}
+            </Clickable>
+        );
+    };
+
     return (
         <Container $widthStyle={displayWidth}>
             <FormLabel>{label}</FormLabel>
-            <Text.Body>{value}</Text.Body>
+            {renderContent()}
         </Container>
     );
 };

--- a/src/uneditable-section/section-item.tsx
+++ b/src/uneditable-section/section-item.tsx
@@ -84,14 +84,16 @@ export const UneditableSectionItem = ({
     // =========================================================================
     // HELPER FUNCTIONS
     // =========================================================================
-    const getMaskedValue = () => {
-        return StringHelper.maskValue(value, {
-            maskChar,
-            maskRange,
-            unmaskRange,
-            maskRegex,
-            maskTransformer,
-        });
+    const getValue = () => {
+        return displayMaskState === "masked"
+            ? StringHelper.maskValue(value, {
+                  maskChar,
+                  maskRange,
+                  unmaskRange,
+                  maskRegex,
+                  maskTransformer,
+              })
+            : value;
     };
 
     // =========================================================================
@@ -119,11 +121,7 @@ export const UneditableSectionItem = ({
             default:
                 return (
                     <>
-                        <Text.Body>
-                            {displayMaskState === "masked"
-                                ? getMaskedValue()
-                                : value}
-                        </Text.Body>
+                        {getValue()}
                         <IconContainer>
                             {displayMaskState === "masked" ? (
                                 <EyeIcon data-testid="masked-icon" />
@@ -142,7 +140,7 @@ export const UneditableSectionItem = ({
         }
 
         if (disableMaskUnmask) {
-            return <Text.Body>{getMaskedValue()}</Text.Body>;
+            return <Text.Body>{getValue()}</Text.Body>;
         }
 
         return (

--- a/src/uneditable-section/section-item.tsx
+++ b/src/uneditable-section/section-item.tsx
@@ -106,9 +106,7 @@ export const UneditableSectionItem = ({
                     <>
                         <ErrorIcon />
                         <ErrorLabel>Error</ErrorLabel>
-                        <TryAgainLabel weight="semibold">
-                            Try again?
-                        </TryAgainLabel>
+                        <TryAgainLabel>Try again?</TryAgainLabel>
                     </>
                 );
             case "loading":

--- a/src/uneditable-section/types.ts
+++ b/src/uneditable-section/types.ts
@@ -42,6 +42,8 @@ export interface UneditableSectionProps {
     className?: string | undefined;
     "data-testid"?: string | undefined;
     id?: string | undefined;
+    /** If specified false, the background will be transparent. Else it is grey by default */
+    background?: boolean | undefined;
     /** The callback function when the mask icon is clicked */
     onMask?: ((item: UneditableSectionItemProps) => void) | undefined;
     /** The callback function when the unmask icon is clicked */

--- a/src/uneditable-section/types.ts
+++ b/src/uneditable-section/types.ts
@@ -1,10 +1,32 @@
-export type UneditableSectionItemDisplayWidth = "half" | "full";
+import { MaskAttributeProps } from "../masked-input";
 
-export interface UneditableSectionItemProps {
+export type UneditableSectionItemDisplayWidth = "half" | "full";
+export type UneditableSectionItemMaskState = "masked" | "unmasked";
+export type UneditableSectionItemMaskLoadingState = "loading" | "fail";
+
+export interface UneditableSectionItemProps extends MaskAttributeProps {
+    id?: string | undefined;
     label: string;
     value: string;
     /** The width that the item can span across. Values: "half", "full" */
     displayWidth?: UneditableSectionItemDisplayWidth | undefined;
+    /**
+     * Specifies if value is masked or unmasked.
+     * If undefined, no masking or unmasking controls will be rendered.
+     *
+     * Values: "masked" | "unmasked"
+     */
+    maskState?: UneditableSectionItemMaskState | undefined;
+    /**
+     * Specifies the state of the component when there is a
+     * loading behaviour from a mask/unmask action. If undefined
+     * the value will be rendered out.
+     *
+     * Values: "loading" | "fail"
+     */
+    maskLoadingState?: UneditableSectionItemMaskLoadingState | undefined;
+    /** If specified, one is unable to mask or unmask the value */
+    disableMaskUnmask?: boolean | undefined;
 }
 
 export interface UneditableSectionProps {
@@ -20,4 +42,10 @@ export interface UneditableSectionProps {
     className?: string | undefined;
     "data-testid"?: string | undefined;
     id?: string | undefined;
+    /** The callback function when the mask icon is clicked */
+    onMask?: ((item: UneditableSectionItemProps) => void) | undefined;
+    /** The callback function when the unmask icon is clicked */
+    onUnmask?: ((item: UneditableSectionItemProps) => void) | undefined;
+    /** The callback function when the "Try again" button is clicked in error state */
+    onTryAgain?: ((item: UneditableSectionItemProps) => void) | undefined;
 }

--- a/src/uneditable-section/uneditable-section.styles.tsx
+++ b/src/uneditable-section/uneditable-section.styles.tsx
@@ -4,8 +4,19 @@ import { Color } from "../color";
 import { MediaQuery } from "../media";
 import { Text } from "../text";
 
-export const Wrapper = styled(Layout.Content)`
-    background: ${Color.Neutral[7]};
+// =============================================================================
+// STYLE INTERFACES
+// =============================================================================
+interface WrapperStyleProps {
+    $background: boolean;
+}
+
+// =============================================================================
+// STYLING
+// =============================================================================
+export const Wrapper = styled(Layout.Content)<WrapperStyleProps>`
+    background: ${({ $background }) =>
+        $background ? Color.Neutral[7] : "transparent"};
     padding-top: 2rem;
     padding-bottom: 2rem;
 `;

--- a/src/uneditable-section/uneditable-section.tsx
+++ b/src/uneditable-section/uneditable-section.tsx
@@ -1,5 +1,5 @@
 import { UneditableSectionItem } from "./section-item";
-import { UneditableSectionProps } from "./types";
+import { UneditableSectionItemProps, UneditableSectionProps } from "./types";
 import {
     CustomSection,
     Description,
@@ -15,15 +15,45 @@ export const UneditableSectionBase = ({
     topSection,
     bottomSection,
     children,
+    onMask,
+    onUnmask,
+    onTryAgain,
     ...otherProps
 }: UneditableSectionProps) => {
+    // =============================================================================
+    // EVENT HANDLERS
+    // =============================================================================
+    const handleItemMask = (item: UneditableSectionItemProps) => () => {
+        if (onMask) onMask(item);
+    };
+
+    const handleItemUnmask = (item: UneditableSectionItemProps) => () => {
+        if (onUnmask) onUnmask(item);
+    };
+
+    const handleTryAgain = (item: UneditableSectionItemProps) => () => {
+        if (onTryAgain) onTryAgain(item);
+    };
+
     // =============================================================================
     // RENDER FUNCTIONS
     // =============================================================================
     const renderItems = () => {
         if (items && items.length > 0) {
             const renderedItems = items.map((item, index) => {
-                return <UneditableSectionItem key={index} {...item} />;
+                return (
+                    <UneditableSectionItem
+                        key={index}
+                        {...item}
+                        {...(onMask ? { onMask: handleItemMask(item) } : {})}
+                        {...(onUnmask
+                            ? { onUnmask: handleItemUnmask(item) }
+                            : {})}
+                        {...(onTryAgain
+                            ? { onTryAgain: handleTryAgain(item) }
+                            : {})}
+                    />
+                );
             });
 
             return <GridUl>{renderedItems}</GridUl>;

--- a/src/uneditable-section/uneditable-section.tsx
+++ b/src/uneditable-section/uneditable-section.tsx
@@ -45,13 +45,9 @@ export const UneditableSectionBase = ({
                     <UneditableSectionItem
                         key={index}
                         {...item}
-                        {...(onMask ? { onMask: handleItemMask(item) } : {})}
-                        {...(onUnmask
-                            ? { onUnmask: handleItemUnmask(item) }
-                            : {})}
-                        {...(onTryAgain
-                            ? { onTryAgain: handleTryAgain(item) }
-                            : {})}
+                        onMask={handleItemMask(item)}
+                        onUnmask={handleItemUnmask(item)}
+                        onTryAgain={handleTryAgain(item)}
                     />
                 );
             });

--- a/src/uneditable-section/uneditable-section.tsx
+++ b/src/uneditable-section/uneditable-section.tsx
@@ -15,6 +15,7 @@ export const UneditableSectionBase = ({
     topSection,
     bottomSection,
     children,
+    background = true,
     onMask,
     onUnmask,
     onTryAgain,
@@ -83,7 +84,7 @@ export const UneditableSectionBase = ({
     };
 
     return (
-        <Wrapper {...otherProps} type="grid">
+        <Wrapper $background={background} {...otherProps} type="grid">
             {renderChildren()}
         </Wrapper>
     );

--- a/src/util/string-helper.ts
+++ b/src/util/string-helper.ts
@@ -1,3 +1,5 @@
+import { MaskAttributeProps } from "../masked-input";
+
 export namespace StringHelper {
     export const transformWithSpaces = (
         value: string | any,
@@ -104,5 +106,55 @@ export namespace StringHelper {
 
         const metrics = context.measureText(text);
         return metrics.width;
+    };
+
+    export const maskValue = (value: string, options?: MaskAttributeProps) => {
+        if (!value) {
+            return value;
+        }
+
+        const {
+            maskRange,
+            unmaskRange,
+            maskChar = "•",
+            maskRegex,
+            maskTransformer,
+        } = options;
+
+        if (maskTransformer) {
+            return maskTransformer(value);
+        } else if (maskRegex) {
+            return value.replace(maskRegex, maskChar);
+        } else if (maskRange) {
+            const { startIndex, endIndex } = determineStartAndEndIndex(
+                maskRange[0],
+                maskRange[1]
+            );
+            return (
+                value.substring(0, startIndex) +
+                maskChar.repeat(
+                    value.substring(startIndex, endIndex + 1).length
+                ) +
+                value.substring(endIndex + 1)
+            );
+        } else if (unmaskRange) {
+            const { startIndex, endIndex } = determineStartAndEndIndex(
+                unmaskRange[0],
+                unmaskRange[1]
+            );
+            return (
+                maskChar.repeat(value.substring(0, startIndex).length) +
+                value.substring(startIndex, endIndex + 1) +
+                maskChar.repeat(value.substring(endIndex + 1).length)
+            );
+        }
+
+        return value;
+    };
+
+    const determineStartAndEndIndex = (index0: number, index1: number) => {
+        return index0 < index1
+            ? { startIndex: index0, endIndex: index1 }
+            : { startIndex: index1, endIndex: index0 };
     };
 }

--- a/src/util/string-helper.ts
+++ b/src/util/string-helper.ts
@@ -1,5 +1,17 @@
-import { MaskAttributeProps } from "../masked-input";
+// =============================================================================
+// TYPINGS
+// =============================================================================
+interface MaskValueOptions {
+    maskRange?: number[] | undefined;
+    unmaskRange?: number[] | undefined;
+    maskRegex?: RegExp | undefined;
+    maskTransformer?: ((value: string) => string) | undefined;
+    maskChar?: string | undefined;
+}
 
+// =============================================================================
+// EXPORTS
+// =============================================================================
 export namespace StringHelper {
     export const transformWithSpaces = (
         value: string | any,
@@ -108,7 +120,7 @@ export namespace StringHelper {
         return metrics.width;
     };
 
-    export const maskValue = (value: string, options?: MaskAttributeProps) => {
+    export const maskValue = (value: string, options?: MaskValueOptions) => {
         if (!value) {
             return value;
         }

--- a/stories/uneditable-section/props-table.tsx
+++ b/stories/uneditable-section/props-table.tsx
@@ -65,6 +65,22 @@ const MAIN_DATA: ApiTableSectionProps[] = [
                 description: "The test identifier for the component",
                 propTypes: ["string"],
             },
+            {
+                name: "onMask",
+                description: "Called when the mask icon is clicked",
+                propTypes: ["(item: UneditableSectionItemProps) => void"],
+            },
+            {
+                name: "onUnmask",
+                description: "Called when the unmask icon is clicked",
+                propTypes: ["(item: UneditableSectionItemProps) => void"],
+            },
+            {
+                name: "onTryAgain",
+                description:
+                    "Called when there is an error state with a Try again? indicator",
+                propTypes: ["(item: UneditableSectionItemProps) => void"],
+            },
         ],
     },
     {
@@ -88,6 +104,56 @@ const MAIN_DATA: ApiTableSectionProps[] = [
                     "The width that the item can span across the entire section",
                 propTypes: [`"half"`, `"full"`],
                 defaultValue: `"full"`,
+            },
+            {
+                name: "id",
+                description: "The unique identifier of the uneditable item",
+                propTypes: [`string`],
+            },
+            {
+                name: "maskRange",
+                description: "The range (start and end index) to mask",
+                propTypes: ["number[]"],
+            },
+            {
+                name: "unmaskRange",
+                description: "The range (start and end index) to NOT mask",
+                propTypes: ["number[]"],
+            },
+            {
+                name: "maskRegex",
+                description:
+                    "The regular expression to be replaced / masked with <maskChar>",
+                propTypes: ["RegExp"],
+            },
+            {
+                name: "maskTransformer",
+                description: "The function to transform the value",
+                propTypes: ["(value) => string"],
+            },
+            {
+                name: "maskChar",
+                description: "The character to mask with",
+                defaultValue: "•",
+                propTypes: ["string"],
+            },
+            {
+                name: "maskState",
+                description:
+                    "Specifies if value is masked or unmasked. If undefined, no masking or unmasking controls will be rendered.",
+                propTypes: [`"masked"`, `"unmasked"`],
+            },
+            {
+                name: "maskLoadingState",
+                description:
+                    "Specifies the state of the component when there is a loading behaviour from a mask/unmask action. If undefined, the value will be displayed.",
+                propTypes: [`"loading"`, `"fail"`],
+            },
+            {
+                name: "disableMaskUnmask",
+                description:
+                    "If specified, the value will be masked or unmasked but no indicator will be rendered",
+                propTypes: ["boolean"],
             },
         ],
     },
@@ -118,25 +184,25 @@ const SECTION_DATA: ApiTableSectionProps[] = [
 const ITEM_DATA: ApiTableSectionProps[] = [
     {
         attributes: [
-            {
-                name: "label",
-                description: "The label of the uneditable item",
-                propTypes: [`string`],
-                mandatory: true,
-            },
-            {
-                name: "value",
-                description: "The value of the uneditable item",
-                propTypes: [`string`],
-                mandatory: true,
-            },
-            {
-                name: "displayWidth",
-                description:
-                    "The width that the item can span across the entire section",
-                propTypes: [`"half"`, `"full"`],
-                defaultValue: `"full"`,
-            },
+            ...MAIN_DATA[1].attributes,
+            ...[
+                {
+                    name: "onMask",
+                    description: "Called when the mask icon is clicked",
+                    propTypes: ["() => void"],
+                },
+                {
+                    name: "onUnmask",
+                    description: "Called when the unmask icon is clicked",
+                    propTypes: ["() => void"],
+                },
+                {
+                    name: "onTryAgain",
+                    description:
+                        "Called when there is an error state with a Try again? indicator",
+                    propTypes: ["() => void"],
+                },
+            ],
         ],
     },
 ];

--- a/stories/uneditable-section/props-table.tsx
+++ b/stories/uneditable-section/props-table.tsx
@@ -60,10 +60,17 @@ const MAIN_DATA: ApiTableSectionProps[] = [
                 description: "The class selector of the component",
                 propTypes: ["string"],
             },
+
             {
                 name: "data-testid",
                 description: "The test identifier for the component",
                 propTypes: ["string"],
+            },
+            {
+                name: "background",
+                description: "Specifies if a background should be rendered",
+                propTypes: ["boolean"],
+                defaultValue: "true",
             },
             {
                 name: "onMask",

--- a/stories/uneditable-section/uneditable-section.mdx
+++ b/stories/uneditable-section/uneditable-section.mdx
@@ -17,6 +17,32 @@ import { UneditableSection } from "@lifesg/react-design-system/uneditable-sectio
 
 <Canvas of={UneditableSectionStories.Default} />
 
+<Heading3>With masked values</Heading3>
+
+You can render values that are masked, with various customisations. Here is an
+example of the different variations.
+
+<Canvas of={UneditableSectionStories.WithMaskedItems} />
+
+You can also handle the masked or unmasked values on your own. To do so, you will
+need to intercept the `onMask` and `onUnmask` callbacks.
+
+<Canvas of={UneditableSectionStories.ControlledMaskUnmask} />
+
+<Heading3>With loading indicator</Heading3>
+
+In some cases, the mask or unmask action requires an API call or an action that has
+some loading time. The component also supports such instances.
+
+<Canvas of={UneditableSectionStories.MaskUnmaskWithLoading} />
+
+<Heading3>With error display</Heading3>
+
+In the event that there is an error, a display will appear with the ability to
+try again.
+
+<Canvas of={UneditableSectionStories.MaskUnmaskWithError} />
+
 <Heading3>With custom content</Heading3>
 
 You are able to compose custom content on the top and bottom of the details to suit

--- a/stories/uneditable-section/uneditable-section.mdx
+++ b/stories/uneditable-section/uneditable-section.mdx
@@ -17,6 +17,13 @@ import { UneditableSection } from "@lifesg/react-design-system/uneditable-sectio
 
 <Canvas of={UneditableSectionStories.Default} />
 
+<Heading3>With no background</Heading3>
+
+The `UneditableSection` comes default with a grey background. However you have the
+choice to render it transparent as well.
+
+<Canvas of={UneditableSectionStories.NoBackground} />
+
 <Heading3>With masked values</Heading3>
 
 You can render values that are masked, with various customisations. Here is an

--- a/stories/uneditable-section/uneditable-section.stories.tsx
+++ b/stories/uneditable-section/uneditable-section.stories.tsx
@@ -31,6 +31,19 @@ export const Default: StoryObj<Component> = {
     },
 };
 
+export const NoBackground: StoryObj<Component> = {
+    render: () => {
+        return (
+            <UneditableSection
+                title="Your personal information"
+                description="Retrieved on 27 Jun 2023"
+                items={SAMPLE_ITEMS}
+                background={false}
+            />
+        );
+    },
+};
+
 export const WithMaskedItems: StoryObj<Component> = {
     render: () => {
         const ITEMS: UneditableSectionItemProps[] = [

--- a/stories/uneditable-section/uneditable-section.stories.tsx
+++ b/stories/uneditable-section/uneditable-section.stories.tsx
@@ -2,8 +2,13 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Alert } from "src/alert";
 import { Button } from "src/button";
 import { Text } from "src/text";
-import { UneditableSection } from "src/uneditable-section";
+import {
+    UneditableSection,
+    UneditableSectionItemMaskState,
+    UneditableSectionItemProps,
+} from "src/uneditable-section";
 import { SAMPLE_ITEMS } from "./doc-elements";
+import { useState } from "react";
 
 type Component = typeof UneditableSection;
 
@@ -21,6 +26,198 @@ export const Default: StoryObj<Component> = {
                 title="Your personal information"
                 description="Retrieved on 27 Jun 2023"
                 items={SAMPLE_ITEMS}
+            />
+        );
+    },
+};
+
+export const WithMaskedItems: StoryObj<Component> = {
+    render: () => {
+        const ITEMS: UneditableSectionItemProps[] = [
+            {
+                label: "Plain value",
+                value: "S1234567D",
+                displayWidth: "half",
+            },
+            {
+                label: "With mask range",
+                value: "S1234567D",
+                maskRange: [1, 4],
+                maskState: "masked",
+                displayWidth: "half",
+            },
+            {
+                label: "With unmask range",
+                value: "S1234567D",
+                unmaskRange: [1, 4],
+                maskState: "masked",
+                displayWidth: "half",
+            },
+            {
+                label: "With mask regex",
+                value: "S1234567D",
+                maskRegex: /\D/g,
+                maskState: "masked",
+                displayWidth: "half",
+            },
+            {
+                label: "With mask transformer",
+                value: "S1234567D",
+                maskTransformer: (value) => value.replace(/\D/g, "*"),
+                maskState: "masked",
+                displayWidth: "half",
+            },
+            {
+                label: "With mask range but disabled unmasking",
+                value: "S1234567D",
+                maskRange: [1, 4],
+                maskState: "masked",
+                displayWidth: "half",
+                disableMaskUnmask: true,
+            },
+        ];
+
+        return (
+            <UneditableSection
+                title="Your personal information"
+                description="Retrieved on 27 Jun 2023"
+                items={ITEMS}
+            />
+        );
+    },
+};
+
+export const ControlledMaskUnmask: StoryObj<Component> = {
+    render: () => {
+        const [item, setItem] = useState<UneditableSectionItemProps>({
+            id: "item1",
+            label: "This has controlled masking/unmasking of values",
+            value: "S1••••67D",
+            maskState: "masked",
+        });
+
+        const handleItemUnmask = (_item: UneditableSectionItemProps) => {
+            setItem((current) => {
+                return {
+                    ...current,
+                    value: "S1234567D",
+                };
+            });
+        };
+
+        const handleItemMask = (_item: UneditableSectionItemProps) => {
+            setItem((current) => {
+                return {
+                    ...current,
+                    value: "S1••••67D",
+                };
+            });
+        };
+
+        return (
+            <UneditableSection
+                title="Your personal information"
+                items={[item]}
+                onMask={handleItemMask}
+                onUnmask={handleItemUnmask}
+            />
+        );
+    },
+};
+
+export const MaskUnmaskWithLoading: StoryObj<Component> = {
+    render: () => {
+        const [item, setItem] = useState<UneditableSectionItemProps>({
+            id: "item1",
+            label: "This has a loading display when unmasking",
+            value: "S1••••67D",
+            maskState: "masked",
+        });
+
+        const handleItemUnmask = (_item: UneditableSectionItemProps) => {
+            setItem((current) => {
+                return {
+                    ...current,
+                    maskLoadingState: "loading",
+                };
+            });
+
+            // This is mocking an api call made
+            setTimeout(() => {
+                setItem((current) => {
+                    return {
+                        ...current,
+                        value: "S1234567D",
+                        maskLoadingState: undefined, // or don't even specify the property
+                    };
+                });
+            }, 2000);
+        };
+
+        const handleItemMask = (_item: UneditableSectionItemProps) => {
+            setItem((current) => {
+                return {
+                    ...current,
+                    value: "S1••••67D",
+                };
+            });
+        };
+
+        return (
+            <UneditableSection
+                title="Your personal information"
+                items={[item]}
+                onMask={handleItemMask}
+                onUnmask={handleItemUnmask}
+            />
+        );
+    },
+};
+
+export const MaskUnmaskWithError: StoryObj<Component> = {
+    render: () => {
+        const [item, setItem] = useState<UneditableSectionItemProps>({
+            id: "item1",
+            label: "This has an error display when unmasking",
+            value: "S1••••67D",
+            maskState: "masked",
+        });
+
+        const handleItemUnmask = (_item: UneditableSectionItemProps) => {
+            setItem((current) => {
+                return {
+                    ...current,
+                    maskLoadingState: "loading",
+                };
+            });
+
+            // This is mocking an api call made
+            setTimeout(() => {
+                setItem((current) => {
+                    return {
+                        ...current,
+                        maskLoadingState: "fail",
+                    };
+                });
+            }, 2000);
+        };
+
+        const handleItemMask = (_item: UneditableSectionItemProps) => {
+            setItem((current) => {
+                return {
+                    ...current,
+                    value: "S1••••67D",
+                };
+            });
+        };
+
+        return (
+            <UneditableSection
+                title="Your personal information"
+                items={[item]}
+                onMask={handleItemMask}
+                onUnmask={handleItemUnmask}
+                onTryAgain={handleItemUnmask}
             />
         );
     },

--- a/tests/uneditable-section/uneditable-section.spec.tsx
+++ b/tests/uneditable-section/uneditable-section.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import {
     UneditableSection,
     UneditableSectionItemProps,
@@ -47,6 +47,169 @@ describe("UneditableSection", () => {
 
         expect(screen.getByTestId("test")).toBeInTheDocument();
         expect(screen.queryByText("Test")).not.toBeInTheDocument();
+    });
+
+    describe("Masked items", () => {
+        it("should render the value label as a clickable", () => {
+            const ITEMS: UneditableSectionItemProps[] = [
+                {
+                    label: "NRIC or FIN",
+                    value: "S••••534J",
+                    maskState: "masked",
+                },
+            ];
+
+            render(<UneditableSection items={ITEMS} title="Test" />);
+
+            expect(screen.getByTestId("clickable-label")).toBeInTheDocument();
+        });
+
+        it("should NOT render the value label as a clickable if there is no masking", () => {
+            const ITEMS: UneditableSectionItemProps[] = [
+                {
+                    label: "NRIC or FIN",
+                    value: "S••••534J",
+                },
+            ];
+
+            render(<UneditableSection items={ITEMS} title="Test" />);
+
+            expect(screen.getByText("S••••534J")).toBeInTheDocument();
+            expect(
+                screen.queryByTestId("clickable-label")
+            ).not.toBeInTheDocument();
+        });
+
+        it("should render the masked indicator", () => {
+            const ITEMS: UneditableSectionItemProps[] = [
+                {
+                    label: "NRIC or FIN",
+                    value: "S••••534J",
+                    maskState: "masked",
+                },
+            ];
+
+            render(<UneditableSection items={ITEMS} title="Test" />);
+
+            expect(screen.getByTestId("masked-icon")).toBeInTheDocument();
+        });
+
+        it("should render the unmasked indicator", () => {
+            const ITEMS: UneditableSectionItemProps[] = [
+                {
+                    label: "NRIC or FIN",
+                    value: "S••••534J",
+                    maskState: "unmasked",
+                },
+            ];
+
+            render(<UneditableSection items={ITEMS} title="Test" />);
+
+            expect(screen.getByTestId("unmasked-icon")).toBeInTheDocument();
+        });
+
+        it("should NOT render the masked indicator if disableMaskUnmask is specified", () => {
+            const ITEMS: UneditableSectionItemProps[] = [
+                {
+                    label: "NRIC or FIN",
+                    value: "S••••534J",
+                    maskState: "masked",
+                    disableMaskUnmask: true,
+                },
+            ];
+
+            render(<UneditableSection items={ITEMS} title="Test" />);
+
+            expect(screen.queryByTestId("masked-icon")).not.toBeInTheDocument();
+        });
+
+        it("should render the loading display", () => {
+            const ITEMS: UneditableSectionItemProps[] = [
+                {
+                    label: "NRIC or FIN",
+                    value: "S••••534J",
+                    maskState: "masked",
+                    maskLoadingState: "loading",
+                },
+            ];
+
+            render(<UneditableSection items={ITEMS} title="Test" />);
+
+            expect(screen.getByText("Retrieving...")).toBeInTheDocument();
+        });
+
+        it("should render the error display", () => {
+            const ITEMS: UneditableSectionItemProps[] = [
+                {
+                    label: "NRIC or FIN",
+                    value: "S••••534J",
+                    maskState: "masked",
+                    maskLoadingState: "fail",
+                },
+            ];
+
+            render(<UneditableSection items={ITEMS} title="Test" />);
+
+            expect(screen.getByText("Error")).toBeInTheDocument();
+            expect(screen.getByText("Try again?")).toBeInTheDocument();
+        });
+
+        it("should fire the onUnmask and onMask callbacks if specified", () => {
+            const ITEMS: UneditableSectionItemProps[] = [
+                {
+                    label: "NRIC or FIN",
+                    value: "S••••534J",
+                    maskState: "masked",
+                },
+            ];
+            const onUnmaskFn = jest.fn();
+            const onMaskFn = jest.fn();
+
+            render(
+                <UneditableSection
+                    items={ITEMS}
+                    title="Test"
+                    onUnmask={onUnmaskFn}
+                    onMask={onMaskFn}
+                />
+            );
+
+            act(() => {
+                fireEvent.click(screen.getByTestId("clickable-label"));
+                expect(onUnmaskFn).toHaveBeenCalledWith(ITEMS[0]);
+            });
+
+            act(() => {
+                fireEvent.click(screen.getByTestId("clickable-label"));
+                expect(onMaskFn).toHaveBeenCalledWith(ITEMS[0]);
+            });
+        });
+
+        it("should fire the onTryAgain callback if specified", () => {
+            const ITEMS: UneditableSectionItemProps[] = [
+                {
+                    label: "NRIC or FIN",
+                    value: "S••••534J",
+                    maskState: "masked",
+                    maskLoadingState: "fail",
+                },
+            ];
+
+            const onTryAgainFn = jest.fn();
+
+            render(
+                <UneditableSection
+                    items={ITEMS}
+                    title="Test"
+                    onTryAgain={onTryAgainFn}
+                />
+            );
+
+            act(() => {
+                fireEvent.click(screen.getByTestId("clickable-label"));
+                expect(onTryAgainFn).toHaveBeenCalledWith(ITEMS[0]);
+            });
+        });
     });
 });
 // =============================================================================

--- a/tests/uneditable-section/uneditable-section.spec.tsx
+++ b/tests/uneditable-section/uneditable-section.spec.tsx
@@ -176,13 +176,13 @@ describe("UneditableSection", () => {
 
             act(() => {
                 fireEvent.click(screen.getByTestId("clickable-label"));
-                expect(onUnmaskFn).toHaveBeenCalledWith(ITEMS[0]);
             });
+            expect(onUnmaskFn).toHaveBeenCalledWith(ITEMS[0]);
 
             act(() => {
                 fireEvent.click(screen.getByTestId("clickable-label"));
-                expect(onMaskFn).toHaveBeenCalledWith(ITEMS[0]);
             });
+            expect(onMaskFn).toHaveBeenCalledWith(ITEMS[0]);
         });
 
         it("should fire the onTryAgain callback if specified", () => {
@@ -207,8 +207,8 @@ describe("UneditableSection", () => {
 
             act(() => {
                 fireEvent.click(screen.getByTestId("clickable-label"));
-                expect(onTryAgainFn).toHaveBeenCalledWith(ITEMS[0]);
             });
+            expect(onTryAgainFn).toHaveBeenCalledWith(ITEMS[0]);
         });
     });
 });

--- a/tests/utils/string-helper.spec.ts
+++ b/tests/utils/string-helper.spec.ts
@@ -147,4 +147,63 @@ describe("StringHelper", () => {
             ).toEqual("123456789");
         });
     });
+
+    describe("maskValue", () => {
+        it("should mask the value basked on the mask range and mask char", () => {
+            const testString = "S1234567D";
+            const options = {
+                maskRange: [2, 5],
+                maskChar: "•",
+            };
+
+            expect(StringHelper.maskValue(testString, options)).toEqual(
+                "S1••••67D"
+            );
+        });
+
+        it("should mask the value basked on the mask range", () => {
+            const testString = "S1234567D";
+            const options = {
+                maskRange: [2, 5],
+                maskChar: "-",
+            };
+
+            expect(StringHelper.maskValue(testString, options)).toEqual(
+                "S1----67D"
+            );
+        });
+
+        it("should mask the value basked on the unmask range", () => {
+            const testString = "S1234567D";
+            const options = {
+                unmaskRange: [1, 4],
+            };
+
+            expect(StringHelper.maskValue(testString, options)).toEqual(
+                "•1234••••"
+            );
+        });
+
+        it("should render the correct masked value based on the mask transformer", () => {
+            const testString = "S1234567D";
+            const options = {
+                maskTransformer: (value) => value.replace(/\D/g, "*"),
+            };
+
+            expect(StringHelper.maskValue(testString, options)).toEqual(
+                "*1234567*"
+            );
+        });
+
+        it("should render the correct masked value based on the mask regex", () => {
+            const testString = "S1234567D";
+            const options = {
+                maskRegex: /\D/g,
+            };
+
+            expect(StringHelper.maskValue(testString, options)).toEqual(
+                "•1234567•"
+            );
+        });
+    });
 });


### PR DESCRIPTION
**Changes**
- Add mask and unmask features along with the loading and error states
- Extract mask function in `MaskedInput` to `StringHelper` to enable shared usage
- Extract mask attribute props in `MaskedInput` for shared usage
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Implement mask and unmask features for items in the `UneditableSection`

**Additional information**

- You may refer to this [ticket](https://jira.ship.gov.sg/browse/CCUBE-1097)
- [Figma reference](https://www.figma.com/file/GpnybGCMIH5YNs1Of3a6d8/ECDA-Subsidy-Application?type=design&node-id=4731-97442&mode=design&t=U9cCc6yBkVpMcqoZ-4)
