### PR TITLE
Bump v2.5.0-canary.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lifesg/react-design-system",
-    "version": "2.5.0-canary.1",
+    "version": "2.5.0-canary.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@lifesg/react-design-system",
-            "version": "2.5.0-canary.1",
+            "version": "2.5.0-canary.2",
             "license": "ISC",
             "dependencies": {
                 "@floating-ui/dom": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lifesg/react-design-system",
-    "version": "2.5.0-canary.1",
+    "version": "2.5.0-canary.2",
     "description": "A component design system for LifeSG web apps",
     "main": "dist/cjs/index.js",
     "module": "dist/index.js",


### PR DESCRIPTION
- Bump v2.5.0-canary.2
- Schedule to release on 12 April 2024
