### PR TITLE
Remove possible cause of infinite rerenders in `DateInput`

### DIFF
--- a/src/date-input/date-input.tsx
+++ b/src/date-input/date-input.tsx
@@ -1,10 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { ElementWithDropdown } from "../shared/dropdown-wrapper";
-import {
-    CalendarAction,
-    CalendarDropdown,
-    InternalCalendarRef,
-} from "../shared/internal-calendar";
+import { CalendarAction, CalendarDropdown } from "../shared/internal-calendar";
 import {
     StandaloneDateInput,
     StandaloneDateInputRef,
@@ -45,7 +41,6 @@ export const DateInput = ({
     const [calendarOpen, setCalendarOpen] = useState<boolean>(false);
 
     const nodeRef = useRef<HTMLDivElement>(null);
-    const calendarRef = useRef<InternalCalendarRef>();
     const inputRef = useRef<StandaloneDateInputRef>();
 
     // =============================================================================
@@ -174,7 +169,6 @@ export const DateInput = ({
     const renderCalendar = () => {
         return (
             <CalendarDropdown
-                ref={calendarRef}
                 type="input"
                 variant="single"
                 initialCalendarDate={selectedDate}

--- a/src/shared/dropdown-wrapper/element-with-dropdown.tsx
+++ b/src/shared/dropdown-wrapper/element-with-dropdown.tsx
@@ -40,7 +40,6 @@ export const ElementWithDropdown = ({
     // =============================================================================
     // CONST, STATE, REF
     // =============================================================================
-    const elementRef = useRef<HTMLDivElement>(null);
     const floatingRef = useRef<HTMLDivElement>(null);
     const { refs, floatingStyles, context } = useFloating({
         open: isOpen,
@@ -92,13 +91,7 @@ export const ElementWithDropdown = ({
     // =============================================================================
     return (
         <>
-            <div
-                ref={(node) => {
-                    elementRef.current = node;
-                    refs.setReference(node);
-                }}
-                {...getReferenceProps()}
-            >
+            <div ref={refs.setReference} {...getReferenceProps()}>
                 {renderElement()}
             </div>
             {isMounted && (

--- a/src/shared/internal-calendar/calendar-dropdown.tsx
+++ b/src/shared/internal-calendar/calendar-dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useImperativeHandle, useRef } from "react";
+import React from "react";
 import { CalendarWrapper } from "./calendar-dropdown.style";
 import { InternalCalendar } from "./internal-calendar";
 import { InternalCalendarProps, InternalCalendarRef } from "./types";
@@ -7,13 +7,9 @@ const Component = (
     props: InternalCalendarProps,
     ref: React.ForwardedRef<InternalCalendarRef>
 ) => {
-    const calendarRef = useRef<InternalCalendarRef>();
-
-    useImperativeHandle(ref, () => calendarRef.current);
-
     return (
         <CalendarWrapper>
-            <InternalCalendar ref={calendarRef} {...props} />
+            <InternalCalendar ref={ref} {...props} />
         </CalendarWrapper>
     );
 };


### PR DESCRIPTION
**Changes**

- Unmemoised callback might be causing reference ref to be set multiple times
- Simplified to pass floating-ui's callback directly as the ref is unused
- Also clean up unnecessary refs
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Resolve `Maximum update depth` error that is triggered when calendar dropdown in `DateInput` is opened