### PR TITLE
[RBS-1245][FY] return options without subItems that match search term in NestedSelected component

### DIFF
--- a/src/shared/nested-dropdown-list/nested-dropdown-list.tsx
+++ b/src/shared/nested-dropdown-list/nested-dropdown-list.tsx
@@ -400,6 +400,8 @@ export const NestedDropdownList = <V1, V2, V3>({
             if (result && result.subItems && result.subItems.size) {
                 list.set(key, result);
             }
+            // if a result is a matching searchTerm with no subItems
+            else if (result && result.isSearchTerm) list.set(key, result);
         }
 
         return list;


### PR DESCRIPTION


**Changes**
currently nested select component doesnt return a option (on the first layer) if there is a match
added an extra condition to check if `result.isSearchTerm == true` 

- [delete] branch

**Changelog entry**
- return options without subItems that match search term in `Form.NestedSelected`


