### PR TITLE
[MISC][KE] Fixed self hosted image not able to zoom

### DIFF
--- a/src/fullscreen-image-carousel/stateful-image.tsx
+++ b/src/fullscreen-image-carousel/stateful-image.tsx
@@ -45,7 +45,7 @@ export const StatefulImage = ({
         img.onload = () => {
             !!retrieveImageDimension &&
                 setDimension({
-                    src: img.src,
+                    src,
                     width: img.width,
                     height: img.height,
                 });


### PR DESCRIPTION
**Changes**
For self hosted image normally specified without domain name, however after the image onload, `img.src` contains domain name causes discrepancy in the state key.

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**
Fixed self hosted image not able to zoom


