### PR TITLE
misc: skip rendering of textarea bottom labels if it empty

### DIFF
--- a/src/form/form-textarea.tsx
+++ b/src/form/form-textarea.tsx
@@ -67,6 +67,7 @@ const FormTextareaComponent = (
     // RENDER FUNCTIONS
     // =============================================================================
     const renderBottomLabels = () => {
+        if (!errorMessage && !otherProps.maxLength) return <></>;
         return (
             <LabelContainer>
                 {errorMessage && (


### PR DESCRIPTION
- skip rendering of textarea bottom labels if it empty
- else it is causing a 0.25rem bottom margin
<img width="1395" alt="image" src="https://github.com/LifeSG/react-design-system/assets/60728851/9cc1b123-2450-4b50-b9c2-b2ea5a1910ca">

