### PR TITLE
Remove z-index from progress indicator

### DIFF
--- a/src/progress-indicator/progress-indicator.style.tsx
+++ b/src/progress-indicator/progress-indicator.style.tsx
@@ -20,7 +20,6 @@ interface IndicatorProps {
 export const Wrapper = styled.div`
     position: relative;
     width: 100%;
-    z-index: 1;
 
     margin: 2rem 0;
 


### PR DESCRIPTION
**Changes**
Quick fix for a z-index conflict with PopoverV2

ProgressIndicator no longer has the fade effect so the z-index is not needed

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**
Style fixes
- Remove z-index from `ProgressIndicator`