### PR TITLE
Fix icon shrinking if button content requires more space

### DIFF
--- a/src/button-with-icon/button-with-icon.style.tsx
+++ b/src/button-with-icon/button-with-icon.style.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { Main } from "../button/button.style";
 import { MainStyleProps } from "../button/types";
 import { ButtonIconPosition } from "./types";
@@ -17,4 +17,27 @@ export const MainButtonWithIcon = styled(Main)<MainStylePropsWithIcon>`
     flex-direction: ${(props) =>
         props.$buttonIconPosition === "right" ? "row-reverse" : "row"};
     gap: 0.5rem;
+
+    svg {
+        flex-shrink: 0;
+    }
+
+    ${(props) => {
+        switch (props.$buttonSizeStyle) {
+            case "small":
+                return css`
+                    svg {
+                        height: 1rem;
+                        width: 1rem;
+                    }
+                `;
+            default:
+                return css`
+                    svg {
+                        height: 1.125rem;
+                        width: 1.125rem;
+                    }
+                `;
+        }
+    }}
 `;


### PR DESCRIPTION
**Changes**
- Fix issue where the icon shrinks due to resizing when the content requires more space

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Fix icon shrinking in `ButtonWithIcon` when the label requires more space

**Additional information**

- You may refer to this [ticket](https://jira.ship.gov.sg/browse/CCUBE-1289)
