### PR TITLE
[MISC][WL] allow more characters in select label before ellipsis

### DIFF
--- a/src/shared/dropdown-wrapper/dropdown-wrapper.styles.tsx
+++ b/src/shared/dropdown-wrapper/dropdown-wrapper.styles.tsx
@@ -168,6 +168,7 @@ export const Divider = styled.div`
 export const LabelContainer = styled.div`
     display: flex;
     flex: 1;
+    word-break: break-all;
 `;
 
 export const ValueLabel = styled(Text.Body)<ValueLabelStyleProps>`


### PR DESCRIPTION
**Changes**
- apply `word-break: break-all` to allow more characters to be rendered in select label before showing ellipsis

**Before**
<img width="532" alt="Screenshot 2024-05-16 at 11 59 15 AM" src="https://github.com/LifeSG/react-design-system/assets/60728851/5459d91e-3be0-4350-908b-49a61c623790">
<img width="513" alt="Screenshot 2024-05-16 at 11 58 59 AM" src="https://github.com/LifeSG/react-design-system/assets/60728851/cc7621bd-c992-4203-8e21-47c7e8ac8c54">

**After**
<img width="521" alt="Screenshot 2024-05-16 at 11 59 27 AM" src="https://github.com/LifeSG/react-design-system/assets/60728851/b2ed325f-90e4-409c-9baf-2daff9c310ac">
<img width="519" alt="Screenshot 2024-05-16 at 11 56 59 AM" src="https://github.com/LifeSG/react-design-system/assets/60728851/257c616b-80ec-4254-a622-fdaf26790792">
