### PR TITLE
Optional zIndex for popover, label addon

### DIFF
--- a/src/form/form-label-addon.tsx
+++ b/src/form/form-label-addon.tsx
@@ -21,7 +21,7 @@ export const PopoverAddon = ({
     // =========================================================================
     // CONST, STATE, REF
     // =========================================================================
-    const { content, type, icon, id, "data-testid": testId } = addon;
+    const { content, type, icon, id, zIndex, "data-testid": testId } = addon;
 
     // =========================================================================
     // RENDER FUNCTION
@@ -41,6 +41,7 @@ export const PopoverAddon = ({
             data-testid={testId}
             popoverContent={content}
             rootNode={rootNode}
+            zIndex={zIndex}
         >
             <AddonWrapper>
                 <TriggerArea>{renderIcon()}</TriggerArea>

--- a/src/form/types.ts
+++ b/src/form/types.ts
@@ -32,6 +32,7 @@ export interface FormLabelAddonProps {
     type?: FormLabelAddonType | undefined;
     icon?: JSX.Element | undefined;
     id?: string | undefined;
+    zIndex?: number | undefined;
     "data-testid"?: string | undefined;
 }
 

--- a/src/popover-v2/popover-trigger.tsx
+++ b/src/popover-v2/popover-trigger.tsx
@@ -19,6 +19,7 @@ export const PopoverTrigger = ({
     popoverContent,
     trigger = "click",
     position = "top",
+    zIndex,
     rootNode,
     onPopoverAppear,
     onPopoverDismiss,
@@ -117,7 +118,10 @@ export const PopoverTrigger = ({
         <>
             {visible && (
                 <FloatingPortal root={rootNode}>
-                    <div ref={refs.setFloating} style={{ ...floatingStyles }}>
+                    <div
+                        ref={refs.setFloating}
+                        style={{ ...floatingStyles, zIndex }}
+                    >
                         {renderPopover()}
                     </div>
                 </FloatingPortal>

--- a/src/popover-v2/types.ts
+++ b/src/popover-v2/types.ts
@@ -23,6 +23,7 @@ export interface PopoverV2TriggerProps {
     trigger?: PopoverV2TriggerType | undefined;
     position?: PopoverV2Position | undefined;
     id?: string | undefined;
+    zIndex?: number | undefined;
     className?: string | undefined;
     "data-testid"?: string | undefined;
     /**

--- a/stories/form/form-label/props-table.tsx
+++ b/stories/form/form-label/props-table.tsx
@@ -69,6 +69,11 @@ export const FORM_LABEL_ADDON_PROPS_DATA: ApiTableSectionProps = {
             propTypes: ["string"],
         },
         {
+            name: "zIndex",
+            description: "The custom z-index of the popover addon",
+            propTypes: ["number"],
+        },
+        {
             name: "data-testid",
             description: "The test identifier of the addon",
             propTypes: ["string"],

--- a/stories/popover-v2/props-table.tsx
+++ b/stories/popover-v2/props-table.tsx
@@ -78,7 +78,12 @@ const POPOVER_TRIGGER_DATA: ApiTableSectionProps[] = [
             },
             {
                 name: "zIndex",
-                description: "The custom z-index of the popover",
+                description: (
+                    <>
+                        The custom z-index of the <code>Popover</code>. Try
+                        specifying this if you encounter z-index conflicts.
+                    </>
+                ),
                 propTypes: ["number"],
             },
             {
@@ -86,7 +91,7 @@ const POPOVER_TRIGGER_DATA: ApiTableSectionProps[] = [
                 description: (
                     <>
                         The root element that hosts the popover element. Try
-                        specifying this if you encounter z-index conflicts.
+                        specifying this if <code>zIndex</code> does not work.
                         <br />
                         <br />
                         For example, if the parent of the trigger element has a

--- a/stories/popover-v2/props-table.tsx
+++ b/stories/popover-v2/props-table.tsx
@@ -77,6 +77,11 @@ const POPOVER_TRIGGER_DATA: ApiTableSectionProps[] = [
                 defaultValue: `"top"`,
             },
             {
+                name: "zIndex",
+                description: "The custom z-index of the popover",
+                propTypes: ["number"],
+            },
+            {
                 name: "rootNode",
                 description: (
                     <>


### PR DESCRIPTION
**Changes**
Adding optional zIndex prop to popover trigger, label addon to control rendering order in some edge cases.

- [delete] branch

**Changelog entry**

- Added optional zIndex to `PopoverTrigger` and `PopoverAddon` on FormLabel addon

**Additional information**

- Relevant tickets: [MOL-15296](https://jira.ship.gov.sg/browse/MOL-15296) and [MOL-15245](https://jira.ship.gov.sg/browse/MOL-15245)
- In some situations just setting the rootNode is not sufficient, and more control over the rendering order is needed.
- Related to #435 
