### PR TITLE
Fix calendar opening on disabled date picker

### DIFF
--- a/src/date-input/date-input.tsx
+++ b/src/date-input/date-input.tsx
@@ -113,7 +113,7 @@ export const DateInput = ({
     };
 
     const handleFocus = () => {
-        if (readOnly) return;
+        if (readOnly || disabled) return;
 
         setCalendarOpen(true);
 

--- a/src/date-range-input/date-range-input.tsx
+++ b/src/date-range-input/date-range-input.tsx
@@ -409,7 +409,7 @@ export const DateRangeInput = ({
     };
 
     const handleFocus = () => {
-        if (readOnly || focused) return;
+        if (readOnly || disabled || focused) return;
 
         actions.focus("start");
         onFocus?.();

--- a/tests/date-input/date-input.spec.tsx
+++ b/tests/date-input/date-input.spec.tsx
@@ -71,6 +71,34 @@ describe("DateInput", () => {
         expect(screen.getByText("2023")).toBeVisible();
     });
 
+    it("should not open calendar for readOnly field", async () => {
+        const user = userEvent.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+        const mockOnFocus = jest.fn();
+
+        render(<DateInput data-testid="e2e" readOnly onFocus={mockOnFocus} />);
+
+        await user.click(screen.queryByTestId(FIELD_TESTID));
+
+        expect(screen.queryByTestId(CALENDAR_TESTID)).not.toBeInTheDocument();
+        expect(mockOnFocus).not.toHaveBeenCalled();
+    });
+
+    it("should not open calendar for disabled field", async () => {
+        const user = userEvent.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+        const mockOnFocus = jest.fn();
+
+        render(<DateInput data-testid="e2e" disabled onFocus={mockOnFocus} />);
+
+        await user.click(screen.queryByTestId(FIELD_TESTID));
+
+        expect(screen.queryByTestId(CALENDAR_TESTID)).not.toBeInTheDocument();
+        expect(mockOnFocus).not.toHaveBeenCalled();
+    });
+
     describe("focus/blur behaviour", () => {
         it("should call onFocus on click and onBlur via outside click", async () => {
             const user = userEvent.setup({


### PR DESCRIPTION
**Changes**

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Fix calendar still opening for disabled `DateInput` and `DateRangeInput`