### PR TITLE
[BOOKINGSG-5584][RT] Fix date input color after selection in mobile stays gray

### DIFF
--- a/src/date-input/date-input.tsx
+++ b/src/date-input/date-input.tsx
@@ -104,6 +104,11 @@ export const DateInput = ({
                 nodeRef.current.focus();
                 setCalendarOpen(false);
             }
+
+            // clear hover value for mobile when onMouseLeave={handleMouseLeaveCell} is not triggered due to touch input
+            if (hoveredDate) {
+                setHoveredDate(undefined);
+            }
         }
     };
 


### PR DESCRIPTION
**Changes**
- Fix bug involving date input on mobile view. The text color remain gray after user selected a date due to some hover function not fired in mobile view.
- [delete] branch

**Changelog entry**
- Fix bug involving date input on mobile view.

**Additional information**
- You may refer to this [BOOKINGSG-5884](https://jira.ship.gov.sg/browse/BOOKINGSG-5884)
