### PR TITLE
Fix text wrap in `UneditableSection.Item`

### DIFF
--- a/src/uneditable-section/section-item.styles.tsx
+++ b/src/uneditable-section/section-item.styles.tsx
@@ -41,6 +41,8 @@ export const Container = styled.li<ContainerStyleProps>`
     ${MediaQuery.MaxWidth.mobileL} {
         grid-column: auto / span 4;
     }
+
+    overflow-wrap: break-word;
 `;
 
 export const IconContainer = styled.div`


### PR DESCRIPTION
**Changes**

Adds style to let long strings (e.g. emails) wrap to the next line

```
<UneditableSection.Item
    label="Email address"
    value="supercalifragilisticexpialidocious@example.com"
/>
```

- [delete] branch
