### PR TITLE
Fix select dropdown getting cut off by parent

### DIFF
--- a/src/date-input/date-input.tsx
+++ b/src/date-input/date-input.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useRef, useState } from "react";
-import { ElementWithDropdown } from "../shared/dropdown-wrapper";
+import {
+    DropdownRenderProps,
+    ElementWithDropdown,
+} from "../shared/dropdown-wrapper";
 import { CalendarAction, CalendarDropdown } from "../shared/internal-calendar";
 import {
     StandaloneDateInput,
@@ -207,7 +210,7 @@ export const DateInput = ({
         );
     };
 
-    const renderCalendar = () => {
+    const renderCalendar = ({ elementWidth }: DropdownRenderProps) => {
         return (
             <CalendarDropdown
                 type="input"
@@ -223,6 +226,7 @@ export const DateInput = ({
                 onSelect={handleSelect}
                 onDismiss={handleCalendarAction}
                 onYearMonthDisplayChange={onYearMonthDisplayChange}
+                width={elementWidth}
             />
         );
     };

--- a/src/date-input/date-input.tsx
+++ b/src/date-input/date-input.tsx
@@ -236,6 +236,7 @@ export const DateInput = ({
             onClose={handleClose}
             onDismiss={handleDismiss}
             zIndex={zIndex}
+            offset={16}
         />
     );
 };

--- a/src/date-range-input/date-range-input.tsx
+++ b/src/date-range-input/date-range-input.tsx
@@ -2,7 +2,10 @@ import dayjs from "dayjs";
 import { useEffect, useRef, useState } from "react";
 import { useMediaQuery } from "react-responsive";
 import { MediaWidths } from "../media";
-import { ElementWithDropdown } from "../shared/dropdown-wrapper";
+import {
+    DropdownRenderProps,
+    ElementWithDropdown,
+} from "../shared/dropdown-wrapper";
 import {
     CalendarAction,
     CalendarDropdown,
@@ -635,7 +638,7 @@ export const DateRangeInput = ({
         );
     };
 
-    const renderCalendar = () => {
+    const renderCalendar = ({ elementWidth }: DropdownRenderProps) => {
         return (
             <CalendarDropdown
                 ref={calendarRef}
@@ -656,6 +659,7 @@ export const DateRangeInput = ({
                 onHover={handleCalendarHover}
                 onYearMonthDisplayChange={onYearMonthDisplayChange}
                 numberOfDays={numberOfDays}
+                width={elementWidth}
             />
         );
     };

--- a/src/date-range-input/date-range-input.tsx
+++ b/src/date-range-input/date-range-input.tsx
@@ -669,6 +669,7 @@ export const DateRangeInput = ({
             renderElement={renderInput}
             renderDropdown={renderCalendar}
             zIndex={zIndex}
+            offset={16}
         />
     );
 };

--- a/src/input-select/input-select.tsx
+++ b/src/input-select/input-select.tsx
@@ -5,7 +5,10 @@ import {
     DropdownListState,
     ExpandableElement,
 } from "../shared/dropdown-list-v2";
-import { ElementWithDropdown } from "../shared/dropdown-wrapper";
+import {
+    DropdownRenderProps,
+    ElementWithDropdown,
+} from "../shared/dropdown-wrapper";
 import {
     LabelContainer,
     PlaceholderLabel,
@@ -238,7 +241,7 @@ export const InputSelect = <T, V>({
         );
     };
 
-    const renderDropdown = () => {
+    const renderDropdown = ({ elementWidth }: DropdownRenderProps) => {
         return (
             <DropdownList
                 listboxId={internalId}
@@ -258,6 +261,7 @@ export const InputSelect = <T, V>({
                 hideNoResultsDisplay={hideNoResultsDisplay}
                 renderCustomCallToAction={renderCustomCallToAction}
                 variant={variant}
+                width={elementWidth}
             />
         );
     };

--- a/src/input-select/input-select.tsx
+++ b/src/input-select/input-select.tsx
@@ -49,6 +49,7 @@ export const InputSelect = <T, V>({
     variant = "default",
     readOnly,
     alignment,
+    dropdownZIndex,
 }: InputSelectProps<T, V>): JSX.Element => {
     // =============================================================================
     // CONST, STATE
@@ -280,6 +281,7 @@ export const InputSelect = <T, V>({
                 offset={8}
                 alignment={alignment}
                 fitAvailableHeight
+                zIndex={dropdownZIndex}
             />
         </DropdownListState>
     );

--- a/src/input-select/input-select.tsx
+++ b/src/input-select/input-select.tsx
@@ -79,9 +79,7 @@ export const InputSelect = <T, V>({
         setShowOptions(false);
         triggerOptionDisplayCallback(false);
 
-        if (onSelectOption) {
-            onSelectOption(item, extractedValue);
-        }
+        onSelectOption?.(item, extractedValue);
     };
 
     const handleListDismiss = () => {
@@ -173,12 +171,10 @@ export const InputSelect = <T, V>({
     };
 
     const triggerOptionDisplayCallback = (show: boolean) => {
-        if (!show && onHideOptions) {
-            onHideOptions();
-        }
-
-        if (show && onShowOptions) {
-            onShowOptions();
+        if (show) {
+            onShowOptions?.();
+        } else {
+            onHideOptions?.();
         }
     };
 

--- a/src/input-select/input-select.tsx
+++ b/src/input-select/input-select.tsx
@@ -283,6 +283,7 @@ export const InputSelect = <T, V>({
                 clickToToggle
                 offset={8}
                 alignment={alignment}
+                fitAvailableHeight
             />
         </DropdownListState>
     );

--- a/src/input-select/input-select.tsx
+++ b/src/input-select/input-select.tsx
@@ -1,16 +1,18 @@
 import { OpenChangeReason } from "@floating-ui/react";
 import React, { useEffect, useRef, useState } from "react";
-import { DropdownList, DropdownListState } from "../shared/dropdown-list-v2";
+import {
+    DropdownList,
+    DropdownListState,
+    ExpandableElement,
+} from "../shared/dropdown-list-v2";
 import { ElementWithDropdown } from "../shared/dropdown-wrapper";
 import {
-    IconContainer,
     LabelContainer,
     PlaceholderLabel,
-    Selector,
-    StyledChevronIcon,
     ValueLabel,
 } from "../shared/dropdown-wrapper/dropdown-wrapper.styles";
 import { InputBox } from "../shared/input-wrapper/input-wrapper";
+import { SimpleIdGenerator } from "../util";
 import { StringHelper } from "../util/string-helper";
 import { InputSelectProps } from "./types";
 
@@ -44,7 +46,6 @@ export const InputSelect = <T, V>({
     variant = "default",
     readOnly,
     alignment,
-    ...otherProps
 }: InputSelectProps<T, V>): JSX.Element => {
     // =============================================================================
     // CONST, STATE
@@ -52,6 +53,7 @@ export const InputSelect = <T, V>({
     const [selected, setSelected] = useState<T>(selectedOption);
     const [showOptions, setShowOptions] = useState<boolean>(false);
     const [focused, setFocused] = useState<boolean>(false);
+    const [internalId] = useState<string>(() => SimpleIdGenerator.generate());
 
     const nodeRef = useRef<HTMLDivElement>();
     const selectorRef = useRef<HTMLButtonElement>();
@@ -204,16 +206,7 @@ export const InputSelect = <T, V>({
     };
 
     const renderSelectorContent = () => (
-        <>
-            <LabelContainer ref={labelContainerRef}>
-                {renderLabel()}
-            </LabelContainer>
-            {!readOnly && (
-                <IconContainer expanded={showOptions}>
-                    <StyledChevronIcon $variant={variant} />
-                </IconContainer>
-            )}
-        </>
+        <LabelContainer ref={labelContainerRef}>{renderLabel()}</LabelContainer>
     );
 
     const renderElement = () => {
@@ -231,18 +224,16 @@ export const InputSelect = <T, V>({
                 $readOnly={readOnly}
                 $error={error}
             >
-                <Selector
+                <ExpandableElement
                     ref={selectorRef}
-                    type="button"
-                    aria-haspopup="listbox"
-                    aria-expanded={showOptions}
-                    data-testid={"selector"}
                     disabled={disabled}
-                    $variant={variant}
-                    {...otherProps}
+                    expanded={showOptions}
+                    id={internalId}
+                    readOnly={readOnly}
+                    variant={variant}
                 >
                     {renderSelectorContent()}
-                </Selector>
+                </ExpandableElement>
             </InputBox>
         );
     };
@@ -250,6 +241,7 @@ export const InputSelect = <T, V>({
     const renderDropdown = () => {
         return (
             <DropdownList
+                listboxId={internalId}
                 listItems={options}
                 onSelectItem={handleListItemClick}
                 onDismiss={handleListDismiss}

--- a/src/input-select/input-select.tsx
+++ b/src/input-select/input-select.tsx
@@ -43,6 +43,7 @@ export const InputSelect = <T, V>({
     onBlur,
     variant = "default",
     readOnly,
+    alignment,
     ...otherProps
 }: InputSelectProps<T, V>): JSX.Element => {
     // =============================================================================
@@ -281,6 +282,7 @@ export const InputSelect = <T, V>({
                 onDismiss={handleDismiss}
                 clickToToggle
                 offset={8}
+                alignment={alignment}
             />
         </DropdownListState>
     );

--- a/src/input-select/types.ts
+++ b/src/input-select/types.ts
@@ -5,6 +5,7 @@ import {
     ItemsLoadStateType,
     TruncateType,
 } from "../shared/dropdown-list-v2/types";
+import { DropdownAlignmentType } from "../shared/dropdown-wrapper";
 
 // =============================================================================
 // SHARED PROPS
@@ -56,6 +57,7 @@ export interface InputSelectProps<T, V>
     renderCustomSelectedOption?: ((option: T) => JSX.Element) | undefined;
     onBlur?: (() => void) | undefined;
     variant?: DropdownVariantType | undefined;
+    alignment?: DropdownAlignmentType | undefined;
 }
 
 /** To be exposed for Form component inheritance */

--- a/src/input-select/types.ts
+++ b/src/input-select/types.ts
@@ -58,6 +58,7 @@ export interface InputSelectProps<T, V>
     onBlur?: (() => void) | undefined;
     variant?: DropdownVariantType | undefined;
     alignment?: DropdownAlignmentType | undefined;
+    dropdownZIndex?: number | undefined;
 }
 
 /** To be exposed for Form component inheritance */

--- a/src/input-select/types.ts
+++ b/src/input-select/types.ts
@@ -1,11 +1,10 @@
 import {
     DropdownDisplayProps,
     DropdownSearchProps,
-    DropdownStyleProps,
     DropdownVariantType,
     ItemsLoadStateType,
     TruncateType,
-} from "../shared/dropdown-list/types";
+} from "../shared/dropdown-list-v2/types";
 
 // =============================================================================
 // SHARED PROPS
@@ -44,8 +43,8 @@ export interface InputSelectProps<T, V>
         InputSelectOptionsProps<T>,
         InputSelectSharedProps<T>,
         DropdownDisplayProps<T, V>,
-        DropdownSearchProps<T>,
-        DropdownStyleProps {
+        DropdownSearchProps<T> {
+    // TODO: should be a common state once all variants implement this
     readOnly?: boolean | undefined;
     selectedOption?: T | undefined;
     onSelectOption?: ((option: T, extractedValue: V) => void) | undefined;

--- a/src/shared/dropdown-list-v2/dropdown-label.styles.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-label.styles.tsx
@@ -67,6 +67,7 @@ export const SecondaryText = styled.div<LabelStyleProps>`
 export const Label = styled.div<LabelStyleProps>`
     text-align: left;
     width: 100%;
+    overflow: hidden;
     overflow-wrap: break-word;
 
     ${(props) => {

--- a/src/shared/dropdown-list-v2/dropdown-label.styles.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-label.styles.tsx
@@ -1,0 +1,111 @@
+import styled, { css } from "styled-components";
+import { Color } from "../../color";
+import { TextStyleHelper } from "../../text";
+import {
+    DropdownVariantType,
+    LabelDisplayType,
+    TruncateType,
+} from "../dropdown-list/types";
+
+// =============================================================================
+// STYLE INTERFACE
+// =============================================================================
+interface LabelStyleProps {
+    $labelDisplayType?: LabelDisplayType;
+    $maxLines?: number;
+    $selected?: boolean;
+    $truncateType?: TruncateType;
+    $variant?: DropdownVariantType;
+}
+
+// =============================================================================
+// STYLING
+// =============================================================================
+
+const lineClampCss = css<LabelStyleProps>`
+    overflow: hidden;
+    display: -webkit-inline-box;
+    text-overflow: ellipsis;
+    -webkit-line-clamp: ${(props) => props.$maxLines || 2};
+    -webkit-box-orient: vertical;
+    overflow-wrap: break-word;
+`;
+
+export const PrimaryText = styled.div<LabelStyleProps>`
+    ${(props) =>
+        TextStyleHelper.getTextStyle(
+            props.$variant === "small" ? "BodySmall" : "Body",
+            "regular"
+        )}
+    color: ${(props) => (props.$selected ? Color.Primary : Color.Neutral[1])};
+    width: 100%;
+
+    ${(props) => props.$truncateType === "end" && lineClampCss}
+`;
+
+export const SecondaryText = styled.div<LabelStyleProps>`
+    color: ${Color.Neutral[4]};
+    width: 100%;
+
+    ${(props) => props.$truncateType === "end" && lineClampCss}
+
+    ${(props) => {
+        switch (props.$labelDisplayType) {
+            case "next-line":
+                return css`
+                    ${TextStyleHelper.getTextStyle("BodySmall", "semibold")}
+                `;
+            case "inline":
+            default:
+                return css`
+                    ${TextStyleHelper.getTextStyle("Body", "regular")}
+                `;
+        }
+    }}
+`;
+
+export const Label = styled.div<LabelStyleProps>`
+    text-align: left;
+    width: 100%;
+    overflow-wrap: break-word;
+
+    ${(props) => {
+        switch (props.$labelDisplayType) {
+            case "next-line":
+                return css`
+                    display: flex;
+                    flex-direction: column;
+                `;
+            case "inline":
+                return css`
+                    ${PrimaryText} {
+                        display: inline;
+                    }
+
+                    ${SecondaryText} {
+                        display: inline;
+                        margin-left: 0.5rem;
+                    }
+                `;
+        }
+    }}
+`;
+
+export const TruncateFirstLine = styled.div<LabelStyleProps>`
+    display: inline-block;
+    width: ${(props) => (props.$maxLines === 1 ? 50 : 100)}%;
+    height: 1.5rem;
+    word-break: break-all;
+    overflow: hidden;
+`;
+
+export const TruncateSecondLine = styled.div<LabelStyleProps>`
+    display: inline-block;
+    width: ${(props) => (props.$maxLines === 1 ? 50 : 100)}%;
+    height: 1.5rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    direction: rtl;
+    text-align: right;
+`;

--- a/src/shared/dropdown-list-v2/dropdown-label.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-label.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useMemo } from "react";
+import { useResizeDetector } from "react-resize-detector";
+import { useTheme } from "styled-components";
+import { TextStyle } from "../../text";
+import { BaseTheme } from "../../theme";
+import { StringHelper } from "../../util/string-helper";
+import { DropdownVariantType, LabelDisplayType } from "../dropdown-list/types";
+import {
+    Label,
+    PrimaryText,
+    SecondaryText,
+    TruncateFirstLine,
+    TruncateSecondLine,
+} from "./dropdown-label.styles";
+
+interface DropdownLabelProps {
+    displayType?: LabelDisplayType | undefined;
+    label: string;
+    maxLines?: number | undefined;
+    selected?: boolean | undefined;
+    sublabel: string;
+    truncationType?: "middle" | "end" | undefined;
+    variant?: DropdownVariantType | undefined;
+}
+
+export const DropdownLabel = ({
+    displayType = "inline",
+    label,
+    maxLines = 2,
+    selected,
+    sublabel,
+    truncationType = "middle",
+    variant,
+}: DropdownLabelProps): JSX.Element => {
+    const theme = useTheme() || BaseTheme;
+    const fontSize = TextStyle.Body.fontSize({ theme });
+    const fontFamily = TextStyle.Body.fontFamily({ theme });
+    const { ref, width } = useResizeDetector();
+
+    // =========================================================================
+    // HELPER FUNCTIONS
+    // =========================================================================
+    const hasExceededContainer = useCallback(
+        (displayText: string) => {
+            if (displayType !== "inline") {
+                return false;
+            }
+
+            // best-effort attempt to check if multi-line text will overflow,
+            // rendering an actual element in the DOM might be more accurate
+            // but might not be performant for large lists
+            const textWidth = StringHelper.getTextWidth(
+                displayText,
+                `${fontSize}rem '${fontFamily}'`
+            );
+
+            // there's less space than expected due to word breaks, so an
+            // arbitary offset is applied
+            return textWidth > width * maxLines - 50;
+        },
+        [width, displayType, fontSize, fontFamily, maxLines]
+    );
+
+    // =========================================================================
+    // CONST, STATE, REFS
+    // =========================================================================
+    const shouldTruncateTitle = useMemo(
+        () => hasExceededContainer(label),
+        [hasExceededContainer, label]
+    );
+    const shouldTruncateLabel = useMemo(
+        () => sublabel && hasExceededContainer(sublabel),
+        [hasExceededContainer, sublabel]
+    );
+
+    // css cannot truncate inline elements so force the display to render
+    // them separately
+    const itemDisplayType =
+        shouldTruncateTitle || shouldTruncateLabel ? "next-line" : displayType;
+
+    // =========================================================================
+    // RENDER FUNCTIONS
+    // =========================================================================
+    const renderTruncatedText = (displayText: string): JSX.Element => {
+        return (
+            <>
+                <TruncateFirstLine $maxLines={maxLines} aria-hidden>
+                    {displayText}
+                </TruncateFirstLine>
+                <TruncateSecondLine $maxLines={maxLines} aria-hidden>
+                    {displayText}
+                </TruncateSecondLine>
+            </>
+        );
+    };
+
+    return (
+        <Label ref={ref} $labelDisplayType={itemDisplayType}>
+            <PrimaryText
+                aria-label={label}
+                $maxLines={maxLines}
+                $selected={selected}
+                $truncateType={truncationType}
+                $variant={variant}
+            >
+                {truncationType === "middle" && shouldTruncateTitle
+                    ? renderTruncatedText(label)
+                    : label}
+            </PrimaryText>
+            {sublabel && (
+                <SecondaryText
+                    aria-label={sublabel}
+                    $maxLines={maxLines}
+                    $truncateType={truncationType}
+                    $labelDisplayType={displayType}
+                >
+                    {truncationType === "middle" && shouldTruncateLabel
+                        ? renderTruncatedText(sublabel)
+                        : sublabel}
+                </SecondaryText>
+            )}
+        </Label>
+    );
+};

--- a/src/shared/dropdown-list-v2/dropdown-list-state.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list-state.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from "react";
+
+interface DropdownListStateProps {
+    children: React.ReactNode;
+}
+
+interface DropdownListStateContext {
+    focusedIndex: number;
+    setFocusedIndex: React.Dispatch<React.SetStateAction<number>>;
+}
+
+export const DropdownListStateContext =
+    React.createContext<DropdownListStateContext>({
+        focusedIndex: -1,
+        setFocusedIndex: () => {
+            // do nothing
+        },
+    });
+
+export const DropdownListState = ({ children }: DropdownListStateProps) => {
+    const [focusedIndex, setFocusedIndex] = useState<number>(-1);
+
+    return (
+        <DropdownListStateContext.Provider
+            value={{
+                focusedIndex,
+                setFocusedIndex,
+            }}
+        >
+            {children}
+        </DropdownListStateContext.Provider>
+    );
+};

--- a/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
@@ -30,18 +30,13 @@ export const Container = styled.div`
     background: ${Color.Neutral[8]};
 
     width: 23rem;
+    max-height: 27rem;
+    overflow-y: auto;
 
     ${MediaQuery.MaxWidth.mobileL} {
         width: calc(100vw - 2.5rem);
+        max-height: 15rem;
     }
-`;
-
-export const List = styled.div`
-    background: transparent;
-    max-height: 27rem;
-    overflow-y: auto;
-    padding: 0.5rem;
-    list-style-type: none;
 
     ::-webkit-scrollbar {
         width: 14px;
@@ -57,10 +52,12 @@ export const List = styled.div`
         border-radius: 9999px;
         background-clip: padding-box;
     }
+`;
 
-    ${MediaQuery.MaxWidth.mobileL} {
-        max-height: 15rem;
-    }
+export const List = styled.div`
+    background: transparent;
+    padding: 0.5rem;
+    list-style-type: none;
 `;
 
 // -----------------------------------------------------------------------------

--- a/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
@@ -11,6 +11,10 @@ import { DropdownVariantType } from "../dropdown-list/types";
 // =============================================================================
 // STYLE INTERFACE
 // =============================================================================
+interface ContainerStyleProps {
+    $width?: number;
+}
+
 interface ListStyleProps {
     $variant?: DropdownVariantType;
 }
@@ -23,17 +27,19 @@ interface ListStyleProps {
 // MAIN STYLES
 // -----------------------------------------------------------------------------
 
-export const Container = styled.div`
+export const Container = styled.div<ContainerStyleProps>`
     overflow: hidden;
     border: 1px solid ${Color.Neutral[5]};
     border-radius: 4px;
     background: ${Color.Neutral[8]};
 
-    width: 23rem;
+    min-width: 23rem;
+    ${(props) => props.$width && `width: ${props.$width}px;`}
     max-height: 27rem;
     overflow-y: auto;
 
     ${MediaQuery.MaxWidth.mobileL} {
+        min-width: unset;
         width: calc(100vw - 2.5rem);
         max-height: 15rem;
     }

--- a/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
@@ -28,6 +28,12 @@ export const Container = styled.div`
     border: 1px solid ${Color.Neutral[5]};
     border-radius: 4px;
     background: ${Color.Neutral[8]};
+
+    width: 23rem;
+
+    ${MediaQuery.MaxWidth.mobileL} {
+        width: calc(100vw - 2.5rem);
+    }
 `;
 
 export const List = styled.div`

--- a/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
@@ -156,7 +156,7 @@ export const ResultStateText = styled.div<ListStyleProps>`
 
 export const LabelIcon = styled(ExclamationCircleFillIcon)<ListStyleProps>`
     ${(props) => {
-        const size = props.$variant === "small" ? 1 : 1.5;
+        const size = props.$variant === "small" ? 1 : 1.125;
         return css`
             height: ${size}rem;
             width: ${size}rem;

--- a/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
@@ -63,6 +63,9 @@ export const Container = styled.div<ContainerStyleProps>`
 export const List = styled.div`
     background: transparent;
     padding: 0.5rem;
+`;
+
+export const Listbox = styled.ul`
     list-style-type: none;
 `;
 

--- a/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
@@ -1,0 +1,158 @@
+import { ExclamationCircleFillIcon } from "@lifesg/react-icons/exclamation-circle-fill";
+import { SquareIcon } from "@lifesg/react-icons/square";
+import { SquareFillIcon } from "@lifesg/react-icons/square-fill";
+import { TickIcon } from "@lifesg/react-icons/tick";
+import styled, { css } from "styled-components";
+import { Color } from "../../color";
+import { MediaQuery } from "../../media";
+import { TextStyleHelper } from "../../text";
+import { DropdownVariantType } from "../dropdown-list/types";
+
+// =============================================================================
+// STYLE INTERFACE
+// =============================================================================
+interface ListStyleProps {
+    $variant?: DropdownVariantType;
+}
+
+// =============================================================================
+// STYLING
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// MAIN STYLES
+// -----------------------------------------------------------------------------
+
+export const Container = styled.div`
+    overflow: hidden;
+    border: 1px solid ${Color.Neutral[5]};
+    border-radius: 4px;
+    background: ${Color.Neutral[8]};
+`;
+
+export const List = styled.div`
+    background: transparent;
+    max-height: 27rem;
+    overflow-y: auto;
+    padding: 0.5rem;
+    list-style-type: none;
+
+    ::-webkit-scrollbar {
+        width: 9px;
+    }
+
+    ::-webkit-scrollbar-track {
+        background: transparent;
+    }
+
+    ::-webkit-scrollbar-thumb {
+        background: ${Color.Neutral[4]};
+        border-right: 5px solid ${Color.Neutral[8]};
+        border-top-right-radius: 4px;
+        border-bottom-right-radius: 4px;
+    }
+
+    ${MediaQuery.MaxWidth.mobileL} {
+        max-height: 15rem;
+    }
+`;
+
+// -----------------------------------------------------------------------------
+// LIST ITEM STYLES
+// -----------------------------------------------------------------------------
+
+export const ListItem = styled.li<ListStyleProps>`
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding: 0.75rem 0.5rem;
+    cursor: pointer;
+
+    outline-color: ${Color.Accent.Light[3]};
+
+    :hover,
+    :focus,
+    :active {
+        background: ${Color.Accent.Light[5]};
+    }
+`;
+
+export const SelectedIndicator = styled(TickIcon)`
+    flex-shrink: 0;
+    height: 1.625rem;
+    width: 1rem;
+    color: ${Color.Primary};
+`;
+
+export const UnselectedIndicator = styled.div`
+    flex-shrink: 0;
+    height: 1.625rem;
+    width: 1rem;
+`;
+
+export const CheckboxSelectedIndicator = styled(SquareFillIcon)`
+    flex-shrink: 0;
+    height: 1.625rem;
+    width: 1.625rem;
+    color: ${Color.Primary};
+`;
+
+export const CheckboxUnselectedIndicator = styled(SquareIcon)`
+    flex-shrink: 0;
+    height: 1.625rem;
+    width: 1.625rem;
+    color: ${Color.Accent.Light[2]};
+`;
+
+// -----------------------------------------------------------------------------
+// ELEMENT STYLES
+// -----------------------------------------------------------------------------
+
+export const SelectAllContainer = styled.div`
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+    padding: 1rem 0 0.5rem 0;
+`;
+
+export const DropdownCommonButton = styled.button<ListStyleProps>`
+    ${(props) =>
+        TextStyleHelper.getTextStyle(
+            props.$variant === "small" ? "BodySmall" : "Body",
+            "semibold"
+        )}
+    background-color: transparent;
+    background-repeat: no-repeat;
+    border: none;
+    cursor: pointer;
+    overflow: hidden;
+    outline: none;
+    color: ${Color.Primary};
+`;
+
+export const ResultStateContainer = styled.div`
+    width: 100%;
+    display: flex;
+    padding: 1rem 0.5rem;
+    align-items: center;
+`;
+
+export const ResultStateText = styled.div<ListStyleProps>`
+    ${(props) =>
+        TextStyleHelper.getTextStyle(
+            props.$variant === "small" ? "BodySmall" : "Body",
+            "regular"
+        )}
+`;
+
+export const LabelIcon = styled(ExclamationCircleFillIcon)<ListStyleProps>`
+    ${(props) => {
+        const size = props.$variant === "small" ? 1 : 1.5;
+        return css`
+            height: ${size}rem;
+            width: ${size}rem;
+        `;
+    }}
+    margin-right: 0.625rem;
+    color: ${Color.Validation.Red.Icon};
+`;

--- a/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
@@ -44,7 +44,7 @@ export const List = styled.div`
     list-style-type: none;
 
     ::-webkit-scrollbar {
-        width: 9px;
+        width: 14px;
     }
 
     ::-webkit-scrollbar-track {
@@ -53,9 +53,9 @@ export const List = styled.div`
 
     ::-webkit-scrollbar-thumb {
         background: ${Color.Neutral[4]};
-        border-right: 5px solid ${Color.Neutral[8]};
-        border-top-right-radius: 4px;
-        border-bottom-right-radius: 4px;
+        border: 5px solid transparent;
+        border-radius: 9999px;
+        background-clip: padding-box;
     }
 
     ${MediaQuery.MaxWidth.mobileL} {

--- a/src/shared/dropdown-list-v2/dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.tsx
@@ -120,15 +120,6 @@ export const DropdownList = <T, V>({
         });
     });
 
-    const hasNextLineLabel = () => {
-        return (
-            labelDisplayType === "next-line" &&
-            displayListItems.length > 0 &&
-            listExtractor &&
-            typeof listExtractor(displayListItems[0]) !== "string"
-        );
-    };
-
     // =========================================================================
     // EVENT HANDLERS
     // =========================================================================

--- a/src/shared/dropdown-list-v2/dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.tsx
@@ -157,8 +157,12 @@ export const DropdownList = <T, V>({
                 }
                 break;
             case "Space":
-                event.preventDefault();
-                handleListItemClick(displayListItems[focusedIndex]);
+                if (document.activeElement !== searchInputRef.current) {
+                    event.preventDefault();
+                    if (displayListItems[focusedIndex]) {
+                        handleListItemClick(displayListItems[focusedIndex]);
+                    }
+                }
                 break;
             default:
                 break;

--- a/src/shared/dropdown-list-v2/dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.tsx
@@ -41,6 +41,7 @@ export const DropdownList = <T, V>({
     labelDisplayType = "inline",
     variant = "default",
     listboxId,
+    width,
     onSelectItem,
     onSelectAll,
     onDismiss,
@@ -460,7 +461,11 @@ export const DropdownList = <T, V>({
     };
 
     return (
-        <Container data-testid="dropdown-container" ref={nodeRef}>
+        <Container
+            data-testid="dropdown-container"
+            ref={nodeRef}
+            $width={width}
+        >
             {renderList()}
             {renderBottomCta()}
         </Container>

--- a/src/shared/dropdown-list-v2/dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.tsx
@@ -163,9 +163,7 @@ export const DropdownList = <T, V>({
 
     const handleListItemClick = (item: T, upcomingIndex: number) => {
         setFocusedIndex(upcomingIndex);
-        if (onSelectItem) {
-            onSelectItem(item, getValue(item));
-        }
+        onSelectItem?.(item, getValue(item));
     };
 
     const handleSearchInputChange = (
@@ -174,18 +172,18 @@ export const DropdownList = <T, V>({
         const value = event.target.value;
         setSearchValue(value);
 
-        if (onSearch) onSearch();
+        onSearch?.();
     };
 
     const handleOnClear = () => {
         setSearchValue("");
         searchInputRef.current.focus();
 
-        if (onSearch) onSearch();
+        onSearch?.();
     };
 
     const handleTryAgain = () => {
-        if (onRetry) onRetry();
+        onRetry?.();
     };
 
     // =========================================================================

--- a/src/shared/dropdown-list-v2/dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.tsx
@@ -396,7 +396,7 @@ export const DropdownList = <T, V>({
 
     const renderLoading = () => {
         if (onRetry && itemsLoadState === "loading") {
-            const spinnerSize = variant === "small" ? 16 : 24;
+            const spinnerSize = variant === "small" ? 16 : 18;
 
             return (
                 <ResultStateContainer data-testid="list-loading">

--- a/src/shared/dropdown-list-v2/dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.tsx
@@ -40,6 +40,7 @@ export const DropdownList = <T, V>({
     itemMaxLines = 2,
     labelDisplayType = "inline",
     variant = "default",
+    listboxId,
     onSelectItem,
     onSelectAll,
     onDismiss,
@@ -435,7 +436,9 @@ export const DropdownList = <T, V>({
                 {renderNoResults()}
                 {renderLoading()}
                 {renderTryAgain()}
-                <ul role="listbox">{renderItems()}</ul>
+                <ul role="listbox" id={listboxId}>
+                    {renderItems()}
+                </ul>
             </List>
         );
     };

--- a/src/shared/dropdown-list-v2/dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.tsx
@@ -157,7 +157,10 @@ export const DropdownList = <T, V>({
                 if (document.activeElement !== searchInputRef.current) {
                     event.preventDefault();
                     if (displayListItems[focusedIndex]) {
-                        handleListItemClick(displayListItems[focusedIndex]);
+                        handleListItemClick(
+                            displayListItems[focusedIndex],
+                            focusedIndex
+                        );
                     }
                 }
                 break;
@@ -166,7 +169,8 @@ export const DropdownList = <T, V>({
         }
     };
 
-    const handleListItemClick = (item: T) => {
+    const handleListItemClick = (item: T, upcomingIndex: number) => {
+        setFocusedIndex(upcomingIndex);
         if (onSelectItem) {
             onSelectItem(item, getValue(item));
         }
@@ -310,7 +314,7 @@ export const DropdownList = <T, V>({
                         aria-multiselectable={multiSelect}
                         data-testid="list-item"
                         key={getItemKey(item, index)}
-                        onClick={() => handleListItemClick(item)}
+                        onClick={() => handleListItemClick(item, index)}
                         ref={(element) =>
                             (listItemRefs.current[index] = element)
                         }

--- a/src/shared/dropdown-list-v2/dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.tsx
@@ -18,6 +18,7 @@ import {
     LabelIcon,
     List,
     ListItem,
+    Listbox,
     ResultStateContainer,
     ResultStateText,
     SelectAllContainer,
@@ -430,9 +431,9 @@ export const DropdownList = <T, V>({
                 {renderNoResults()}
                 {renderLoading()}
                 {renderTryAgain()}
-                <ul role="listbox" id={listboxId}>
+                <Listbox role="listbox" id={listboxId}>
                     {renderItems()}
-                </ul>
+                </Listbox>
             </List>
         );
     };

--- a/src/shared/dropdown-list-v2/dropdown-search.styles.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-search.styles.tsx
@@ -1,0 +1,67 @@
+import { MagnifierIcon } from "@lifesg/react-icons/magnifier";
+import styled, { css } from "styled-components";
+import { Color } from "../../color";
+import { ClickableIcon } from "../clickable-icon";
+import { DropdownVariantType } from "../dropdown-list/types";
+import { BasicInput, InputStyleProps } from "../input-wrapper/input-wrapper";
+
+//=============================================================================
+// STYLE INTERFACE
+//=============================================================================
+export interface IconStyleProps {
+    $variant?: DropdownVariantType | undefined;
+}
+
+//=============================================================================
+// STYLING
+//=============================================================================
+const getIconSize = (variant?: DropdownVariantType) => {
+    return variant === "small" ? 1 : 1.125;
+};
+
+const getIconDimensions = (variant?: DropdownVariantType) => {
+    return css`
+        height: ${getIconSize(variant)}rem;
+        width: ${getIconSize(variant)}rem;
+    `;
+};
+
+export const Container = styled.li`
+    background: ${Color.Neutral[7]};
+    border-radius: 4px;
+
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 0.5rem;
+`;
+
+export const SearchInput = styled(BasicInput)<InputStyleProps>`
+    height: ${(props) => (props.$variant === "small" ? 2.5 : 3)}rem;
+    flex: 1;
+    padding: 0;
+    height: auto;
+`;
+
+export const SearchIcon = styled(MagnifierIcon)<IconStyleProps>`
+    color: ${Color.Neutral[3]};
+    flex-shrink: 0;
+    ${(props) => {
+        return getIconDimensions(props.$variant);
+    }}
+`;
+
+export const ClearButton = styled(ClickableIcon)<IconStyleProps>`
+    margin: -0.9375rem -0.4375rem;
+    padding: 0.9375rem 0.4375rem;
+    color: ${Color.Neutral[3]};
+    cursor: pointer;
+
+    ${(props) => {
+        return css`
+            svg {
+                ${getIconDimensions(props.$variant)}
+            }
+        `;
+    }}
+`;

--- a/src/shared/dropdown-list-v2/dropdown-search.styles.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-search.styles.tsx
@@ -8,7 +8,7 @@ import { BasicInput, InputStyleProps } from "../input-wrapper/input-wrapper";
 //=============================================================================
 // STYLE INTERFACE
 //=============================================================================
-export interface IconStyleProps {
+export interface StyleProps {
     $variant?: DropdownVariantType | undefined;
 }
 
@@ -26,14 +26,16 @@ const getIconDimensions = (variant?: DropdownVariantType) => {
     `;
 };
 
-export const Container = styled.li`
+export const Container = styled.div<StyleProps>`
     background: ${Color.Neutral[7]};
     border-radius: 4px;
 
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    padding: 0.75rem 0.5rem;
+    padding: ${(props) =>
+        props.$variant === "small" ? "0.4375rem 0.5rem" : "0.75rem 0.5rem"};
+    margin: 0.5rem 0;
 `;
 
 export const SearchInput = styled(BasicInput)<InputStyleProps>`
@@ -43,7 +45,7 @@ export const SearchInput = styled(BasicInput)<InputStyleProps>`
     height: auto;
 `;
 
-export const SearchIcon = styled(MagnifierIcon)<IconStyleProps>`
+export const SearchIcon = styled(MagnifierIcon)<StyleProps>`
     color: ${Color.Neutral[3]};
     flex-shrink: 0;
     ${(props) => {
@@ -51,7 +53,7 @@ export const SearchIcon = styled(MagnifierIcon)<IconStyleProps>`
     }}
 `;
 
-export const ClearButton = styled(ClickableIcon)<IconStyleProps>`
+export const ClearButton = styled(ClickableIcon)<StyleProps>`
     margin: -0.9375rem -0.4375rem;
     padding: 0.9375rem 0.4375rem;
     color: ${Color.Neutral[3]};

--- a/src/shared/dropdown-list-v2/dropdown-search.styles.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-search.styles.tsx
@@ -26,16 +26,20 @@ const getIconDimensions = (variant?: DropdownVariantType) => {
     `;
 };
 
-export const Container = styled.div<StyleProps>`
+export const Container = styled.div`
     background: ${Color.Neutral[7]};
     border-radius: 4px;
+    display: flex;
+    align-items: center;
+`;
 
+export const SearchBox = styled.label<StyleProps>`
+    flex: 1;
     display: flex;
     align-items: center;
     gap: 0.5rem;
     padding: ${(props) =>
-        props.$variant === "small" ? "0.4375rem 0.5rem" : "0.75rem 0.5rem"};
-    margin: 0.5rem 0;
+        props.$variant === "small" ? "0.4375rem 0.5rem" : "0.6875rem 0.5rem"};
 `;
 
 export const SearchInput = styled(BasicInput)<InputStyleProps>`
@@ -54,8 +58,10 @@ export const SearchIcon = styled(MagnifierIcon)<StyleProps>`
 `;
 
 export const ClearButton = styled(ClickableIcon)<StyleProps>`
-    margin: -0.9375rem -0.4375rem;
-    padding: 0.9375rem 0.4375rem;
+    align-self: stretch;
+    box-sizing: content-box;
+    padding: 0 0.5rem;
+    margin-left: -0.5rem;
     color: ${Color.Neutral[3]};
     cursor: pointer;
 

--- a/src/shared/dropdown-list-v2/dropdown-search.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-search.tsx
@@ -11,7 +11,7 @@ import {
 interface Props extends React.HTMLAttributes<HTMLInputElement> {
     value: string /** override to cast type */;
     variant?: DropdownVariantType | undefined;
-    onClear?: () => void | undefined;
+    onClear?: (() => void) | undefined;
 }
 
 const Component = (

--- a/src/shared/dropdown-list-v2/dropdown-search.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-search.tsx
@@ -1,0 +1,44 @@
+import { CrossIcon } from "@lifesg/react-icons/cross";
+import React, { forwardRef } from "react";
+import { DropdownVariantType } from "../dropdown-list/types";
+import {
+    ClearButton,
+    Container,
+    SearchIcon,
+    SearchInput,
+} from "./dropdown-search.styles";
+
+interface Props extends React.HTMLAttributes<HTMLInputElement> {
+    value: string /** override to cast type */;
+    variant?: DropdownVariantType | undefined;
+    onClear?: () => void | undefined;
+}
+
+const Component = (
+    { value, variant, onClear, ...otherProps }: Props,
+    ref: React.Ref<HTMLInputElement>
+): JSX.Element => {
+    return (
+        <Container>
+            <SearchIcon $variant={variant} />
+            <SearchInput
+                ref={ref}
+                value={value}
+                $variant={variant}
+                {...otherProps}
+            />
+            {value && (
+                <ClearButton
+                    aria-label="Clear search"
+                    focusOutline="browser"
+                    onClick={onClear}
+                    $variant={variant}
+                >
+                    <CrossIcon aria-hidden />
+                </ClearButton>
+            )}
+        </Container>
+    );
+};
+
+export const DropdownSearch = forwardRef(Component);

--- a/src/shared/dropdown-list-v2/dropdown-search.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-search.tsx
@@ -4,6 +4,7 @@ import { DropdownVariantType } from "../dropdown-list/types";
 import {
     ClearButton,
     Container,
+    SearchBox,
     SearchIcon,
     SearchInput,
 } from "./dropdown-search.styles";
@@ -19,14 +20,16 @@ const Component = (
     ref: React.Ref<HTMLInputElement>
 ): JSX.Element => {
     return (
-        <Container $variant={variant}>
-            <SearchIcon $variant={variant} />
-            <SearchInput
-                ref={ref}
-                value={value}
-                $variant={variant}
-                {...otherProps}
-            />
+        <Container>
+            <SearchBox>
+                <SearchIcon $variant={variant} aria-hidden />
+                <SearchInput
+                    ref={ref}
+                    value={value}
+                    $variant={variant}
+                    {...otherProps}
+                />
+            </SearchBox>
             {value && (
                 <ClearButton
                     aria-label="Clear search"

--- a/src/shared/dropdown-list-v2/dropdown-search.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-search.tsx
@@ -19,7 +19,7 @@ const Component = (
     ref: React.Ref<HTMLInputElement>
 ): JSX.Element => {
     return (
-        <Container>
+        <Container $variant={variant}>
             <SearchIcon $variant={variant} />
             <SearchInput
                 ref={ref}

--- a/src/shared/dropdown-list-v2/expandable-element.styles.tsx
+++ b/src/shared/dropdown-list-v2/expandable-element.styles.tsx
@@ -8,10 +8,8 @@ import { DropdownVariantType } from "./types";
 // =============================================================================
 // STYLE INTERFACE
 // =============================================================================
-export interface StyleProps {
-    $disabled?: boolean;
+interface StyleProps {
     $expanded?: boolean;
-    $readOnly?: boolean;
     $variant?: DropdownVariantType;
 }
 

--- a/src/shared/dropdown-list-v2/expandable-element.styles.tsx
+++ b/src/shared/dropdown-list-v2/expandable-element.styles.tsx
@@ -1,0 +1,58 @@
+import styled, { css } from "styled-components";
+import { Color } from "../../color";
+import { TextStyle, TextStyleHelper } from "../../text";
+import { Transition } from "../../transition";
+import { BasicButton } from "../input-wrapper/input-wrapper";
+import { DropdownVariantType } from "./types";
+
+// =============================================================================
+// STYLE INTERFACE
+// =============================================================================
+export interface StyleProps {
+    $disabled?: boolean;
+    $expanded?: boolean;
+    $readOnly?: boolean;
+    $variant?: DropdownVariantType;
+}
+
+// =============================================================================
+// STYLING
+// =============================================================================
+export const Selector = styled(BasicButton)<StyleProps>`
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.6875rem 1rem;
+
+    ${(props) =>
+        TextStyleHelper.getTextStyle(
+            props.$variant === "small" ? "BodySmall" : "Body",
+            "regular"
+        )}
+
+    :disabled {
+        cursor: not-allowed;
+    }
+`;
+
+export const IconContainer = styled.div<StyleProps>`
+    display: flex;
+    align-items: center;
+    transform: rotate(${(props) => (props.$expanded ? 180 : 0)}deg);
+    transition: ${Transition.Base};
+
+    svg {
+        color: ${Color.Neutral[3]};
+        ${(props) => {
+            const size =
+                props.$variant === "small"
+                    ? TextStyle.BodySmall.fontSize
+                    : TextStyle.Body.fontSize;
+            return css`
+                height: ${size}rem;
+                width: ${size}rem;
+            `;
+        }}
+    }
+`;

--- a/src/shared/dropdown-list-v2/expandable-element.styles.tsx
+++ b/src/shared/dropdown-list-v2/expandable-element.styles.tsx
@@ -23,7 +23,8 @@ export const Selector = styled(BasicButton)<StyleProps>`
     align-items: center;
     gap: 0.5rem;
     width: 100%;
-    padding: 0.6875rem 1rem;
+    padding: ${(props) =>
+        props.$variant === "small" ? "0.4375rem 1rem" : "0.6875rem 1rem"};
 
     ${(props) =>
         TextStyleHelper.getTextStyle(

--- a/src/shared/dropdown-list-v2/expandable-element.tsx
+++ b/src/shared/dropdown-list-v2/expandable-element.tsx
@@ -36,6 +36,7 @@ export const Component = (
             disabled={disabled}
             aria-controls={id}
             $readOnly={readOnly}
+            $variant={variant}
         >
             {children}
             {!readOnly && (

--- a/src/shared/dropdown-list-v2/expandable-element.tsx
+++ b/src/shared/dropdown-list-v2/expandable-element.tsx
@@ -35,7 +35,6 @@ export const Component = (
             data-testid="selector"
             disabled={disabled}
             aria-controls={id}
-            $readOnly={readOnly}
             $variant={variant}
         >
             {children}

--- a/src/shared/dropdown-list-v2/expandable-element.tsx
+++ b/src/shared/dropdown-list-v2/expandable-element.tsx
@@ -1,0 +1,50 @@
+import { ChevronDownIcon } from "@lifesg/react-icons/chevron-down";
+import { Ref, forwardRef } from "react";
+import { IconContainer, Selector } from "./expandable-element.styles";
+import { DropdownVariantType } from "./types";
+
+interface ExpandableElementProps {
+    children: React.ReactNode;
+    disabled: boolean;
+    expanded: boolean;
+    id: string;
+    readOnly: boolean;
+    variant: DropdownVariantType;
+}
+
+export const Component = (
+    {
+        children,
+        disabled,
+        expanded,
+        id,
+        readOnly,
+        variant,
+    }: ExpandableElementProps,
+    ref: Ref<HTMLButtonElement>
+) => {
+    // =============================================================================
+    // RENDER FUNCTION
+    // =============================================================================
+    return (
+        <Selector
+            ref={ref}
+            type="button"
+            aria-expanded={expanded}
+            aria-haspopup="listbox"
+            data-testid="selector"
+            disabled={disabled}
+            aria-controls={id}
+            $readOnly={readOnly}
+        >
+            {children}
+            {!readOnly && (
+                <IconContainer $expanded={expanded} $variant={variant}>
+                    <ChevronDownIcon aria-hidden />
+                </IconContainer>
+            )}
+        </Selector>
+    );
+};
+
+export const ExpandableElement = forwardRef(Component);

--- a/src/shared/dropdown-list-v2/index.ts
+++ b/src/shared/dropdown-list-v2/index.ts
@@ -1,0 +1,3 @@
+export * from "./dropdown-label";
+export * from "./dropdown-list";
+export * from "./dropdown-list-state";

--- a/src/shared/dropdown-list-v2/index.ts
+++ b/src/shared/dropdown-list-v2/index.ts
@@ -1,3 +1,4 @@
 export * from "./dropdown-label";
 export * from "./dropdown-list";
 export * from "./dropdown-list-state";
+export * from "./expandable-element";

--- a/src/shared/dropdown-list-v2/types.ts
+++ b/src/shared/dropdown-list-v2/types.ts
@@ -1,0 +1,71 @@
+export type TruncateType = "middle" | "end";
+export type ItemsLoadStateType = "loading" | "fail" | "success";
+export type LabelDisplayType = "inline" | "next-line";
+export type DropdownVariantType = "small" | "default";
+
+export interface ListItemRenderArgs {
+    selected: boolean;
+}
+
+export interface ListItemDisplayProps {
+    title: string;
+    secondaryLabel?: string | undefined;
+}
+
+export interface DropdownDisplayProps<T, V> {
+    /** Function to derive value from an item */
+    valueExtractor?: ((item: T) => V) | undefined;
+    /** Function to derive options display value from an item */
+    listExtractor?: ((item: T) => string | ListItemDisplayProps) | undefined;
+    /** Function to render custom component */
+    renderListItem?:
+        | ((item: T, args: ListItemRenderArgs) => JSX.Element)
+        | undefined;
+    /**
+     * Function to render a custom call-to-action component at the bottom of the dropdown list.
+     * @param hideOptions - A function that can be called to hide the dropdown list.
+     * @param options - The currently displayed list items in the dropdown list.
+     * @returns A JSX.Element representing the custom call-to-action component.
+     */
+    renderCustomCallToAction?:
+        | ((hideOptions: () => void, options: T[]) => JSX.Element)
+        | undefined;
+}
+
+export interface DropdownSearchProps<T> {
+    /** Specifying will render a search bar in the dropdown */
+    enableSearch?: boolean | undefined;
+    /** If specified, the default no results display will not be rendered */
+    hideNoResultsDisplay?: boolean | undefined;
+    searchPlaceholder?: string | undefined;
+    /** Custom function to perform search when a user keys in a value in the search input */
+    searchFunction?: ((searchValue: string) => T[]) | undefined;
+    onSearch?: (() => void) | undefined;
+}
+
+export interface DropdownListProps<T, V>
+    extends DropdownDisplayProps<T, V>,
+        DropdownSearchProps<T> {
+    listItems?: T[] | undefined;
+    multiSelect?: boolean | undefined;
+    selectedItems?: T[] | undefined;
+    disableItemFocus?: boolean | undefined;
+    /**
+     * Used when items are loaded from an api call.
+     * Values: "loading" | "fail" | "success"
+     */
+    itemsLoadState?: ItemsLoadStateType | undefined;
+    /** Specifies the truncation type. Truncated text will be replaced with ellipsis. Values: "middle" | "end" */
+    itemTruncationType?: TruncateType | undefined;
+    /** Specifies the maximum number of lines visible before the label is truncated for "end" type */
+    itemMaxLines?: number | undefined;
+    /** Specifying flex direction within item */
+    labelDisplayType?: LabelDisplayType | undefined;
+    /** Specifies the variant type. Small type will have shorter height. Values: "default" | "small" */
+    variant?: DropdownVariantType | undefined;
+
+    onSelectItem?: ((item: T, extractedValue: V) => void) | undefined;
+    onSelectAll?: (() => void) | undefined;
+    onDismiss?: ((setSelectorFocus?: boolean | undefined) => void) | undefined;
+    onRetry?: (() => void) | undefined;
+}

--- a/src/shared/dropdown-list-v2/types.ts
+++ b/src/shared/dropdown-list-v2/types.ts
@@ -50,6 +50,7 @@ export interface DropdownListProps<T, V>
     multiSelect?: boolean | undefined;
     selectedItems?: T[] | undefined;
     disableItemFocus?: boolean | undefined;
+    listboxId?: string | undefined;
     /**
      * Used when items are loaded from an api call.
      * Values: "loading" | "fail" | "success"

--- a/src/shared/dropdown-list-v2/types.ts
+++ b/src/shared/dropdown-list-v2/types.ts
@@ -51,6 +51,7 @@ export interface DropdownListProps<T, V>
     selectedItems?: T[] | undefined;
     disableItemFocus?: boolean | undefined;
     listboxId?: string | undefined;
+    width?: number | undefined;
     /**
      * Used when items are loaded from an api call.
      * Values: "loading" | "fail" | "success"

--- a/src/shared/dropdown-wrapper/element-with-dropdown.styles.tsx
+++ b/src/shared/dropdown-wrapper/element-with-dropdown.styles.tsx
@@ -1,0 +1,8 @@
+import styled from "styled-components";
+
+// hack to force child to respect max-height of parent
+// even though parent does not have explicit height
+export const DropdownContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+`;

--- a/src/shared/dropdown-wrapper/element-with-dropdown.tsx
+++ b/src/shared/dropdown-wrapper/element-with-dropdown.tsx
@@ -8,6 +8,7 @@ import {
     limitShift,
     offset,
     shift,
+    size,
     useClick,
     useDismiss,
     useFloating,
@@ -16,6 +17,7 @@ import {
 } from "@floating-ui/react";
 import { useRef } from "react";
 import { useResizeDetector } from "react-resize-detector";
+import { DropdownContainer } from "./element-with-dropdown.styles";
 import { DropdownAlignmentType } from "./types";
 
 export interface DropdownRenderProps {
@@ -36,6 +38,7 @@ interface ElementWithDropdownProps {
     offset?: number | undefined;
     /* the alignment of the dropdown to the left or right of the reference element */
     alignment?: DropdownAlignmentType | undefined;
+    fitAvailableHeight?: boolean | undefined;
 }
 
 const getFloatingPlacement = (alignment: DropdownAlignmentType): Placement => {
@@ -60,6 +63,7 @@ export const ElementWithDropdown = ({
     clickToToggle = false,
     offset: dropdownOffset = 0,
     alignment = "left",
+    fitAvailableHeight,
 }: ElementWithDropdownProps) => {
     // =============================================================================
     // CONST, STATE, REF
@@ -88,6 +92,17 @@ export const ElementWithDropdown = ({
             flip(),
             shift({
                 limiter: limitShift(),
+            }),
+            size({
+                // shrink to fit available vertical space
+                apply({ availableHeight }) {
+                    Object.assign(dropdownRef.current.style, {
+                        maxHeight: fitAvailableHeight
+                            ? `${availableHeight}px`
+                            : undefined,
+                        overflowY: fitAvailableHeight ? "hidden" : undefined,
+                    });
+                },
             }),
         ],
     });
@@ -130,10 +145,13 @@ export const ElementWithDropdown = ({
                     >
                         <div
                             ref={refs.setFloating}
-                            style={{ ...floatingStyles, zIndex }}
+                            style={{
+                                ...floatingStyles,
+                                zIndex,
+                            }}
                             {...getFloatingProps()}
                         >
-                            <div
+                            <DropdownContainer
                                 ref={dropdownRef}
                                 style={{ ...styles }}
                                 inert={
@@ -145,7 +163,7 @@ export const ElementWithDropdown = ({
                                 {renderDropdown({
                                     elementWidth: referenceWidth,
                                 })}
-                            </div>
+                            </DropdownContainer>
                         </div>
                     </FloatingFocusManager>
                 </FloatingPortal>

--- a/src/shared/dropdown-wrapper/element-with-dropdown.tsx
+++ b/src/shared/dropdown-wrapper/element-with-dropdown.tsx
@@ -1,6 +1,7 @@
 import {
     FloatingFocusManager,
     FloatingPortal,
+    OpenChangeReason,
     autoUpdate,
     flip,
     limitShift,
@@ -19,7 +20,7 @@ interface ElementWithDropdownProps {
     enabled: boolean;
     isOpen: boolean;
     onOpen?: () => void | undefined;
-    onClose?: () => void | undefined;
+    onClose?: (reason: OpenChangeReason) => void | undefined;
     onDismiss?: () => void | undefined;
     renderElement: () => React.ReactNode;
     renderDropdown: () => React.ReactNode;
@@ -52,7 +53,7 @@ export const ElementWithDropdown = ({
             } else if (open && !isOpen) {
                 onOpen?.();
             } else if (!open && isOpen) {
-                onClose?.();
+                onClose?.(reason);
             }
         },
         whileElementsMounted: autoUpdate,

--- a/src/shared/dropdown-wrapper/element-with-dropdown.tsx
+++ b/src/shared/dropdown-wrapper/element-with-dropdown.tsx
@@ -25,6 +25,7 @@ interface ElementWithDropdownProps {
     renderDropdown: () => React.ReactNode;
     zIndex?: number | undefined;
     clickToToggle?: boolean | undefined;
+    offset?: number | undefined;
 }
 
 export const ElementWithDropdown = ({
@@ -37,6 +38,7 @@ export const ElementWithDropdown = ({
     renderDropdown,
     zIndex = 50,
     clickToToggle = false,
+    offset: dropdownOffset = 0,
 }: ElementWithDropdownProps) => {
     // =============================================================================
     // CONST, STATE, REF
@@ -56,7 +58,7 @@ export const ElementWithDropdown = ({
         whileElementsMounted: autoUpdate,
         placement: "bottom-start",
         middleware: [
-            offset(16),
+            offset(dropdownOffset),
             flip(),
             shift({
                 limiter: limitShift(),

--- a/src/shared/dropdown-wrapper/element-with-dropdown.tsx
+++ b/src/shared/dropdown-wrapper/element-with-dropdown.tsx
@@ -2,6 +2,7 @@ import {
     FloatingFocusManager,
     FloatingPortal,
     OpenChangeReason,
+    Placement,
     autoUpdate,
     flip,
     limitShift,
@@ -15,6 +16,7 @@ import {
     useTransitionStyles,
 } from "@floating-ui/react";
 import { useRef } from "react";
+import { DropdownAlignmentType } from "./types";
 
 interface ElementWithDropdownProps {
     enabled: boolean;
@@ -26,8 +28,21 @@ interface ElementWithDropdownProps {
     renderDropdown: () => React.ReactNode;
     zIndex?: number | undefined;
     clickToToggle?: boolean | undefined;
+    /* the distance between the reference element and the dropdown */
     offset?: number | undefined;
+    /* the alignment of the dropdown to the left or right of the reference element */
+    alignment?: DropdownAlignmentType | undefined;
 }
+
+const getFloatingPlacement = (alignment: DropdownAlignmentType): Placement => {
+    switch (alignment) {
+        case "right":
+            return "bottom-end";
+        case "left":
+        default:
+            return "bottom-start";
+    }
+};
 
 export const ElementWithDropdown = ({
     enabled,
@@ -40,6 +55,7 @@ export const ElementWithDropdown = ({
     zIndex = 50,
     clickToToggle = false,
     offset: dropdownOffset = 0,
+    alignment = "left",
 }: ElementWithDropdownProps) => {
     // =============================================================================
     // CONST, STATE, REF
@@ -57,7 +73,7 @@ export const ElementWithDropdown = ({
             }
         },
         whileElementsMounted: autoUpdate,
-        placement: "bottom-start",
+        placement: getFloatingPlacement(alignment),
         middleware: [
             offset(dropdownOffset),
             flip(),

--- a/src/shared/dropdown-wrapper/types.ts
+++ b/src/shared/dropdown-wrapper/types.ts
@@ -11,3 +11,5 @@ export interface DropdownSelectorProps {
     className?: string | undefined;
     variant?: DropdownVariantType | undefined;
 }
+
+export type DropdownAlignmentType = "left" | "right";

--- a/src/shared/input-wrapper/input-wrapper.tsx
+++ b/src/shared/input-wrapper/input-wrapper.tsx
@@ -43,18 +43,14 @@ const errorFocusCss = css`
     box-shadow: ${DesignToken.InputErrorBoxShadow};
 `;
 
-export const InputWrapper = styled.div<InputWrapperStyleProps>`
-    display: flex;
-    align-items: center;
-    position: relative;
+/**
+ * basic wrapper for input fields that provides the border style but does not
+ * prescibe any layout for content
+ */
+export const InputBox = styled.div<InputWrapperStyleProps>`
     border: 1px solid ${Color.Neutral[5]};
     border-radius: 4px;
     background: ${Color.Neutral[8]};
-    height: max-content;
-    width: 100%;
-    padding: 0 1rem;
-    flex-direction: ${(props) =>
-        props.$position === "right" ? "row-reverse" : "row"};
 
     :focus-within {
         ${defaultFocusCss}
@@ -94,6 +90,17 @@ export const InputWrapper = styled.div<InputWrapperStyleProps>`
             `;
         }
     }}
+`;
+
+export const InputWrapper = styled(InputBox)<InputWrapperStyleProps>`
+    display: flex;
+    align-items: center;
+    position: relative;
+    height: max-content;
+    width: 100%;
+    padding: 0 1rem;
+    flex-direction: ${(props) =>
+        props.$position === "right" ? "row-reverse" : "row"};
 `;
 
 /**

--- a/src/shared/input-wrapper/input-wrapper.tsx
+++ b/src/shared/input-wrapper/input-wrapper.tsx
@@ -29,7 +29,7 @@ const defaultFocusCss = css`
 `;
 
 const readOnlyFocusCss = css`
-    border: 1px solid transparent;
+    border: 1px solid ${Color.Accent.Light[1]};
     box-shadow: none;
 `;
 
@@ -145,4 +145,18 @@ export const BasicInput = styled.input<InputStyleProps>`
 
     // Firefox
     --moz-appearance: textfield;
+`;
+
+/**
+ * standalone native button with stripped-down styles
+ */
+export const BasicButton = styled.button<InputStyleProps>`
+    background: transparent;
+    border: none;
+    outline: none;
+
+    :focus,
+    :active {
+        outline: none;
+    }
 `;

--- a/src/shared/internal-calendar/calendar-dropdown.style.tsx
+++ b/src/shared/internal-calendar/calendar-dropdown.style.tsx
@@ -1,7 +1,18 @@
 import styled from "styled-components";
 import { MediaQuery } from "../../media";
 
-export const CalendarWrapper = styled.div`
+// =============================================================================
+// STYLE INTERFACE
+// =============================================================================
+interface StyleProps {
+    $width: number;
+}
+
+// =============================================================================
+// STYLING
+// =============================================================================
+export const CalendarWrapper = styled.div<StyleProps>`
+    width: ${(props) => props.$width}px;
     max-width: 41rem;
     min-width: 21rem;
 

--- a/src/shared/internal-calendar/calendar-dropdown.tsx
+++ b/src/shared/internal-calendar/calendar-dropdown.tsx
@@ -1,15 +1,15 @@
 import React from "react";
 import { CalendarWrapper } from "./calendar-dropdown.style";
 import { InternalCalendar } from "./internal-calendar";
-import { InternalCalendarProps, InternalCalendarRef } from "./types";
+import { CalendarDropdownProps, InternalCalendarRef } from "./types";
 
 const Component = (
-    props: InternalCalendarProps,
+    { width, ...otherProps }: CalendarDropdownProps,
     ref: React.ForwardedRef<InternalCalendarRef>
 ) => {
     return (
-        <CalendarWrapper data-testid="calendar-dropdown">
-            <InternalCalendar ref={ref} {...props} />
+        <CalendarWrapper $width={width} data-testid="calendar-dropdown">
+            <InternalCalendar ref={ref} {...otherProps} />
         </CalendarWrapper>
     );
 };

--- a/src/shared/internal-calendar/types.ts
+++ b/src/shared/internal-calendar/types.ts
@@ -47,9 +47,8 @@ export interface InternalCalendarProps extends CommonCalendarProps {
     numberOfDays?: number | undefined;
 }
 
-export interface AnimatedInternalCalendarProps extends InternalCalendarProps {
-    /** If calendar is visible. */
-    isOpen?: boolean | undefined;
+export interface CalendarDropdownProps extends InternalCalendarProps {
+    width: number;
 }
 
 export type CalendarAction = "reset" | "confirmed";

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -7,5 +7,7 @@ export * from "./use-container-query";
 export * from "./use-event";
 export * from "./use-event-listener";
 export * from "./use-isomorphic-layout-effect";
+export * from "./use-mount";
 export * from "./use-next-input-state";
+export * from "./use-previous";
 export * from "./use-state-ref";

--- a/src/util/use-mount.ts
+++ b/src/util/use-mount.ts
@@ -1,0 +1,11 @@
+import { useEffect, useState } from "react";
+
+export const useIsMounted = (): boolean => {
+    const [mounted, setMounted] = useState(false);
+
+    useEffect(() => {
+        setMounted(true);
+    }, []);
+
+    return mounted;
+};

--- a/src/util/use-previous.ts
+++ b/src/util/use-previous.ts
@@ -1,0 +1,19 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Lets you access the previous value of state
+ */
+export const usePrevious = <T>(value: T) => {
+    const currentRef = useRef<T>(value);
+    const previousRef = useRef<T>();
+    useEffect(() => {
+        previousRef.current = currentRef.current;
+        currentRef.current = value;
+    }, [value]);
+    return previousRef.current;
+};
+
+export const useCompare = <T>(value: T) => {
+    const prevValue = usePrevious(value);
+    return prevValue !== value;
+};

--- a/stories/form/form-select/form-select.mdx
+++ b/stories/form/form-select/form-select.mdx
@@ -34,6 +34,14 @@ of the list.
 
 <Canvas of={FormSelectStories.WithCustomCallToAction} />
 
+<Heading3>Label truncation</Heading3>
+
+<Canvas of={FormSelectStories.LabelTruncation} />
+
+<Heading3>Load state display</Heading3>
+
+<Canvas of={FormSelectStories.LoadState} />
+
 <Heading3>Rendering in grid layouts</Heading3>
 
 You can also specify [ColDiv's](/docs/getting-started-layout-column-divs--docs)

--- a/stories/form/form-select/form-select.stories.tsx
+++ b/stories/form/form-select/form-select.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { ComponentProps, useEffect, useState } from "react";
 import { Button } from "src/button";
 import { Form } from "src/form";
 import { InputSelect } from "src/input-select";
@@ -187,6 +188,84 @@ export const WithCustomCallToAction: StoryObj<Component> = {
                                 </CustomCTAContainer>
                             );
                         }}
+                    />
+                </Container>
+            </StoryContainer>
+        );
+    },
+};
+
+export const LabelTruncation: StoryObj<Component> = {
+    render: () => {
+        const options = [
+            "fringilla urna porttitor rhoncus dolor purus non enim",
+            "fringilla urna porttitor rhoncus dolor purus non enim praesent",
+            "fringilla urna porttitor rhoncus dolor purus non enim praesent ele",
+            "fringilla urna porttitor rhoncus dolor purus non enim praesent elem",
+            "fringilla urna porttitor rhoncus dolor purus non enim praesent elementum",
+        ];
+        return (
+            <StoryContainer>
+                <Container>
+                    <Form.Select
+                        label="This has truncation at the end"
+                        options={options}
+                        listExtractor={(item) => ({
+                            title: item,
+                            secondaryLabel: item,
+                        })}
+                    />
+                    <Form.Select
+                        label="This has truncation in the middle"
+                        optionTruncationType="middle"
+                        options={options}
+                        listExtractor={(item) => ({
+                            title: item,
+                            secondaryLabel: item,
+                        })}
+                    />
+                </Container>
+            </StoryContainer>
+        );
+    },
+};
+
+export const LoadState: StoryObj<Component> = {
+    render: () => {
+        const [loadState, setLoadState] =
+            useState<ComponentProps<typeof Form.Select>["optionsLoadState"]>(
+                "loading"
+            );
+        const [results, setResults] = useState([]);
+
+        useEffect(() => {
+            const timer = setTimeout(() => {
+                setLoadState("fail");
+            }, 1500);
+            return () => clearTimeout(timer);
+        }, []);
+
+        const handleRetry = () => {
+            setLoadState("loading");
+            setTimeout(() => {
+                setLoadState("success");
+                setResults(
+                    Array(10)
+                        .fill(0)
+                        .map((_, i) => `Option ${i + 1}`)
+                );
+            }, 1500);
+        };
+
+        return (
+            <StoryContainer>
+                <Container>
+                    <Form.Select
+                        label="This has different load states"
+                        options={results}
+                        enableSearch
+                        optionsLoadState={loadState}
+                        onRetry={handleRetry}
                     />
                 </Container>
             </StoryContainer>

--- a/stories/form/form-select/props-table.tsx
+++ b/stories/form/form-select/props-table.tsx
@@ -176,6 +176,13 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: [`"small"`, `"default"`],
                 defaultValue: `"default"`,
             },
+            {
+                name: "alignment",
+                description:
+                    "Specifies if the dropdown is aligned to the left or right of the main field",
+                propTypes: [`"left"`, `"right"`],
+                defaultValue: `"left"`,
+            },
         ],
     },
     {

--- a/tests/date-input/date-input.spec.tsx
+++ b/tests/date-input/date-input.spec.tsx
@@ -22,6 +22,12 @@ describe("DateInput", () => {
         jest.useFakeTimers({
             doNotFake: ["setInterval", "setTimeout", "requestAnimationFrame"],
         }).setSystemTime(new Date("2024-02-01T12:00:00"));
+
+        global.ResizeObserver = jest.fn().mockImplementation(() => ({
+            observe: jest.fn(),
+            unobserve: jest.fn(),
+            disconnect: jest.fn(),
+        }));
     });
 
     afterEach(() => {

--- a/tests/input-select/input-select.spec.tsx
+++ b/tests/input-select/input-select.spec.tsx
@@ -1,0 +1,266 @@
+import {
+    act,
+    render,
+    screen,
+    waitFor,
+    waitForElementToBeRemoved,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { InputSelect } from "../../src";
+
+const FIELD_TESTID = "test";
+const SELECTOR_TESTID = "selector";
+const DROPDOWN_TESTID = "dropdown-list";
+const OPTIONS = ["Option 1", "Option 2", "Option 3"];
+
+describe("InputSelect", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        global.ResizeObserver = jest.fn().mockImplementation(() => ({
+            observe: jest.fn(),
+            unobserve: jest.fn(),
+            disconnect: jest.fn(),
+        }));
+    });
+
+    it("should render the component", async () => {
+        render(<InputSelect data-testid={FIELD_TESTID} options={OPTIONS} />);
+
+        expect(screen.getByText("Select")).toBeVisible();
+        expect(screen.queryByTestId(DROPDOWN_TESTID)).not.toBeInTheDocument();
+    });
+
+    it("should open dropdown list when selector is clicked", async () => {
+        const user = userEvent.setup();
+
+        render(<InputSelect data-testid={FIELD_TESTID} options={OPTIONS} />);
+
+        await user.click(screen.queryByTestId(FIELD_TESTID));
+
+        await waitFor(() => {
+            expect(screen.queryByTestId(DROPDOWN_TESTID)).toBeVisible();
+        });
+
+        expect(screen.queryByText("Option 1")).toBeVisible();
+        expect(screen.queryByText("Option 2")).toBeVisible();
+        expect(screen.queryByText("Option 3")).toBeVisible();
+    });
+
+    it("should toggle dropdown list when selector is clicked", async () => {
+        const user = userEvent.setup();
+
+        render(<InputSelect data-testid={FIELD_TESTID} options={OPTIONS} />);
+
+        await user.click(screen.queryByTestId(FIELD_TESTID));
+
+        await waitFor(() => {
+            expect(screen.queryByTestId(DROPDOWN_TESTID)).toBeVisible();
+        });
+
+        await user.click(screen.queryByTestId(FIELD_TESTID));
+
+        await waitFor(() => {
+            expect(
+                screen.queryByTestId(DROPDOWN_TESTID)
+            ).not.toBeInTheDocument();
+        });
+    });
+
+    it("should select list item correctly", async () => {
+        const user = userEvent.setup();
+        const mockOnSelectOption = jest.fn();
+
+        render(
+            <InputSelect
+                data-testid={FIELD_TESTID}
+                options={OPTIONS}
+                onSelectOption={mockOnSelectOption}
+            />
+        );
+
+        await user.click(screen.queryByTestId(FIELD_TESTID));
+
+        await waitFor(() => {
+            expect(screen.queryByTestId(DROPDOWN_TESTID)).toBeVisible();
+        });
+
+        await user.click(screen.queryByText("Option 1"));
+
+        await waitFor(() => {
+            expect(
+                screen.queryByTestId(DROPDOWN_TESTID)
+            ).not.toBeInTheDocument();
+        });
+
+        expect(mockOnSelectOption).toHaveBeenCalledWith("Option 1", "Option 1");
+    });
+
+    describe("focus/blur behaviour", () => {
+        it("should call onBlur via outside click", async () => {
+            const user = userEvent.setup();
+            const mockOnBlur = jest.fn();
+
+            render(
+                <InputSelect
+                    data-testid={FIELD_TESTID}
+                    options={OPTIONS}
+                    onBlur={mockOnBlur}
+                />
+            );
+
+            await user.click(screen.queryByTestId(FIELD_TESTID));
+
+            await waitFor(() => screen.getByTestId(DROPDOWN_TESTID));
+            await waitFor(() =>
+                expect(
+                    screen.queryByRole("option", { name: "Option 1" })
+                ).toHaveFocus()
+            );
+
+            expect(mockOnBlur).toHaveBeenCalledTimes(0);
+
+            await user.click(screen.queryByText("Option 1"));
+
+            await waitForElementToBeRemoved(() =>
+                screen.queryByTestId(DROPDOWN_TESTID)
+            );
+
+            expect(mockOnBlur).toHaveBeenCalledTimes(0);
+
+            await user.click(document.body);
+
+            expect(mockOnBlur).toHaveBeenCalledTimes(1);
+        });
+
+        it("should dismiss dropdown if it is open", async () => {
+            const user = userEvent.setup();
+            const mockOnBlur = jest.fn();
+
+            render(
+                <InputSelect
+                    data-testid={FIELD_TESTID}
+                    options={OPTIONS}
+                    onBlur={mockOnBlur}
+                />
+            );
+
+            await user.click(screen.queryByTestId(FIELD_TESTID));
+
+            await waitFor(() => screen.getByTestId(DROPDOWN_TESTID));
+            await waitFor(() =>
+                expect(
+                    screen.queryByRole("option", { name: "Option 1" })
+                ).toHaveFocus()
+            );
+
+            expect(mockOnBlur).toHaveBeenCalledTimes(0);
+
+            await user.click(document.body);
+
+            await waitForElementToBeRemoved(() =>
+                screen.queryByTestId(DROPDOWN_TESTID)
+            );
+
+            expect(mockOnBlur).toHaveBeenCalledTimes(1);
+        });
+
+        it("should dismiss dropdown via Esc key", async () => {
+            const user = userEvent.setup();
+            const mockOnBlur = jest.fn();
+
+            render(
+                <InputSelect
+                    data-testid={FIELD_TESTID}
+                    options={OPTIONS}
+                    onBlur={mockOnBlur}
+                />
+            );
+
+            await act(async () => {
+                await user.click(screen.queryByTestId(FIELD_TESTID));
+            });
+
+            await waitFor(() => screen.getByTestId(DROPDOWN_TESTID));
+            await waitFor(() =>
+                expect(
+                    screen.queryByRole("option", { name: "Option 1" })
+                ).toHaveFocus()
+            );
+
+            expect(mockOnBlur).toHaveBeenCalledTimes(0);
+
+            await act(async () => {
+                await user.keyboard("{Escape}");
+            });
+
+            await waitForElementToBeRemoved(() =>
+                screen.queryByTestId(DROPDOWN_TESTID)
+            );
+
+            expect(screen.queryByTestId(SELECTOR_TESTID)).toHaveFocus();
+            expect(mockOnBlur).toHaveBeenCalledTimes(0);
+
+            await act(async () => {
+                await user.click(document.body);
+            });
+
+            expect(mockOnBlur).toHaveBeenCalledTimes(1);
+        });
+
+        it("should call onFocus and onBlur when cycling through the tab sequence", async () => {
+            const user = userEvent.setup();
+            const mockOnBlur = jest.fn();
+
+            render(
+                <>
+                    <button data-testid="before" />
+                    <InputSelect
+                        data-testid={FIELD_TESTID}
+                        options={OPTIONS}
+                        onBlur={mockOnBlur}
+                        enableSearch
+                    />
+                    <button data-testid="after" />
+                </>
+            );
+
+            await user.keyboard("{Tab}");
+
+            expect(screen.getByTestId("before")).toHaveFocus();
+
+            await user.keyboard("{Tab} ");
+
+            await waitFor(() => screen.getByTestId(DROPDOWN_TESTID));
+            await waitFor(() => {
+                expect(
+                    screen.getByLabelText("Enter text to search")
+                ).toHaveFocus();
+            });
+            expect(mockOnBlur).toHaveBeenCalledTimes(0);
+
+            await act(async () => {
+                await user.keyboard("{Tab}");
+            });
+
+            await waitForElementToBeRemoved(() =>
+                screen.queryByTestId(DROPDOWN_TESTID)
+            );
+
+            expect(screen.getByTestId("after")).toHaveFocus();
+            expect(mockOnBlur).toHaveBeenCalledTimes(1);
+
+            await act(async () => {
+                await user.keyboard("{Shift>}{Tab}{/Shift}");
+            });
+
+            await waitFor(() => {
+                expect(screen.queryByTestId(SELECTOR_TESTID)).toHaveFocus();
+                expect(
+                    screen.queryByTestId(DROPDOWN_TESTID)
+                ).not.toBeInTheDocument();
+                expect(mockOnBlur).toHaveBeenCalledTimes(1);
+            });
+        });
+    });
+});

--- a/tests/input-select/input-select.spec.tsx
+++ b/tests/input-select/input-select.spec.tsx
@@ -263,4 +263,139 @@ describe("InputSelect", () => {
             });
         });
     });
+
+    describe("search behaviour", () => {
+        it("should support default search for string options", async () => {
+            const user = userEvent.setup();
+
+            render(
+                <InputSelect
+                    data-testid={FIELD_TESTID}
+                    options={OPTIONS}
+                    enableSearch
+                />
+            );
+
+            await user.click(screen.queryByTestId(FIELD_TESTID));
+
+            await waitFor(() => {
+                expect(screen.queryByTestId(DROPDOWN_TESTID)).toBeVisible();
+            });
+            await waitFor(() => {
+                expect(
+                    screen.getByLabelText("Enter text to search")
+                ).toHaveFocus();
+            });
+
+            await act(async () => {
+                await user.keyboard("1");
+            });
+
+            expect(screen.queryByText("Option 1")).toBeVisible();
+            expect(screen.queryByText("Option 2")).not.toBeInTheDocument();
+        });
+
+        it("should support default search for title", async () => {
+            const user = userEvent.setup();
+
+            render(
+                <InputSelect
+                    data-testid={FIELD_TESTID}
+                    options={OPTIONS}
+                    listExtractor={(item) => ({
+                        title: item + " title",
+                        secondaryLabel: item + " label",
+                    })}
+                    enableSearch
+                />
+            );
+
+            await user.click(screen.queryByTestId(FIELD_TESTID));
+
+            await waitFor(() => {
+                expect(screen.queryByTestId(DROPDOWN_TESTID)).toBeVisible();
+            });
+            await waitFor(() => {
+                expect(
+                    screen.getByLabelText("Enter text to search")
+                ).toHaveFocus();
+            });
+
+            await act(async () => {
+                await user.keyboard("1 t");
+            });
+
+            expect(screen.getByText("Option 1 title")).toBeVisible();
+            expect(
+                screen.queryByText("Option 2 title")
+            ).not.toBeInTheDocument();
+        });
+
+        it("should support default search for label", async () => {
+            const user = userEvent.setup();
+
+            render(
+                <InputSelect
+                    data-testid={FIELD_TESTID}
+                    options={OPTIONS}
+                    listExtractor={(item) => ({
+                        title: item + " title",
+                        secondaryLabel: item + " label",
+                    })}
+                    enableSearch
+                />
+            );
+
+            await user.click(screen.queryByTestId(FIELD_TESTID));
+
+            await waitFor(() => {
+                expect(screen.queryByTestId(DROPDOWN_TESTID)).toBeVisible();
+            });
+            await waitFor(() => {
+                expect(
+                    screen.getByLabelText("Enter text to search")
+                ).toHaveFocus();
+            });
+
+            await act(async () => {
+                await user.keyboard("1 l");
+            });
+
+            expect(screen.getByText("Option 1 label")).toBeVisible();
+            expect(
+                screen.queryByText("Option 2 label")
+            ).not.toBeInTheDocument();
+        });
+
+        it("should support custom search", async () => {
+            const user = userEvent.setup();
+
+            render(
+                <InputSelect
+                    data-testid={FIELD_TESTID}
+                    options={OPTIONS}
+                    enableSearch
+                    searchFunction={() => ["custom 1"]}
+                />
+            );
+
+            await user.click(screen.queryByTestId(FIELD_TESTID));
+
+            await waitFor(() => {
+                expect(screen.queryByTestId(DROPDOWN_TESTID)).toBeVisible();
+            });
+            await waitFor(() => {
+                expect(
+                    screen.getByLabelText("Enter text to search")
+                ).toHaveFocus();
+            });
+
+            await act(async () => {
+                await user.keyboard("custom");
+            });
+
+            expect(screen.queryByText("custom 1")).toBeVisible();
+            expect(screen.queryByText("Option 1")).not.toBeInTheDocument();
+        });
+    });
 });


### PR DESCRIPTION
**Changes**

Fix for `InputSelect` in https://github.com/LifeSG/react-design-system/issues/443

- Use Floating UI to handle the positioning
- Rework the dropdown list for the new card-based view
- Extract dropdown label - planning to reuse in the nested selects
- Extract the selector + chevron - planning to reuse across the various selects
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Fix dropdown in `InputSelect` getting cut off when it exceeds the parent container bounds

**Additional info**
You may refer to the new Figma specs [here](https://www.figma.com/design/60eQNJwWWyDnQkfaXRACYi/%F0%9F%9B%9D-DCube-DS-Playground?node-id=995-17511&t=baj51SCOzbMKLLHc-0)