### PR TITLE
Make it easier to reset spacing in `Toggle` composite section

### DIFF
--- a/src/toggle/toggle.styles.tsx
+++ b/src/toggle/toggle.styles.tsx
@@ -296,16 +296,16 @@ export const RemoveButton = styled.button<StyleProps>`
 export const ExpandButton = styled.button<ExpandButtonStyleProps>`
     color: ${(props) => (props.disabled ? Color.Neutral[3] : Color.Primary)};
     ${TextStyleHelper.getTextStyle("H4", "semibold")}
-    width: 100%;
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    padding-bottom: 0.6875rem;
     border: none;
     background: none;
     cursor: ${(props) => (props.disabled ? "not-allowed" : "pointer")};
+    padding: 0 1rem 0.6875rem 1rem;
     padding-top: ${(props) =>
         props.$paddingTopRequired ? "0.6875rem" : "0rem"};
+    width: 100%;
 
     svg {
         width: 1.125rem;
@@ -320,8 +320,7 @@ export const ErrorContainer = styled.div<StyleProps>`
     border: none;
     background: none;
     cursor: ${(props) => (props.$disabled ? "not-allowed" : "pointer")};
-    padding-top: 0.6875rem;
-    padding-bottom: 0.5rem;
+    padding: 0.6875rem 1rem 0.5rem 1rem;
 `;
 
 export const AlertContainer = styled(Alert)`
@@ -329,11 +328,8 @@ export const AlertContainer = styled(Alert)`
     user-select: none;
 `;
 
-export const CompositeSectionContainer = styled.div`
-    padding: 0 1rem;
-`;
-
 export const Children = styled.div<ChildrenStyleProps>`
+    padding: 0 1rem;
     padding-top: 0.6875rem;
     padding-bottom: ${(props) => (props.$isFinalItem ? "0.6875rem" : "0.5rem")};
     ${applyHtmlContentStyle({ textSize: "BodySmall" })}

--- a/src/toggle/toggle.tsx
+++ b/src/toggle/toggle.tsx
@@ -6,7 +6,6 @@ import { SimpleIdGenerator } from "../util";
 import {
     AlertContainer,
     Children,
-    CompositeSectionContainer,
     Container,
     ErrorContainer,
     ErrorList,
@@ -171,7 +170,11 @@ export const Toggle = ({
     const renderCompositeChildren = () => {
         return (
             (!collapsible || expanded) && (
-                <Children $isFinalItem={!collapsible} $disabled={disabled}>
+                <Children
+                    data-id="toggle-composite-children"
+                    $isFinalItem={!collapsible}
+                    $disabled={disabled}
+                >
                     {compositeSectionChildren}
                 </Children>
             )
@@ -304,11 +307,11 @@ export const Toggle = ({
     const renderCompositeSection = () => {
         return (
             compositeSectionChildren && (
-                <CompositeSectionContainer>
+                <div>
                     {renderCompositeChildren()}
                     {renderError()}
                     {renderExpandButton()}
-                </CompositeSectionContainer>
+                </div>
             )
         );
     };


### PR DESCRIPTION
**Changes**

- There's a default padding on the `Toggle` composite section, but sometimes the children might need to take up the full width of the Toggle or remove the padding, which is not possible without negative margin hacks
- Moved the top-level padding to individual elements in the composite section and added a `data-id` to target the children container
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

Feature
- Add `data-id` for `Toggle` composite section children and make it easier to reset spacing