### PR TITLE
Create component to apply default HTML styles for JSX children

### DIFF
--- a/src/alert/alert.style.tsx
+++ b/src/alert/alert.style.tsx
@@ -66,17 +66,12 @@ export const Wrapper = styled.div<StyleProps>`
         `;
     }}
 
+    color: ${Color.Neutral[1]};
     ${(props) => {
         if (props.$sizeType === "small") {
-            return applyHtmlContentStyle({
-                textSize: "H6",
-                textColor: Color.Neutral[1],
-            });
+            return applyHtmlContentStyle({ textSize: "H6" });
         }
-        return applyHtmlContentStyle({
-            textSize: "BodySmall",
-            textColor: Color.Neutral[1],
-        });
+        return applyHtmlContentStyle({ textSize: "BodySmall" });
     }}
 `;
 

--- a/src/alert/alert.style.tsx
+++ b/src/alert/alert.style.tsx
@@ -68,9 +68,15 @@ export const Wrapper = styled.div<StyleProps>`
 
     ${(props) => {
         if (props.$sizeType === "small") {
-            return applyHtmlContentStyle("H6");
+            return applyHtmlContentStyle({
+                textSize: "H6",
+                textColor: Color.Neutral[1],
+            });
         }
-        return applyHtmlContentStyle("BodySmall");
+        return applyHtmlContentStyle({
+            textSize: "BodySmall",
+            textColor: Color.Neutral[1],
+        });
     }}
 `;
 

--- a/src/file-upload/file-upload.styles.tsx
+++ b/src/file-upload/file-upload.styles.tsx
@@ -20,10 +20,8 @@ export const Title = styled(Text.H4)`
 `;
 
 export const TitleContainer = styled.div`
-    ${applyHtmlContentStyle({
-        textSize: "Body",
-        textColor: Color.Neutral[1],
-    })}
+    color: ${Color.Neutral[1]};
+    ${applyHtmlContentStyle({ textSize: "Body" })}
 `;
 
 export const Description = styled(Text.BodySmall)`
@@ -32,10 +30,8 @@ export const Description = styled(Text.BodySmall)`
 `;
 
 export const DescriptionContainer = styled.div`
-    ${applyHtmlContentStyle({
-        textSize: "BodySmall",
-        textColor: Color.Neutral[3],
-    })}
+    color: ${Color.Neutral[3]};
+    ${applyHtmlContentStyle({ textSize: "BodySmall" })}
 `;
 
 export const WarningAlert = styled(Alert)`

--- a/src/file-upload/file-upload.styles.tsx
+++ b/src/file-upload/file-upload.styles.tsx
@@ -20,7 +20,10 @@ export const Title = styled(Text.H4)`
 `;
 
 export const TitleContainer = styled.div`
-    ${applyHtmlContentStyle("Body")}
+    ${applyHtmlContentStyle({
+        textSize: "Body",
+        textColor: Color.Neutral[1],
+    })}
 `;
 
 export const Description = styled(Text.BodySmall)`
@@ -29,7 +32,8 @@ export const Description = styled(Text.BodySmall)`
 `;
 
 export const DescriptionContainer = styled.div`
-    ${applyHtmlContentStyle("BodySmall", {
+    ${applyHtmlContentStyle({
+        textSize: "BodySmall",
         textColor: Color.Neutral[3],
     })}
 `;

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export * from "./input-slider";
 export * from "./input-textarea";
 export * from "./layout";
 export * from "./link-list";
+export * from "./markup";
 export * from "./masked-input";
 export * from "./masonry";
 export * from "./masthead";

--- a/src/markup/index.ts
+++ b/src/markup/index.ts
@@ -1,0 +1,2 @@
+export * from "./markup";
+export * from "./types";

--- a/src/markup/markup.style.tsx
+++ b/src/markup/markup.style.tsx
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+import {
+    HtmlContentStyleOptions,
+    applyHtmlContentStyle,
+} from "../shared/html-content/html-content";
+
+// =============================================================================
+// STYLE INTERFACES
+// =============================================================================
+interface ContainerStyleProps {
+    $options?: HtmlContentStyleOptions | undefined;
+}
+
+// =============================================================================
+// STYLING
+// =============================================================================
+export const Container = styled.div<ContainerStyleProps>`
+    ${(props) => applyHtmlContentStyle(props.$options)}
+`;

