### PR TITLE
Add Alert to UneditableSection item

### DIFF
--- a/src/uneditable-section/section-item.styles.tsx
+++ b/src/uneditable-section/section-item.styles.tsx
@@ -5,6 +5,7 @@ import { MediaQuery } from "../media";
 import { ComponentLoadingSpinner } from "../shared/component-loading-spinner/component-loading-spinner";
 import { TextStyleHelper } from "../text";
 import { UneditableSectionItemDisplayWidth } from "./types";
+import { Alert } from "../alert";
 
 // =============================================================================
 // STYLING INTERFACES
@@ -109,4 +110,8 @@ export const TryAgainLabel = styled.span`
     color: ${Color.Primary};
     text-decoration: underline;
     margin-left: 0.5rem;
+`;
+
+export const StyledAlert = styled(Alert)`
+    margin-top: 0.5rem;
 `;

--- a/src/uneditable-section/section-item.tsx
+++ b/src/uneditable-section/section-item.tsx
@@ -160,7 +160,7 @@ export const UneditableSectionItem = ({
         <Container $widthStyle={displayWidth}>
             <FormLabel>{label}</FormLabel>
             {renderContent()}
-            {alert && <StyledAlert {...alert} />}
+            {alert && <StyledAlert sizeType="small" {...alert} />}
         </Container>
     );
 };

--- a/src/uneditable-section/section-item.tsx
+++ b/src/uneditable-section/section-item.tsx
@@ -1,9 +1,9 @@
 import { EyeIcon } from "@lifesg/react-icons/eye";
 import { EyeSlashIcon } from "@lifesg/react-icons/eye-slash";
