### PR TITLE
`DateInput`: fix dismiss behaviour, enhance focus and blur handling

### DIFF
--- a/src/date-input/date-input.tsx
+++ b/src/date-input/date-input.tsx
@@ -127,6 +127,8 @@ export const DateInput = ({
             !calendarOpen &&
             !nodeRef.current.contains(e.relatedTarget as Node)
         ) {
+            inputRef.current.resetInput();
+            setSelectedDate(initialDate);
             setFocused(false);
             performOnBlurHandler();
         }

--- a/src/date-input/date-input.tsx
+++ b/src/date-input/date-input.tsx
@@ -117,6 +117,7 @@ export const DateInput = ({
                 break;
         }
 
+        nodeRef.current.focus();
         setCalendarOpen(false);
         performOnBlurHandler();
     };
@@ -142,6 +143,7 @@ export const DateInput = ({
     const renderInput = () => {
         return (
             <Container
+                tabIndex={-1}
                 ref={nodeRef}
                 $disabled={disabled}
                 $readOnly={readOnly}

--- a/src/date-input/date-input.tsx
+++ b/src/date-input/date-input.tsx
@@ -56,15 +56,17 @@ export const DateInput = ({
     // EVENT HANDLERS
     // =============================================================================
     const handleClose = () => {
+        inputRef.current.resetInput();
+        setSelectedDate(initialDate);
         setCalendarOpen(false);
         performOnBlurHandler();
     };
 
     const handleDismiss = () => {
         inputRef.current.resetInput();
+        nodeRef.current.focus();
         setSelectedDate(initialDate);
         setCalendarOpen(false);
-        performOnBlurHandler();
     };
 
     const handleChange = (val: string) => {
@@ -86,7 +88,19 @@ export const DateInput = ({
             setInitialDate(val);
             if (val) {
                 setCalendarOpen(false);
-                performOnBlurHandler();
+            }
+        }
+    };
+
+    const handleSelect = (val: string) => {
+        setSelectedDate(val);
+
+        if (!withButton) {
+            performOnChangeHandler(val);
+            setInitialDate(val);
+            if (val) {
+                nodeRef.current.focus();
+                setCalendarOpen(false);
             }
         }
     };
@@ -98,6 +112,15 @@ export const DateInput = ({
 
         if (onFocus) {
             onFocus();
+        }
+    };
+
+    const handleBlur = (e: React.FocusEvent) => {
+        if (
+            !calendarOpen &&
+            !nodeRef.current.contains(e.relatedTarget as Node)
+        ) {
+            performOnBlurHandler();
         }
     };
 
@@ -119,7 +142,6 @@ export const DateInput = ({
 
         nodeRef.current.focus();
         setCalendarOpen(false);
-        performOnBlurHandler();
     };
 
     // =============================================================================
@@ -145,6 +167,8 @@ export const DateInput = ({
             <Container
                 tabIndex={-1}
                 ref={nodeRef}
+                onBlur={handleBlur}
+                onFocus={handleFocus}
                 $disabled={disabled}
                 $readOnly={readOnly}
                 $error={error}
@@ -156,7 +180,6 @@ export const DateInput = ({
                     ref={inputRef}
                     disabled={disabled}
                     onChange={handleChange}
-                    onFocus={handleFocus}
                     readOnly={readOnly}
                     focused={calendarOpen}
                     names={["start-day", "start-month", "start-year"]}
@@ -181,7 +204,7 @@ export const DateInput = ({
                 maxDate={maxDate}
                 allowDisabledSelection={allowDisabledSelection}
                 onHover={handleHoverDayCell}
-                onSelect={handleChange}
+                onSelect={handleSelect}
                 onDismiss={handleCalendarAction}
                 onYearMonthDisplayChange={onYearMonthDisplayChange}
             />

--- a/src/date-input/date-input.tsx
+++ b/src/date-input/date-input.tsx
@@ -39,6 +39,7 @@ export const DateInput = ({
     );
     const [hoveredDate, setHoveredDate] = useState<string>(undefined);
     const [calendarOpen, setCalendarOpen] = useState<boolean>(false);
+    const [focused, setFocused] = useState<boolean>(false);
 
     const nodeRef = useRef<HTMLDivElement>(null);
     const inputRef = useRef<StandaloneDateInputRef>();
@@ -59,6 +60,7 @@ export const DateInput = ({
         inputRef.current.resetInput();
         setSelectedDate(initialDate);
         setCalendarOpen(false);
+        setFocused(false);
         performOnBlurHandler();
     };
 
@@ -106,9 +108,10 @@ export const DateInput = ({
     };
 
     const handleFocus = () => {
-        if (readOnly) return;
+        if (readOnly || focused) return;
 
         setCalendarOpen(true);
+        setFocused(true);
 
         if (onFocus) {
             onFocus();
@@ -117,9 +120,11 @@ export const DateInput = ({
 
     const handleBlur = (e: React.FocusEvent) => {
         if (
+            focused &&
             !calendarOpen &&
             !nodeRef.current.contains(e.relatedTarget as Node)
         ) {
+            setFocused(false);
             performOnBlurHandler();
         }
     };
@@ -171,6 +176,7 @@ export const DateInput = ({
                 onFocus={handleFocus}
                 $disabled={disabled}
                 $readOnly={readOnly}
+                $focused={focused}
                 $error={error}
                 id={id}
                 data-testid={otherProps["data-testid"]}

--- a/src/date-input/date-input.tsx
+++ b/src/date-input/date-input.tsx
@@ -108,9 +108,12 @@ export const DateInput = ({
     };
 
     const handleFocus = () => {
-        if (readOnly || focused) return;
+        if (readOnly) return;
 
         setCalendarOpen(true);
+
+        if (focused) return;
+
         setFocused(true);
 
         if (onFocus) {

--- a/src/date-range-input/date-range-input.tsx
+++ b/src/date-range-input/date-range-input.tsx
@@ -452,6 +452,8 @@ export const DateRangeInput = ({
     };
 
     const handleCalendarDismiss = (action: CalendarAction) => {
+        nodeRef.current.focus();
+
         switch (action) {
             case "reset":
                 actions.cancel();
@@ -526,6 +528,7 @@ export const DateRangeInput = ({
         return (
             <Container
                 ref={nodeRef}
+                tabIndex={-1}
                 $disabled={disabled}
                 $readOnly={readOnly}
                 $error={error}

--- a/src/shared/dropdown-wrapper/element-with-dropdown.tsx
+++ b/src/shared/dropdown-wrapper/element-with-dropdown.tsx
@@ -10,7 +10,6 @@ import {
     useClick,
     useDismiss,
     useFloating,
-    useFocus,
     useInteractions,
     useTransitionStyles,
 } from "@floating-ui/react";
@@ -25,6 +24,7 @@ interface ElementWithDropdownProps {
     renderElement: () => React.ReactNode;
     renderDropdown: () => React.ReactNode;
     zIndex?: number | undefined;
+    clickToToggle?: boolean | undefined;
 }
 
 export const ElementWithDropdown = ({
@@ -36,6 +36,7 @@ export const ElementWithDropdown = ({
     renderElement,
     renderDropdown,
     zIndex = 50,
+    clickToToggle = false,
 }: ElementWithDropdownProps) => {
     // =============================================================================
     // CONST, STATE, REF
@@ -76,13 +77,11 @@ export const ElementWithDropdown = ({
         duration: 300,
     });
 
-    const click = useClick(context, { enabled });
-    const focus = useFocus(context, { enabled });
+    const click = useClick(context, { enabled, toggle: clickToToggle });
     const dismiss = useDismiss(context, { enabled });
 
     const { getReferenceProps, getFloatingProps } = useInteractions([
         click,
-        focus,
         dismiss,
     ]);
 

--- a/src/shared/input-wrapper/input-wrapper.tsx
+++ b/src/shared/input-wrapper/input-wrapper.tsx
@@ -12,6 +12,7 @@ export interface InputWrapperStyleProps {
     $disabled?: boolean | undefined;
     $error?: boolean | undefined;
     $readOnly?: boolean | undefined;
+    $focused?: boolean | undefined;
     $position?: "left" | "right" | undefined;
 }
 
@@ -22,6 +23,26 @@ export interface InputStyleProps {
 // =============================================================================
 // STYLING
 // =============================================================================
+const defaultFocusCss = css`
+    border: 1px solid ${Color.Accent.Light[1]};
+    box-shadow: ${DesignToken.InputBoxShadow};
+`;
+
+const readOnlyFocusCss = css`
+    border: 1px solid transparent;
+    box-shadow: none;
+`;
+
+const disabledFocusCss = css`
+    border: 1px solid ${Color.Neutral[5]};
+    box-shadow: none;
+`;
+
+const errorFocusCss = css`
+    border: 1px solid ${Color.Validation.Red.Border};
+    box-shadow: ${DesignToken.InputErrorBoxShadow};
+`;
+
 export const InputWrapper = styled.div<InputWrapperStyleProps>`
     display: flex;
     align-items: center;
@@ -36,9 +57,9 @@ export const InputWrapper = styled.div<InputWrapperStyleProps>`
         props.$position === "right" ? "row-reverse" : "row"};
 
     :focus-within {
-        border: 1px solid ${Color.Accent.Light[1]};
-        box-shadow: ${DesignToken.InputBoxShadow};
+        ${defaultFocusCss}
     }
+    ${(props) => props.$focused && defaultFocusCss}
 
     ${(props) => {
         if (props.$readOnly) {
@@ -48,9 +69,9 @@ export const InputWrapper = styled.div<InputWrapperStyleProps>`
                 background: transparent !important;
 
                 :focus-within {
-                    border: 1px solid transparent;
-                    box-shadow: none;
+                    ${readOnlyFocusCss}
                 }
+                ${props.$focused && readOnlyFocusCss}
             `;
         } else if (props.$disabled) {
             return css`
@@ -58,18 +79,18 @@ export const InputWrapper = styled.div<InputWrapperStyleProps>`
                 cursor: not-allowed;
 
                 :focus-within {
-                    border: 1px solid ${Color.Neutral[5]};
-                    box-shadow: none;
+                    ${disabledFocusCss}
                 }
+                ${props.$focused && disabledFocusCss}
             `;
         } else if (props.$error) {
             return css`
                 border: 1px solid ${Color.Validation.Red.Border};
 
                 :focus-within {
-                    border: 1px solid ${Color.Validation.Red.Border};
-                    box-shadow: ${DesignToken.InputErrorBoxShadow};
+                    ${errorFocusCss}
                 }
+                ${props.$focused && errorFocusCss}
             `;
         }
     }}

--- a/src/shared/standalone-date-input/standalone-date-input.tsx
+++ b/src/shared/standalone-date-input/standalone-date-input.tsx
@@ -33,7 +33,7 @@ interface Props {
     placeholder?: string | undefined;
     label?: string | undefined;
     onChange: (value: string) => void;
-    onFocus?: (() => void) | undefined;
+    onFocus?: ((event: React.FocusEvent) => void) | undefined;
     onBlur?: ((valid: boolean) => void) | undefined;
 }
 
@@ -138,7 +138,7 @@ export const Component = (
         }
     };
 
-    const handleSectionFocus = () => {
+    const handleSectionFocus = (event: React.FocusEvent) => {
         if (disabled) {
             return;
         }
@@ -146,7 +146,7 @@ export const Component = (
         setHidePlaceholder(true);
 
         if (!focused) {
-            onFocus?.();
+            onFocus?.(event);
         }
     };
 

--- a/src/shared/standalone-date-input/standalone-date-input.tsx
+++ b/src/shared/standalone-date-input/standalone-date-input.tsx
@@ -33,7 +33,7 @@ interface Props {
     placeholder?: string | undefined;
     label?: string | undefined;
     onChange: (value: string) => void;
-    onFocus: () => void;
+    onFocus?: (() => void) | undefined;
     onBlur?: ((valid: boolean) => void) | undefined;
 }
 
@@ -146,7 +146,7 @@ export const Component = (
         setHidePlaceholder(true);
 
         if (!focused) {
-            onFocus();
+            onFocus?.();
         }
     };
 

--- a/stories/filter/doc-elements.tsx
+++ b/stories/filter/doc-elements.tsx
@@ -41,18 +41,7 @@ export const SearchFilter = ({ mode, value, onChange }: Props<string>) => {
 };
 
 export const DateFilter = ({ value, onChange }: Props<string>) => {
-    const [isFocused, setIsFocused] = useState(false);
-
-    return (
-        <div style={{ height: isFocused ? "33rem" : undefined }}>
-            <Form.DateInput
-                value={value}
-                onChange={(date) => onChange(date)}
-                onFocus={() => setIsFocused(true)}
-                onBlur={() => setIsFocused(false)}
-            />
-        </div>
-    );
+    return <Form.DateInput value={value} onChange={(date) => onChange(date)} />;
 };
 
 export const TextFilter = () => {


### PR DESCRIPTION
**Changes**

- Restores dismiss behaviour for variant `withButton={true}`
  - It's supposed to reset to the previous value if the Done button is not clicked
- Tweak blur event handling in date input
  - After date selection, transfer focus to the main element. This prevents the user from losing their place in the form
  - Only trigger `onBlur` when user moves away from the field, instead of whenever the calendar is dismissed
- Ensure main element still appears focused when calendar is active
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

Bug fix
- `DateInput`
  - Restore behaviour to reset to the previous value if dismissed without confirmation
  - Only trigger `onBlur` when leaving the field instead of calendar dismissal
  - Ensure main input still appears focused when calendar is active