--- a/src/markup/markup.style.tsx
+++ b/src/markup/markup.style.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import {
     HtmlContentStyleOptions,
     applyHtmlContentStyle,
@@ -8,12 +8,18 @@ import {
 // STYLE INTERFACES
 // =============================================================================
 interface ContainerStyleProps {
-    $options?: HtmlContentStyleOptions | undefined;
+    $textSize?: HtmlContentStyleOptions["textSize"] | undefined;
+    $textColor?: string | ((props: unknown) => string) | undefined;
 }
 
 // =============================================================================
 // STYLING
 // =============================================================================
 export const Container = styled.div<ContainerStyleProps>`
-    ${(props) => applyHtmlContentStyle(props.$options)}
+    ${(props) => applyHtmlContentStyle({ textSize: props.$textSize })}
+    ${(props) =>
+        props.color &&
+        css`
+            color: ${props.color};
+        `}
 `;

--- a/src/markup/markup.tsx
+++ b/src/markup/markup.tsx
@@ -1,0 +1,24 @@
+import React, { forwardRef } from "react";
+import { Container } from "./markup.style";
+import { MarkupProps } from "./types";
+
+const Component = (props: MarkupProps, ref: React.Ref<HTMLDivElement>) => {
+    // =========================================================================
+    // CONST, STATE, REF
+    // =========================================================================
+    const { baseTextColor, baseTextSize, inline, ...otherProps } = props;
+
+    // =========================================================================
+    // RENDER FUNCTION
+    // =========================================================================
+    return (
+        <Container
+            ref={ref}
+            as={inline ? "span" : "div"}
+            $options={{ textSize: baseTextSize, textColor: baseTextColor }}
+            {...otherProps}
+        />
+    );
+};
+
+export const Markup = forwardRef(Component);

--- a/src/markup/markup.tsx
+++ b/src/markup/markup.tsx
@@ -15,7 +15,8 @@ const Component = (props: MarkupProps, ref: React.Ref<HTMLDivElement>) => {
         <Container
             ref={ref}
             as={inline ? "span" : "div"}
-            $options={{ textSize: baseTextSize, textColor: baseTextColor }}
+            $textSize={baseTextSize}
+            $textColor={baseTextColor}
             {...otherProps}
         />
     );

--- a/src/markup/types.ts
+++ b/src/markup/types.ts
@@ -1,0 +1,13 @@
+import { TextSizeType } from "../text";
+
+export interface MarkupProps extends React.HTMLAttributes<HTMLDivElement> {
+    /** The default font size. If not specified, inherited from the parent */
+    baseTextSize?: TextSizeType | undefined;
+    /** The default font color. If not specified, inherited from the parent */
+    baseTextColor?: string | ((props: unknown) => string) | undefined;
+    /**
+     * Specifies if element is rendered as block element `div` or inline
+     * element `span`
+     */
+    inline?: boolean | undefined;
+}

--- a/src/popover-v2/popover.styles.tsx
+++ b/src/popover-v2/popover.styles.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import { Card } from "../card";
+import { Color } from "../color";
 import { MediaQuery } from "../media";
 import { ModalBox } from "../modal/modal-box";
 import { applyHtmlContentStyle } from "../shared/html-content/html-content";
@@ -14,7 +15,10 @@ export const PopoverContainer = styled.div`
 `;
 
 export const PopoverCard = styled(Card)`
-    ${applyHtmlContentStyle("BodySmall")}
+    ${applyHtmlContentStyle({
+        textSize: "BodySmall",
+        textColor: Color.Neutral[1],
+    })}
 
     ${MediaQuery.MaxWidth.mobileL} {
         display: none;
@@ -32,5 +36,8 @@ export const ContentWrapper = styled.div`
         display: none; /* Chrome/Safari/Webkit */
     }
 
-    ${applyHtmlContentStyle("BodySmall")}
+    ${applyHtmlContentStyle({
+        textSize: "BodySmall",
+        textColor: Color.Neutral[1],
+    })}
 `;

--- a/src/popover-v2/popover.styles.tsx
+++ b/src/popover-v2/popover.styles.tsx
@@ -15,10 +15,8 @@ export const PopoverContainer = styled.div`
 `;
 
 export const PopoverCard = styled(Card)`
-    ${applyHtmlContentStyle({
-        textSize: "BodySmall",
-        textColor: Color.Neutral[1],
-    })}
+    color: ${Color.Neutral[1]};
+    ${applyHtmlContentStyle({ textSize: "BodySmall" })}
 
     ${MediaQuery.MaxWidth.mobileL} {
         display: none;
@@ -36,8 +34,6 @@ export const ContentWrapper = styled.div`
         display: none; /* Chrome/Safari/Webkit */
     }
 
-    ${applyHtmlContentStyle({
-        textSize: "BodySmall",
-        textColor: Color.Neutral[1],
-    })}
+    color: ${Color.Neutral[1]};
+    ${applyHtmlContentStyle({ textSize: "BodySmall" })}
 `;

--- a/src/shared/html-content/html-content.ts
+++ b/src/shared/html-content/html-content.ts
@@ -1,25 +1,27 @@
 import { css } from "styled-components";
 import { Color } from "../../color";
+import { FontFamily } from "../../spec/text-spec/font-spec";
 import { TextLinkSizeType, TextSizeType, TextStyleHelper } from "../../text";
 
-interface HtmlContentStyleOptions {
-    textColor?: string | ((props: any) => string);
+export interface HtmlContentStyleOptions {
+    textSize?: TextSizeType | TextLinkSizeType | undefined;
+    textColor?: string | ((props: any) => string) | undefined;
 }
 
-export const applyHtmlContentStyle = (
-    textStyle: TextSizeType | TextLinkSizeType,
-    options?: HtmlContentStyleOptions
-) => {
-    const { textColor = Color.Neutral[1] } = options || {};
+export const applyHtmlContentStyle = (options?: HtmlContentStyleOptions) => {
+    const { textSize, textColor } = options || {};
 
     return css`
-        // Text
-        ${TextStyleHelper.getTextStyle(textStyle, "regular")}
-        color: ${textColor};
-
-        a,
+        // Text styling
+        ${textSize && TextStyleHelper.getTextStyle(textSize, "regular")}
+        ${textColor &&
+        css`
+            color: ${textColor};
+        `}
+        
         strong {
-            ${TextStyleHelper.getTextStyle(textStyle, "semibold")}
+            font-family: ${FontFamily.OpenSans.Semibold};
+            ${textSize && TextStyleHelper.getTextStyle(textSize, "semibold")}
         }
 
         p {
@@ -28,11 +30,22 @@ export const applyHtmlContentStyle = (
 
         // Link styling
         a {
+            font-family: ${FontFamily.OpenSans.Semibold};
+            ${textSize && TextStyleHelper.getTextStyle(textSize, "semibold")}
             color: ${Color.Primary};
             text-decoration: none;
 
+            svg {
+                color: ${Color.Primary};
+                height: 1rem;
+                width: 1rem;
+                margin-left: 0.4rem;
+                vertical-align: baseline;
+            }
+
             :hover,
             :active,
+            :visited,
             :focus {
                 color: ${Color.Secondary};
 

--- a/src/shared/html-content/html-content.ts
+++ b/src/shared/html-content/html-content.ts
@@ -1,24 +1,19 @@
 import { css } from "styled-components";
 import { Color } from "../../color";
 import { FontFamily } from "../../spec/text-spec/font-spec";
-import { TextLinkSizeType, TextSizeType, TextStyleHelper } from "../../text";
+import { TextSizeType, TextStyleHelper } from "../../text";
 
 export interface HtmlContentStyleOptions {
-    textSize?: TextSizeType | TextLinkSizeType | undefined;
-    textColor?: string | ((props: any) => string) | undefined;
+    textSize?: TextSizeType | undefined;
 }
 
 export const applyHtmlContentStyle = (options?: HtmlContentStyleOptions) => {
-    const { textSize, textColor } = options || {};
+    const { textSize } = options || {};
 
     return css`
         // Text styling
         ${textSize && TextStyleHelper.getTextStyle(textSize, "regular")}
-        ${textColor &&
-        css`
-            color: ${textColor};
-        `}
-        
+
         strong {
             font-family: ${FontFamily.OpenSans.Semibold};
             ${textSize && TextStyleHelper.getTextStyle(textSize, "semibold")}

--- a/stories/markup/markup.mdx
+++ b/stories/markup/markup.mdx
@@ -1,6 +1,7 @@
 import { Canvas, Meta } from "@storybook/blocks";
 import { Secondary, Title } from "../storybook-common";
 import * as MarkupStories from "./markup.stories";
+import { PropsTable } from "./props-table";
 
 <Meta of={MarkupStories} />
 
@@ -15,3 +16,11 @@ import { Markup } from "@lifesg/react-design-system/markup";
 ```
 
 <Canvas of={MarkupStories.Default} />
+
+By default, text will inherit the parent's font style and color.
+
+<Canvas of={MarkupStories.Inheritance} />
+
+<Secondary>Component API</Secondary>
+
+<PropsTable />

--- a/stories/markup/markup.mdx
+++ b/stories/markup/markup.mdx
@@ -1,0 +1,17 @@
+import { Canvas, Meta } from "@storybook/blocks";
+import { Secondary, Title } from "../storybook-common";
+import * as MarkupStories from "./markup.stories";
+
+<Meta of={MarkupStories} />
+
+<Title>Markup</Title>
+
+<Secondary>Overview</Secondary>
+
+A component that sets styling for commonly used markup such as `<strong>` or `<a>`.
+
+```tsx
+import { Markup } from "@lifesg/react-design-system/markup";
+```
+
+<Canvas of={MarkupStories.Default} />

--- a/stories/markup/markup.stories.tsx
+++ b/stories/markup/markup.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Markup } from "src/markup";
+
+type Component = typeof Markup;
+
+const meta: Meta<Component> = {
+    title: "General/Markup",
+    component: Markup,
+};
+
+export default meta;
+
+export const Default: StoryObj<Component> = {
+    render: () => (
+        <Markup>
+            <p>
+                You can use <strong>bold text</strong> to emphasise important
+                information
+            </p>
+            <br />
+            <p>
+                Or add a{" "}
+                <a href="https://life.gov.sg" target="_blank" rel="noreferrer">
+                    hyperlink
+                </a>{" "}
+                to direct users to some external source
+            </p>
+            <br />
+            <p>This also supports bullet points:</p>
+            <ul>
+                <li>List item</li>
+                <li>List item</li>
+                <li>List item</li>
+            </ul>
+            <br />
+            <p>As well as numbered lists:</p>
+            <ol>
+                <li>List item</li>
+                <li>List item</li>
+                <li>List item</li>
+            </ol>
+        </Markup>
+    ),
+};

--- a/stories/markup/markup.stories.tsx
+++ b/stories/markup/markup.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { Color } from "src/color";
 import { Markup } from "src/markup";
 
 type Component = typeof Markup;
@@ -12,7 +13,7 @@ export default meta;
 
 export const Default: StoryObj<Component> = {
     render: () => (
-        <Markup>
+        <Markup baseTextColor={Color.Neutral[1]} baseTextSize="Body">
             <p>
                 You can use <strong>bold text</strong> to emphasise important
                 information
@@ -40,5 +41,16 @@ export const Default: StoryObj<Component> = {
                 <li>List item</li>
             </ol>
         </Markup>
+    ),
+};
+
+export const Inheritance: StoryObj<Component> = {
+    render: () => (
+        <div style={{ color: "red", fontSize: "14px" }}>
+            <Markup>
+                Font style and color are inherited. In particular, this is what{" "}
+                <strong>bolded</strong> and <a>link</a> elements look like
+            </Markup>
+        </div>
     ),
 };

--- a/stories/markup/props-table.tsx
+++ b/stories/markup/props-table.tsx
@@ -1,0 +1,56 @@
+import { ApiTable, code } from "../storybook-common/api-table";
+import { ApiTableSectionProps } from "../storybook-common/api-table/types";
+
+const DATA: ApiTableSectionProps[] = [
+    {
+        attributes: [
+            {
+                name: "",
+                description: (
+                    <>
+                        This component also inherits props from&nbsp;
+                        <a
+                            href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement"
+                            rel="noreferrer"
+                            target="_blank"
+                        >
+                            HTMLDivAttributes
+                        </a>
+                    </>
+                ),
+            },
+            {
+                name: "baseTextSize",
+                description:
+                    "The default font size. If not specified, inherited from the parent",
+                propTypes: (
+                    <a
+                        href="https://designsystem.life.gov.sg/react/index.html?path=/docs/general-text-base-style--docs"
+                        rel="noreferrer"
+                        target="_blank"
+                    >
+                        TextSizeType
+                    </a>
+                ),
+            },
+            {
+                name: "baseTextColor",
+                description:
+                    "The default font color. Supports theming. If not specified, inherited from the parent",
+                propTypes: ["string", "(props: unknown) => string"],
+            },
+            {
+                name: "inline",
+                description: (
+                    <>
+                        Specifies if component is a block {code("<div />")}{" "}
+                        element or inline {code("<span />")} element
+                    </>
+                ),
+                propTypes: ["boolean"],
+            },
+        ],
+    },
+];
+
+export const PropsTable = () => <ApiTable sections={DATA} />;


### PR DESCRIPTION
**Changes**

Styles the common HTML tags `strong`, `a`, `ul`, and `ol`
Useful for components that accept JSX.Element as children

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Introduce `Markup` to apply default styles for HTML markup

**Additional information**

- You may refer to this [CCUBE-1360](https://jira.ship.gov.sg/browse/CCUBE-1360)