-import {
-    UneditableSectionItemMaskState,
-    UneditableSectionItemProps,
-} from "./types";
+import { useEffect, useState } from "react";
+import { FormLabel } from "../form/form-label";
+import { Text } from "../text";
+import { StringHelper } from "../util/string-helper";
 import {
     Clickable,
     Container,
@@ -12,12 +12,13 @@ import {
     IconContainer,
     LoadingLabel,
     Spinner,
+    StyledAlert,
     TryAgainLabel,
 } from "./section-item.styles";
-import { FormLabel } from "../form/form-label";
-import { Text } from "../text";
-import { StringHelper } from "../util/string-helper";
-import { useEffect, useState } from "react";
+import {
+    UneditableSectionItemMaskState,
+    UneditableSectionItemProps,
+} from "./types";
 
 export interface UneditableSectionItemComponentProps
     extends UneditableSectionItemProps {
@@ -37,6 +38,7 @@ export const UneditableSectionItem = ({
     unmaskRange,
     maskRegex,
     disableMaskUnmask,
+    alert,
     maskTransformer,
     onMask,
     onUnmask,
@@ -158,6 +160,7 @@ export const UneditableSectionItem = ({
         <Container $widthStyle={displayWidth}>
             <FormLabel>{label}</FormLabel>
             {renderContent()}
+            {alert && <StyledAlert {...alert} />}
         </Container>
     );
 };

--- a/src/uneditable-section/types.ts
+++ b/src/uneditable-section/types.ts
@@ -1,3 +1,4 @@
+import { AlertProps } from "../alert";
 import { MaskAttributeProps } from "../masked-input";
 
 export type UneditableSectionItemDisplayWidth = "half" | "full";
@@ -27,6 +28,7 @@ export interface UneditableSectionItemProps extends MaskAttributeProps {
     maskLoadingState?: UneditableSectionItemMaskLoadingState | undefined;
     /** If specified, one is unable to mask or unmask the value */
     disableMaskUnmask?: boolean | undefined;
+    alert?: AlertProps | undefined;
 }
 
 export interface UneditableSectionProps {

--- a/src/uneditable-section/types.ts
+++ b/src/uneditable-section/types.ts
@@ -28,6 +28,7 @@ export interface UneditableSectionItemProps extends MaskAttributeProps {
     maskLoadingState?: UneditableSectionItemMaskLoadingState | undefined;
     /** If specified, one is unable to mask or unmask the value */
     disableMaskUnmask?: boolean | undefined;
+    /** If specified, an Alert will be rendered below the item */
     alert?: AlertProps | undefined;
 }
 

--- a/stories/uneditable-section/props-table.tsx
+++ b/stories/uneditable-section/props-table.tsx
@@ -73,24 +73,6 @@ const MAIN_DATA: ApiTableSectionProps[] = [
                 defaultValue: "true",
             },
             {
-                name: "alert",
-                description: (
-                    <>
-                        Specifies if an {code("Alert")} should be rendered under
-                        the section item
-                    </>
-                ),
-                propTypes: (
-                    <a
-                        href="https://designsystem.life.gov.sg/react/index.html?path=/docs/modules-alert--docs#component-api"
-                        rel="noreferrer"
-                        target="_blank"
-                    >
-                        AlertProps
-                    </a>
-                ),
-            },
-            {
                 name: "onMask",
                 description: "Called when the mask icon is clicked",
                 propTypes: ["(item: UneditableSectionItemProps) => void"],
@@ -179,6 +161,24 @@ const MAIN_DATA: ApiTableSectionProps[] = [
                 description:
                     "If specified, the value will be masked or unmasked but no indicator will be rendered",
                 propTypes: ["boolean"],
+            },
+            {
+                name: "alert",
+                description: (
+                    <>
+                        Specifies if an {code("Alert")} should be rendered under
+                        the section item
+                    </>
+                ),
+                propTypes: (
+                    <a
+                        href="https://designsystem.life.gov.sg/react/index.html?path=/docs/modules-alert--docs#component-api"
+                        rel="noreferrer"
+                        target="_blank"
+                    >
+                        AlertProps
+                    </a>
+                ),
             },
         ],
     },

--- a/stories/uneditable-section/props-table.tsx
+++ b/stories/uneditable-section/props-table.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ApiTable } from "../storybook-common/api-table";
+import { ApiTable, code } from "../storybook-common/api-table";
 import { ApiTableSectionProps } from "../storybook-common/api-table/types";
 import { TabAttribute, Tabs } from "../storybook-common/tabs";
 
@@ -71,6 +71,24 @@ const MAIN_DATA: ApiTableSectionProps[] = [
                 description: "Specifies if a background should be rendered",
                 propTypes: ["boolean"],
                 defaultValue: "true",
+            },
+            {
+                name: "alert",
+                description: (
+                    <>
+                        Specifies if an {code("Alert")} should be rendered under
+                        the section item
+                    </>
+                ),
+                propTypes: (
+                    <a
+                        href="https://designsystem.life.gov.sg/react/index.html?path=/docs/modules-alert--docs#component-api"
+                        rel="noreferrer"
+                        target="_blank"
+                    >
+                        AlertProps
+                    </a>
+                ),
             },
             {
                 name: "onMask",

--- a/stories/uneditable-section/uneditable-section.mdx
+++ b/stories/uneditable-section/uneditable-section.mdx
@@ -50,6 +50,11 @@ try again.
 
 <Canvas of={UneditableSectionStories.MaskUnmaskWithError} />
 
+<Heading3>With alert display</Heading3>
+
+Sometimes you might have some extra information which you would like to inform users of.
+As such you can make use of the `Alert` to render those information.
+
 <Canvas of={UneditableSectionStories.MaskUnmaskWithAlert} />
 
 <Heading3>With custom content</Heading3>

--- a/stories/uneditable-section/uneditable-section.mdx
+++ b/stories/uneditable-section/uneditable-section.mdx
@@ -50,6 +50,8 @@ try again.
 
 <Canvas of={UneditableSectionStories.MaskUnmaskWithError} />
 
+<Canvas of={UneditableSectionStories.MaskUnmaskWithAlert} />
+
 <Heading3>With custom content</Heading3>
 
 You are able to compose custom content on the top and bottom of the details to suit

--- a/stories/uneditable-section/uneditable-section.stories.tsx
+++ b/stories/uneditable-section/uneditable-section.stories.tsx
@@ -238,22 +238,24 @@ export const MaskUnmaskWithError: StoryObj<Component> = {
 
 export const MaskUnmaskWithAlert: StoryObj<Component> = {
     render: () => {
-        const [item, setItem] = useState<UneditableSectionItemProps>({
-            id: "item1",
-            label: "This has an error display when unmasking",
-            value: "S1••••67D",
-            maskState: "masked",
-            maskLoadingState: "fail",
-            alert: {
-                type: "warning",
-                children: "This is an alert message",
+        const ITEMS: UneditableSectionItemProps[] = [
+            {
+                id: "item1",
+                label: "This has an error display when unmasking",
+                value: "S1••••67D",
+                maskState: "masked",
+                maskLoadingState: "fail",
+                alert: {
+                    type: "warning",
+                    children: "This is an alert message",
+                },
             },
-        });
+        ];
 
         return (
             <UneditableSection
                 title="Your personal information"
-                items={[item]}
+                items={ITEMS}
             />
         );
     },

--- a/stories/uneditable-section/uneditable-section.stories.tsx
+++ b/stories/uneditable-section/uneditable-section.stories.tsx
@@ -236,6 +236,29 @@ export const MaskUnmaskWithError: StoryObj<Component> = {
     },
 };
 
+export const MaskUnmaskWithAlert: StoryObj<Component> = {
+    render: () => {
+        const [item, setItem] = useState<UneditableSectionItemProps>({
+            id: "item1",
+            label: "This has an error display when unmasking",
+            value: "S1••••67D",
+            maskState: "masked",
+            maskLoadingState: "fail",
+            alert: {
+                type: "warning",
+                children: "This is an alert message",
+            },
+        });
+
+        return (
+            <UneditableSection
+                title="Your personal information"
+                items={[item]}
+            />
+        );
+    },
+};
+
 export const WithCustomContent: StoryObj<Component> = {
     render: () => {
         return (

--- a/tests/uneditable-section/uneditable-section.spec.tsx
+++ b/tests/uneditable-section/uneditable-section.spec.tsx
@@ -211,6 +211,24 @@ describe("UneditableSection", () => {
             expect(onTryAgainFn).toHaveBeenCalledWith(ITEMS[0]);
         });
     });
+
+    describe("With alert", () => {
+        it("should render the Alert in the section item if specified", () => {
+            const ITEMS: UneditableSectionItemProps[] = [
+                {
+                    label: "NRIC or FIN",
+                    value: "S••••534J",
+                    alert: {
+                        type: "warning",
+                        children: "This is an alert",
+                    },
+                },
+            ];
+
+            render(<UneditableSection items={ITEMS} title="Test" />);
+            expect(screen.getByText("This is an alert")).toBeInTheDocument();
+        });
+    });
 });
 // =============================================================================
 // MOCKS


### PR DESCRIPTION
**Changes**
- To add ability to render an `Alert` in an `UneditableSection` item

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Add ability to render an `Alert` in an `UneditableSection` item

**Additional information**

- You may refer to this [ticket](https://jira.ship.gov.sg/browse/CCUBE-1232)
- [Figma mockup](https://figma.fun/d3ALxc)
