### PR TITLE
Allow toggle composite section to be hidden but remain mounted

### DIFF
--- a/src/toggle/toggle.styles.tsx
+++ b/src/toggle/toggle.styles.tsx
@@ -36,6 +36,7 @@ interface ExpandButtonStyleProps extends StyleProps {
 
 interface ChildrenStyleProps extends StyleProps {
     $isFinalItem?: boolean;
+    $show?: boolean;
 }
 
 // =============================================================================
@@ -353,6 +354,8 @@ export const Children = styled.div<ChildrenStyleProps>`
             `;
         }
     }}
+
+    ${(props) => !props.$show && `display: none;`}
 `;
 
 export const ErrorText = styled(Text.BodySmall)<StyleProps>`

--- a/src/toggle/toggle.tsx
+++ b/src/toggle/toggle.tsx
@@ -46,6 +46,7 @@ export const Toggle = ({
     // =============================================================================
     const {
         collapsible = true,
+        show = true,
         errors,
         children: compositeSectionChildren,
         initialExpanded,
@@ -171,7 +172,11 @@ export const Toggle = ({
     const renderCompositeChildren = () => {
         return (
             (!collapsible || expanded) && (
-                <Children $isFinalItem={!collapsible} $disabled={disabled}>
+                <Children
+                    $isFinalItem={!collapsible}
+                    $disabled={disabled}
+                    $show={show}
+                >
                     {compositeSectionChildren}
                 </Children>
             )

--- a/src/toggle/types.ts
+++ b/src/toggle/types.ts
@@ -50,6 +50,8 @@ export interface ToggleProps
 
 export interface ToggleCompositeSectionProps {
     children: React.ReactNode;
+    /** Specifies if the subsection is visible. Remains mounted */
+    show?: boolean | undefined;
     /** Specifies if the subsection is collapsible */
     collapsible?: boolean | undefined;
     /** The initial expanded state. Only applicable if collapsible */

--- a/stories/toggle/props-table.tsx
+++ b/stories/toggle/props-table.tsx
@@ -137,6 +137,19 @@ const DATA: ApiTableSectionProps[] = [
                 mandatory: true,
             },
             {
+                name: "show",
+                description: (
+                    <>
+                        Specifies if the subsection is visible.{" "}
+                        <strong>Note:</strong> remains mounted when set to{" "}
+                        <code>false</code>. If it is preferred to unmount the
+                        subsection, omit <code>compositeSection</code> instead
+                    </>
+                ),
+                propTypes: ["boolean"],
+                defaultValue: `true`,
+            },
+            {
                 name: "collapsible",
                 description: "Specifies if the subsection is collapsible",
                 propTypes: ["boolean"],


### PR DESCRIPTION
**Changes**

In FEE, a hidden field still needs to remain mounted for the conditional rendering logic to run

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Allow `Toggle` composite section to be hidden but remain mounted