### PR TITLE
Remove stacking context in toggle

### DIFF
--- a/src/toggle/toggle.styles.tsx
+++ b/src/toggle/toggle.styles.tsx
@@ -32,7 +32,6 @@ export const Container = styled.div<ContainerStyleProps>`
     border-style: solid;
     cursor: ${(props) => (props.$disabled ? "not-allowed" : "pointer")};
     padding: 0.6875rem 1rem;
-    isolation: isolate;
 
     // Content positioning style
     ${(props) => {


### PR DESCRIPTION
**Changes**
Remove isolation style to avoid creating a stacking context in the toggle

It was causing components such as dropdowns within the sublabel to get rendered behind other toggles (see the screenshot example below)

![Screenshot 2024-03-15 at 9 27 53 AM](https://github.com/LifeSG/react-design-system/assets/16853062/e40f05e5-7ae3-470f-a5de-a3414eb1c5e3)


- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Remove stacking context in `Toggle`
