### PR TITLE
Adding action button and ammending typings for title and label for the toast 

### DIFF
--- a/src/toast/toast.styles.tsx
+++ b/src/toast/toast.styles.tsx
@@ -112,8 +112,6 @@ export const Title = styled(Text.H4)<StyleProps>`
 `;
 
 export const Description = styled.div<StyleProps>`
-    display: flex;
-    align-items: center;
     position: relative;
     ${(props) => {
         return css`

--- a/src/toast/toast.styles.tsx
+++ b/src/toast/toast.styles.tsx
@@ -71,24 +71,25 @@ export const ContentWrapper = styled.div`
     flex: 1;
     justify-content: space-between;
 
-    ${MediaQuery.MaxWidth.tablet} {
+    ${MediaQuery.MaxWidth.mobileL} {
         display: flex;
         flex-direction: column;
         gap: 0.75rem;
     }
 `;
 
-export const TextIconWrapper = styled(animated.div)<StyleProps>`
+export const TextIconWrapper = styled.div<StyleProps>`
     display: flex;
     flex-direction: row;
-    align-items: start;
+    align-items: flex-start;
 
     ${(props) => {
         return css`
             & > svg {
                 flex-shrink: 0;
                 width: 1.5rem;
-                height: 1.625rem;
+                height: 1.5rem;
+                margin-top: 0.0625rem;
                 margin-right: 0.5rem;
                 color: ${getValidationColorAttributes(props).Icon};
             }
@@ -112,7 +113,6 @@ export const Title = styled(Text.H4)<StyleProps>`
 `;
 
 export const Description = styled.div<StyleProps>`
-    position: relative;
     ${(props) => {
         return css`
             p {
@@ -123,13 +123,13 @@ export const Description = styled.div<StyleProps>`
 `;
 
 export const ActionButton = styled(Button.Small)`
-    font-weight: 600;
     align-self: center;
-    white-space: nowrap;
+    overflow-wrap: anywhere;
     margin-left: auto;
+    height: auto;
 
     ${MediaQuery.MaxWidth.mobileL} {
-        align-self: start;
+        align-self: flex-start;
         margin-left: 2rem;
     }
 `;

--- a/src/toast/toast.styles.tsx
+++ b/src/toast/toast.styles.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@lifesg/react-design-system";
+import { Button } from "../button";
 import { animated } from "react-spring";
 import { ValidationElementAttributes } from "src/color";
 import { PropertiesToType } from "src/util/utility-types";

--- a/src/toast/toast.styles.tsx
+++ b/src/toast/toast.styles.tsx
@@ -46,12 +46,11 @@ export const Wrapper = styled(animated.div)<StyleProps>`
     right: 0;
     padding: 1rem;
     border-radius: 0.5rem;
-    line-height: 0;
     z-index: 10;
     align-items: center;
     gap: 2rem;
 
-    ${MediaQuery.MaxWidth.mobileL} {
+    ${MediaQuery.MaxWidth.tablet} {
         left: 0;
     }
 
@@ -150,7 +149,6 @@ export const DismissButton = styled(ClickableIcon)<StyleProps>`
             }
             ${MediaQuery.MaxWidth.mobileL} {
                 align-self: center;
-                margin-left: 2rem;
             }
         `;
     }};

--- a/src/toast/toast.styles.tsx
+++ b/src/toast/toast.styles.tsx
@@ -51,7 +51,7 @@ export const Wrapper = styled(animated.div)<StyleProps>`
     align-items: center;
     gap: 2rem;
 
-    ${MediaQuery.MaxWidth.tablet} {
+    ${MediaQuery.MaxWidth.mobileL} {
         left: 0;
     }
 
@@ -113,7 +113,8 @@ export const Title = styled(Text.H4)<StyleProps>`
 
 export const Description = styled.div<StyleProps>`
     display: flex;
-
+    align-items: center;
+    position: relative;
     ${(props) => {
         return css`
             p {
@@ -127,8 +128,9 @@ export const ActionButton = styled(Button.Small)`
     font-weight: 600;
     align-self: center;
     white-space: nowrap;
+    margin-left: auto;
 
-    ${MediaQuery.MaxWidth.tablet} {
+    ${MediaQuery.MaxWidth.mobileL} {
         align-self: start;
         margin-left: 2rem;
     }
@@ -147,6 +149,10 @@ export const DismissButton = styled(ClickableIcon)<StyleProps>`
             }
             :hover {
                 background: transparent;
+            }
+            ${MediaQuery.MaxWidth.mobileL} {
+                align-self: center;
+                margin-left: 2rem;
             }
         `;
     }};

--- a/src/toast/toast.styles.tsx
+++ b/src/toast/toast.styles.tsx
@@ -1,12 +1,13 @@
+import { Button } from "@lifesg/react-design-system";
 import { animated } from "react-spring";
 import { ValidationElementAttributes } from "src/color";
 import { PropertiesToType } from "src/util/utility-types";
 import styled, { css } from "styled-components";
 import { Color } from "../color/color";
+import { MediaQuery } from "../media";
 import { ClickableIcon } from "../shared/clickable-icon";
 import { Text } from "../text";
 import { ToastType } from "./types";
-import { MediaQuery } from "../media";
 
 //=============================================================================
 // STYLE INTERFACE
@@ -38,7 +39,7 @@ const getValidationColorAttributes = (
 // =============================================================================
 export const Wrapper = styled(animated.div)<StyleProps>`
     display: flex;
-
+    flex-direction: row;
     position: ${(props) => (props.$fixed ? "fixed" : "relative")};
     margin: ${(props) => (props.$fixed ? "1rem" : 0)};
     top: 0;
@@ -47,6 +48,8 @@ export const Wrapper = styled(animated.div)<StyleProps>`
     border-radius: 0.5rem;
     line-height: 0;
     z-index: 10;
+    align-items: center;
+    gap: 2rem;
 
     ${MediaQuery.MaxWidth.tablet} {
         left: 0;
@@ -57,9 +60,35 @@ export const Wrapper = styled(animated.div)<StyleProps>`
             background: ${getValidationColorAttributes(props).Background};
             border: 1px solid ${getValidationColorAttributes(props).Border};
             color: ${getValidationColorAttributes(props).Text};
+        `;
+    }};
+`;
+
+export const ContentWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 2rem;
+    flex: 1;
+    justify-content: space-between;
+
+    ${MediaQuery.MaxWidth.tablet} {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+`;
+
+export const TextIconWrapper = styled(animated.div)<StyleProps>`
+    display: flex;
+    flex-direction: row;
+    align-items: start;
+
+    ${(props) => {
+        return css`
             & > svg {
+                flex-shrink: 0;
                 width: 1.5rem;
-                height: 1.5rem;
+                height: 1.625rem;
                 margin-right: 0.5rem;
                 color: ${getValidationColorAttributes(props).Icon};
             }
@@ -70,8 +99,6 @@ export const Wrapper = styled(animated.div)<StyleProps>`
 export const TextContainer = styled.div`
     display: flex;
     flex-direction: column;
-    padding-right: 2rem;
-    flex: 1;
 `;
 
 export const Title = styled(Text.H4)<StyleProps>`
@@ -94,6 +121,17 @@ export const Description = styled.div<StyleProps>`
             }
         `;
     }}
+`;
+
+export const ActionButton = styled(Button.Small)`
+    font-weight: 600;
+    align-self: center;
+    white-space: nowrap;
+
+    ${MediaQuery.MaxWidth.tablet} {
+        align-self: start;
+        margin-left: 2rem;
+    }
 `;
 
 export const DismissButton = styled(ClickableIcon)<StyleProps>`

--- a/src/toast/toast.tsx
+++ b/src/toast/toast.tsx
@@ -108,6 +108,16 @@ export const Toast = ({
         }
     };
 
+    const renderDesc = () => {
+        if (React.isValidElement(label)) {
+            return label;
+        } else if (title) {
+            return <Text.BodySmall>{label}</Text.BodySmall>;
+        } else {
+            return <Text.Body>{label}</Text.Body>;
+        }
+    };
+
     return (
         <Wrapper
             style={transitions}
@@ -129,17 +139,7 @@ export const Toast = ({
                             ))}
                         {label && (
                             <Description $type={type}>
-                                {!title ? (
-                                    React.isValidElement(label) ? (
-                                        label
-                                    ) : (
-                                        <Text.Body>{label}</Text.Body>
-                                    )
-                                ) : React.isValidElement(label) ? (
-                                    label
-                                ) : (
-                                    <Text.BodySmall>{label}</Text.BodySmall>
-                                )}
+                                {renderDesc()}
                             </Description>
                         )}
                     </TextContainer>

--- a/src/toast/toast.tsx
+++ b/src/toast/toast.tsx
@@ -11,13 +11,17 @@ import { easings, useSpring } from "react-spring";
 import { MediaWidths } from "../spec/media-spec";
 import { Text } from "../text";
 import {
+    ActionButton,
+    ContentWrapper,
     Description,
     DismissButton,
     TextContainer,
+    TextIconWrapper,
     Title,
     Wrapper,
 } from "./toast.styles";
 import { ToastProps } from "./types";
+import React from "react";
 
 const DEFAULT_AUTO_DISMISS_TIME = 4000;
 
@@ -29,6 +33,7 @@ export const Toast = ({
     autoDismissTime = DEFAULT_AUTO_DISMISS_TIME,
     onDismiss,
     fixed = true,
+    actionButton,
     ...otherProps
 }: ToastProps) => {
     // =============================================================================
@@ -110,23 +115,45 @@ export const Toast = ({
             $fixed={fixed}
             {...otherProps}
         >
-            {renderIcon()}
-            <TextContainer>
-                {title && (
-                    <Title $type={type} weight="semibold">
-                        {title}
-                    </Title>
-                )}
-                {label && (
-                    <Description $type={type}>
-                        {!title ? (
-                            <Text.Body>{label}</Text.Body>
-                        ) : (
-                            <Text.BodySmall>{label}</Text.BodySmall>
+            <ContentWrapper>
+                <TextIconWrapper $type={type}>
+                    {renderIcon()}
+                    <TextContainer>
+                        {title &&
+                            (React.isValidElement(title) ? (
+                                title
+                            ) : (
+                                <Title $type={type} weight="semibold">
+                                    {title}
+                                </Title>
+                            ))}
+                        {label && (
+                            <Description $type={type}>
+                                {!title ? (
+                                    React.isValidElement(label) ? (
+                                        label
+                                    ) : (
+                                        <Text.Body>{label}</Text.Body>
+                                    )
+                                ) : React.isValidElement(label) ? (
+                                    label
+                                ) : (
+                                    <Text.BodySmall>{label}</Text.BodySmall>
+                                )}
+                            </Description>
                         )}
-                    </Description>
+                    </TextContainer>
+                </TextIconWrapper>
+
+                {actionButton && (
+                    <ActionButton
+                        styleType="light"
+                        onClick={actionButton.onClick}
+                    >
+                        {actionButton.label}
+                    </ActionButton>
                 )}
-            </TextContainer>
+            </ContentWrapper>
             <DismissButton $type={type} onClick={handleDismiss}>
                 <CrossIcon />
             </DismissButton>

--- a/src/toast/types.ts
+++ b/src/toast/types.ts
@@ -2,7 +2,7 @@ import React, { HTMLAttributes } from "react";
 
 export type ToastType = "success" | "warning" | "error" | "info";
 
-export interface ActionButtonProps {
+export interface ToastActionButtonProps {
     label: string;
     onClick: () => void;
 }
@@ -24,5 +24,5 @@ export interface ToastProps
     /** Specifies if Toast should be fixed to top. Defaults to true */
     fixed?: boolean | undefined;
     /** If given, will display an actionButton with the given title and run the given function upon clicking of the button */
-    actionButton?: ActionButtonProps | undefined;
+    actionButton?: ToastActionButtonProps | undefined;
 }

--- a/src/toast/types.ts
+++ b/src/toast/types.ts
@@ -1,20 +1,28 @@
-import React from "react";
+import React, { HTMLAttributes } from "react";
 
 export type ToastType = "success" | "warning" | "error" | "info";
 
-export interface ToastProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface ActionButtonProps {
+    label: string;
+    onClick: () => void;
+}
+
+export interface ToastProps
+    extends Omit<HTMLAttributes<HTMLDivElement>, "title"> {
     /** The type of Toast. Control the display */
     type: ToastType;
     /** The content of the Toast. If a `title` is provided, this will act as a description label  */
-    label: string;
+    label: string | React.ReactNode;
     /** The title of the Toast  */
-    title?: string | undefined;
+    title?: string | React.ReactNode | undefined;
     /** If specified, the Toast will be automatically dismissed after 4 seconds */
     autoDismiss?: boolean | undefined;
     /** Time until auto dismissal in milliseconds. Requires `autoDismiss` to be `true` */
     autoDismissTime?: number | undefined;
     /** If given, the function will be called when the Toast is dismissed */
-    onDismiss?: () => void;
+    onDismiss?: (() => void) | undefined;
     /** Specifies if Toast should be fixed to top. Defaults to true */
     fixed?: boolean | undefined;
+    /** If given, will display an actionButton with the given title and run the given function upon clicking of the button */
+    actionButton?: ActionButtonProps | undefined;
 }

--- a/stories/toast/props-table.tsx
+++ b/stories/toast/props-table.tsx
@@ -38,7 +38,7 @@ const DATA: ApiTableSectionProps[] = [
                         The title of the <code>Toast</code>
                     </>
                 ),
-                propTypes: [`string`],
+                propTypes: [`string | JSX.Element`],
                 defaultValue: "",
             },
             {
@@ -49,7 +49,7 @@ const DATA: ApiTableSectionProps[] = [
                         display the content information.
                     </>
                 ),
-                propTypes: [`string`],
+                propTypes: [`string | JSX.Element`],
                 defaultValue: "",
                 mandatory: true,
             },
@@ -78,16 +78,6 @@ const DATA: ApiTableSectionProps[] = [
                 defaultValue: "4000",
             },
             {
-                name: "onDismiss",
-                description: (
-                    <>
-                        Called when the <code>Toast</code> is dismissed, either
-                        by user action or from auto dismiss.
-                    </>
-                ),
-                propTypes: ["() => void"],
-            },
-            {
                 name: "fixed",
                 description: (
                     <>
@@ -98,6 +88,35 @@ const DATA: ApiTableSectionProps[] = [
                 ),
                 propTypes: ["boolean"],
                 defaultValue: "true",
+            },
+            {
+                name: "actionButton",
+                description: (
+                    <>
+                        Consist of <code>label</code> and <code>onClick</code>,
+                        which dictates what the label of the button is and what
+                        happens when the button is clicked on
+                    </>
+                ),
+                propTypes: ["ActionButtonProps"],
+            },
+        ],
+    },
+    {
+        name: "ActionButtonProps",
+        attributes: [
+            {
+                name: "label",
+                mandatory: true,
+                description: "The label of the button",
+                propTypes: ["string"],
+            },
+            {
+                name: "onClick",
+                mandatory: true,
+                description:
+                    "The function that should be rendered when the action button is clicked.",
+                propTypes: ["() => void"],
             },
         ],
     },

--- a/stories/toast/props-table.tsx
+++ b/stories/toast/props-table.tsx
@@ -38,7 +38,7 @@ const DATA: ApiTableSectionProps[] = [
                         The title of the <code>Toast</code>
                     </>
                 ),
-                propTypes: [`string | JSX.Element`],
+                propTypes: [`string`, `JSX.Element`],
                 defaultValue: "",
             },
             {
@@ -49,7 +49,7 @@ const DATA: ApiTableSectionProps[] = [
                         display the content information.
                     </>
                 ),
-                propTypes: [`string | JSX.Element`],
+                propTypes: [`string`, `JSX.Element`],
                 defaultValue: "",
                 mandatory: true,
             },
@@ -76,6 +76,16 @@ const DATA: ApiTableSectionProps[] = [
                 ),
                 propTypes: ["number"],
                 defaultValue: "4000",
+            },
+            {
+                name: "onDismiss",
+                description: (
+                    <>
+                        Called when the <code>Toast</code> is dismissed, either
+                        by user action or from auto dismiss.
+                    </>
+                ),
+                propTypes: ["() => void"],
             },
             {
                 name: "fixed",

--- a/stories/toast/toast.mdx
+++ b/stories/toast/toast.mdx
@@ -34,6 +34,18 @@ This example demonstrates the default positioning of the Toast. It remains fixed
 
 <Canvas of={ToastStories.FixedPositioning} />
 
+<Heading3>Using JSX Element Titles/Labels</Heading3>
+
+This example demonstrates how the toast will be displayed when a JSX element is passed into the title & label.
+
+<Canvas of={ToastStories.WithJSXTitleAndLabel} />
+
+<Heading3>With an Action Button</Heading3>
+
+This example demonstrates how the action button works.
+
+<Canvas of={ToastStories.WithActionButton} />
+
 <Secondary>Component API</Secondary>
 
 <PropsTable />

--- a/stories/toast/toast.stories.tsx
+++ b/stories/toast/toast.stories.tsx
@@ -2,6 +2,9 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { Button } from "src/button";
 import { Toast } from "src/toast";
+import { Text } from "src/text";
+import { Card } from "src/card";
+import { Color } from "src/color";
 
 type Component = typeof Toast;
 
@@ -14,6 +17,10 @@ export default meta;
 
 export const Default: StoryObj<Component> = {
     render: () => {
+        const customActionButton = {
+            label: "Click me",
+            onClick: () => console.log("This function is called"),
+        };
         return (
             <>
                 <Toast
@@ -167,5 +174,106 @@ export const FixedPositioning: StoryObj<Component> = {
     parameters: {
         layout: "fullscreen",
         docs: { story: { inline: false, iframeHeight: 300 } },
+    },
+};
+
+export const WithJSXTitleAndLabel: StoryObj<Component> = {
+    render: () => {
+        const title = (
+            <Text.H4
+                weight={"regular"}
+                style={{
+                    color: "grey",
+                    fontSize: "2rem",
+                }}
+            >
+                This is a <strong>JSX Element</strong>
+            </Text.H4>
+        );
+
+        const label = (
+            <Text.Body
+                style={{
+                    display: "flex",
+                    alignItems: "center",
+                }}
+            >
+                The
+                <a
+                    style={{
+                        margin: "0 0.25rem",
+                        color: "#1C76D5",
+                    }}
+                >
+                    label
+                </a>
+                and title were passed in as JSX Elements
+            </Text.Body>
+        );
+        return (
+            <>
+                <Toast
+                    type="success"
+                    title={title}
+                    label={label}
+                    fixed={false}
+                />
+                <br />
+                <Toast type="error" title={title} label={label} fixed={false} />
+                <br />
+                <Toast
+                    type="warning"
+                    title={title}
+                    label={label}
+                    fixed={false}
+                />
+                <br />
+                <Toast type="info" label={label} fixed={false} />
+            </>
+        );
+    },
+};
+
+export const WithActionButton: StoryObj<Component> = {
+    render: () => {
+        const customActionButton = {
+            label: "Click me",
+            onClick: () => console.log("This function is called"),
+        };
+        return (
+            <>
+                <Toast
+                    type="success"
+                    title="Template successfully updated"
+                    label="Your bookings has been updated and received by the service provider."
+                    actionButton={customActionButton}
+                    fixed={false}
+                />
+                <br />
+                <Toast
+                    type="warning"
+                    label="Your bookings has been updated and received by the service provider."
+                    actionButton={customActionButton}
+                    fixed={false}
+                />
+                <br />
+                <Toast
+                    type="error"
+                    label="An internal system error had occured. Please log out and try
+                again."
+                    actionButton={customActionButton}
+                    fixed={false}
+                />
+                <br />
+                <Toast
+                    type="info"
+                    title="Updated automatically"
+                    label="The calendar will be automatically updated when you have done
+                editing the event information."
+                    actionButton={customActionButton}
+                    fixed={false}
+                />
+            </>
+        );
     },
 };


### PR DESCRIPTION
**Changes**

- Adding an action button to the toast component
- Enabling the title and label to be passed in as a JSX Element 
- Enabling the displaying of the toast in the mobile version.

**Additional information**

- This is from the ticket [CCUBE-1400](https://jira.ship.gov.sg/browse/CCUBE-1400)
