### PR TITLE
Revert toggle width

### DIFF
--- a/src/toggle/toggle.styles.tsx
+++ b/src/toggle/toggle.styles.tsx
@@ -51,7 +51,6 @@ export const Container = styled.div<ContainerStyleProps>`
     overflow: hidden;
     flex-direction: column;
     height: fit-content;
-    width: 100%;
 
     // Content positioning style
     ${(props) => {


### PR DESCRIPTION
**Changes**

width 100% results in the toggle growing to fit the parent width, changing the initial behaviour where the toggles would only grow to fit the content

this broke the default display for FEE checkboxes and radios

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Revert fixed toggle width in `Toggle`