### PR TITLE
Fix multiselect dropdown getting cut off

### DIFF
--- a/src/input-multi-select/input-multi-select.tsx
+++ b/src/input-multi-select/input-multi-select.tsx
@@ -217,7 +217,7 @@ export const InputMultiSelect = <T, V>({
                     ref={selectorRef}
                     disabled={disabled}
                     expanded={showOptions}
-                    id={internalId}
+                    listboxId={internalId}
                     readOnly={readOnly}
                     variant={variant}
                 >

--- a/src/input-multi-select/types.ts
+++ b/src/input-multi-select/types.ts
@@ -5,21 +5,23 @@ import {
 import {
     DropdownDisplayProps,
     DropdownSearchProps,
-    DropdownStyleProps,
     DropdownVariantType,
-} from "../shared/dropdown-list/types";
+} from "../shared/dropdown-list-v2/types";
+import { DropdownAlignmentType } from "../shared/dropdown-wrapper";
 
 export interface InputMultiSelectProps<T, V>
     extends React.HTMLAttributes<HTMLElement>,
         InputSelectOptionsProps<T>,
         InputSelectSharedProps<T>,
         DropdownDisplayProps<T, V>,
-        DropdownSearchProps<T>,
-        DropdownStyleProps {
+        DropdownSearchProps<T> {
+    readOnly?: boolean | undefined;
     selectedOptions?: T[] | undefined;
     onSelectOptions?: ((options: T[]) => void) | undefined;
     onBlur?: (() => void) | undefined;
     variant?: DropdownVariantType | undefined;
+    alignment?: DropdownAlignmentType | undefined;
+    dropdownZIndex?: number | undefined;
 }
 
 /** To be exposed for Form component inheritance */

--- a/src/input-select/input-select.tsx
+++ b/src/input-select/input-select.tsx
@@ -228,7 +228,7 @@ export const InputSelect = <T, V>({
                     ref={selectorRef}
                     disabled={disabled}
                     expanded={showOptions}
-                    id={internalId}
+                    listboxId={internalId}
                     readOnly={readOnly}
                     variant={variant}
                 >

--- a/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
@@ -7,6 +7,7 @@ import { Color } from "../../color";
 import { MediaQuery } from "../../media";
 import { TextStyleHelper } from "../../text";
 import { DropdownVariantType } from "../dropdown-list/types";
+import { BasicButton } from "../input-wrapper/input-wrapper";
 
 // =============================================================================
 // STYLE INTERFACE
@@ -128,22 +129,21 @@ export const SelectAllContainer = styled.div`
     width: 100%;
     display: flex;
     justify-content: flex-end;
-    padding: 1rem 0 0.5rem 0;
 `;
 
-export const DropdownCommonButton = styled.button<ListStyleProps>`
+export const DropdownCommonButton = styled(BasicButton)<ListStyleProps>`
     ${(props) =>
         TextStyleHelper.getTextStyle(
             props.$variant === "small" ? "BodySmall" : "Body",
             "semibold"
         )}
-    background-color: transparent;
-    background-repeat: no-repeat;
-    border: none;
     cursor: pointer;
     overflow: hidden;
-    outline: none;
     color: ${Color.Primary};
+`;
+
+export const SelectAllButton = styled(DropdownCommonButton)`
+    padding: 0.5rem 1rem;
 `;
 
 export const ResultStateContainer = styled.div`

--- a/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
@@ -142,6 +142,10 @@ export const DropdownCommonButton = styled(BasicButton)<ListStyleProps>`
     color: ${Color.Primary};
 `;
 
+export const TryAgainButton = styled(DropdownCommonButton)`
+    outline-offset: 0.25rem;
+`;
+
 export const SelectAllButton = styled(DropdownCommonButton)`
     padding: 0.5rem 1rem;
 `;

--- a/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
@@ -1,6 +1,6 @@
 import { ExclamationCircleFillIcon } from "@lifesg/react-icons/exclamation-circle-fill";
 import { SquareIcon } from "@lifesg/react-icons/square";
-import { SquareFillIcon } from "@lifesg/react-icons/square-fill";
+import { SquareTickFillIcon } from "@lifesg/react-icons/square-tick-fill";
 import { TickIcon } from "@lifesg/react-icons/tick";
 import styled, { css } from "styled-components";
 import { Color } from "../../color";
@@ -102,7 +102,7 @@ export const UnselectedIndicator = styled.div`
     width: 1rem;
 `;
 
-export const CheckboxSelectedIndicator = styled(SquareFillIcon)`
+export const CheckboxSelectedIndicator = styled(SquareTickFillIcon)`
     flex-shrink: 0;
     height: 1.625rem;
     width: 1.625rem;

--- a/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
@@ -19,6 +19,10 @@ interface ListStyleProps {
     $variant?: DropdownVariantType;
 }
 
+interface ListItemStyleProps {
+    $active?: boolean;
+}
+
 // =============================================================================
 // STYLING
 // =============================================================================
@@ -73,7 +77,7 @@ export const Listbox = styled.ul`
 // LIST ITEM STYLES
 // -----------------------------------------------------------------------------
 
-export const ListItem = styled.li<ListStyleProps>`
+export const ListItem = styled.li<ListItemStyleProps>`
     display: flex;
     align-items: flex-start;
     gap: 0.5rem;
@@ -82,11 +86,11 @@ export const ListItem = styled.li<ListStyleProps>`
 
     outline-color: ${Color.Accent.Light[3]};
 
-    :hover,
-    :focus,
-    :active {
-        background: ${Color.Accent.Light[5]};
-    }
+    ${(props) =>
+        props.$active &&
+        css`
+            background: ${Color.Accent.Light[5]};
+        `}
 `;
 
 export const SelectedIndicator = styled(TickIcon)`

--- a/src/shared/dropdown-list-v2/dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.tsx
@@ -14,7 +14,6 @@ import {
     CheckboxSelectedIndicator,
     CheckboxUnselectedIndicator,
     Container,
-    DropdownCommonButton,
     LabelIcon,
     List,
     ListItem,
@@ -24,6 +23,7 @@ import {
     SelectAllButton,
     SelectAllContainer,
     SelectedIndicator,
+    TryAgainButton,
     UnselectedIndicator,
 } from "./dropdown-list.styles";
 import { DropdownSearch } from "./dropdown-search";
@@ -421,13 +421,13 @@ export const DropdownList = <T, V>({
                         Failed to load.
                     </ResultStateText>
                     &nbsp;
-                    <DropdownCommonButton
+                    <TryAgainButton
                         onClick={handleTryAgain}
                         type="button"
                         $variant={variant}
                     >
                         Try again.
-                    </DropdownCommonButton>
+                    </TryAgainButton>
                 </ResultStateContainer>
             );
         }

--- a/src/shared/dropdown-list-v2/dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.tsx
@@ -147,7 +147,10 @@ export const DropdownList = <T, V>({
                 }
                 break;
             case "Space":
-                if (document.activeElement !== searchInputRef.current) {
+                if (
+                    document.activeElement ===
+                    listItemRefs.current[focusedIndex]
+                ) {
                     event.preventDefault();
                     if (displayListItems[focusedIndex]) {
                         handleListItemClick(
@@ -204,13 +207,13 @@ export const DropdownList = <T, V>({
         if (searchInputRef.current) {
             setFocusedIndex(-1);
             setTimeout(() => searchInputRef.current.focus(), 200); // wait for animation
-        } else {
+        } else if (listItemRefs.current[focusedIndex]) {
             // Else focus on the specified element
-            const target =
-                listItemRefs.current[focusedIndex] || listItemRefs.current[0];
-            if (target) {
-                setTimeout(() => target.focus(), 200); // wait for animation
-            }
+            setTimeout(() => listItemRefs.current[focusedIndex].focus(), 200);
+        } else {
+            // Else focus on the first list item
+            setFocusedIndex(0);
+            setTimeout(() => listItemRefs.current[0]?.focus(), 200);
         }
     }, [disableItemFocus, focusedIndex, mounted, setFocusedIndex]);
 

--- a/src/shared/dropdown-list-v2/dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.tsx
@@ -21,6 +21,7 @@ import {
     Listbox,
     ResultStateContainer,
     ResultStateText,
+    SelectAllButton,
     SelectAllContainer,
     SelectedIndicator,
     UnselectedIndicator,
@@ -358,7 +359,7 @@ export const DropdownList = <T, V>({
         ) {
             return (
                 <SelectAllContainer>
-                    <DropdownCommonButton
+                    <SelectAllButton
                         onClick={onSelectAll}
                         type="button"
                         $variant={variant}
@@ -366,7 +367,7 @@ export const DropdownList = <T, V>({
                         {selectedItems.length === 0
                             ? "Select all"
                             : "Clear all"}
-                    </DropdownCommonButton>
+                    </SelectAllButton>
                 </SelectAllContainer>
             );
         }

--- a/src/shared/dropdown-list-v2/dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.tsx
@@ -145,6 +145,9 @@ export const DropdownList = <T, V>({
                     listItemRefs.current[upcomingIndex].focus();
 
                     setFocusedIndex(upcomingIndex);
+                } else if (focusedIndex === 0 && searchInputRef.current) {
+                    searchInputRef.current.focus();
+                    setFocusedIndex(-1);
                 }
                 break;
             case "Space":

--- a/src/shared/dropdown-list-v2/dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.tsx
@@ -170,6 +170,10 @@ export const DropdownList = <T, V>({
         onSelectItem?.(item, getValue(item));
     };
 
+    const handleListItemHover = (index: number) => {
+        setFocusedIndex(index);
+    };
+
     const handleSearchInputChange = (
         event: React.ChangeEvent<HTMLInputElement>
     ) => {
@@ -302,6 +306,7 @@ export const DropdownList = <T, V>({
         if (!onRetry || (onRetry && itemsLoadState === "success")) {
             return displayListItems.map((item, index) => {
                 const selected = checkListItemSelected(item);
+                const active = index === focusedIndex;
                 return (
                     <ListItem
                         aria-selected={selected}
@@ -309,12 +314,13 @@ export const DropdownList = <T, V>({
                         data-testid="list-item"
                         key={getItemKey(item, index)}
                         onClick={() => handleListItemClick(item, index)}
+                        onMouseEnter={() => handleListItemHover(index)}
                         ref={(element) =>
                             (listItemRefs.current[index] = element)
                         }
                         role="option"
-                        tabIndex={-1}
-                        $variant={variant}
+                        tabIndex={active ? 0 : -1}
+                        $active={active}
                     >
                         {renderListItemIcon(selected)}
                         {renderListItem

--- a/src/shared/dropdown-list-v2/expandable-element.tsx
+++ b/src/shared/dropdown-list-v2/expandable-element.tsx
@@ -7,7 +7,7 @@ interface ExpandableElementProps {
     children: React.ReactNode;
     disabled: boolean;
     expanded: boolean;
-    id: string;
+    listboxId: string;
     readOnly: boolean;
     variant: DropdownVariantType;
 }
@@ -17,7 +17,7 @@ export const Component = (
         children,
         disabled,
         expanded,
-        id,
+        listboxId,
         readOnly,
         variant,
     }: ExpandableElementProps,
@@ -34,7 +34,7 @@ export const Component = (
             aria-haspopup="listbox"
             data-testid="selector"
             disabled={disabled}
-            aria-controls={id}
+            aria-controls={listboxId}
             $variant={variant}
         >
             {children}

--- a/src/shared/input-wrapper/input-wrapper.tsx
+++ b/src/shared/input-wrapper/input-wrapper.tsx
@@ -159,4 +159,8 @@ export const BasicButton = styled.button<InputStyleProps>`
     :active {
         outline: none;
     }
+
+    :focus-visible {
+        outline: 2px auto ${Color.Primary};
+    }
 `;

--- a/stories/form/form-multi-select/props-table.tsx
+++ b/stories/form/form-multi-select/props-table.tsx
@@ -132,6 +132,20 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: [`"small"`, `"default"`],
                 defaultValue: `"default"`,
             },
+            {
+                name: "alignment",
+                description:
+                    "Specifies if the dropdown is aligned to the left or right of the main field",
+                propTypes: [`"left"`, `"right"`],
+                defaultValue: `"left"`,
+            },
+            {
+                name: "dropdownZIndex",
+                description:
+                    "The custom z-index of the dropdown. Try specifying this if you encounter z-index conflicts.",
+                propTypes: ["number"],
+                defaultValue: "50",
+            },
         ],
     },
     ...SHARED_FORM_PROPS_DATA,

--- a/stories/form/form-select/props-table.tsx
+++ b/stories/form/form-select/props-table.tsx
@@ -183,6 +183,13 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: [`"left"`, `"right"`],
                 defaultValue: `"left"`,
             },
+            {
+                name: "dropdownZIndex",
+                description:
+                    "The custom z-index of the dropdown. Try specifying this if you encounter z-index conflicts.",
+                propTypes: ["number"],
+                defaultValue: "50",
+            },
         ],
     },
     {

--- a/tests/input-multi-select/input-multi-select.spec.tsx
+++ b/tests/input-multi-select/input-multi-select.spec.tsx
@@ -1,0 +1,402 @@
+import {
+    act,
+    render,
+    screen,
+    waitFor,
+    waitForElementToBeRemoved,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { InputMultiSelect } from "../../src/input-multi-select";
+
+const FIELD_TESTID = "test";
+const SELECTOR_TESTID = "selector";
+const DROPDOWN_TESTID = "dropdown-list";
+const OPTIONS = ["Option 1", "Option 2", "Option 3"];
+
+describe("InputMultiSelect", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        global.ResizeObserver = jest.fn().mockImplementation(() => ({
+            observe: jest.fn(),
+            unobserve: jest.fn(),
+            disconnect: jest.fn(),
+        }));
+    });
+
+    it("should render the component", async () => {
+        render(
+            <InputMultiSelect data-testid={FIELD_TESTID} options={OPTIONS} />
+        );
+
+        expect(screen.getByText("Select")).toBeVisible();
+        expect(screen.queryByTestId(DROPDOWN_TESTID)).not.toBeInTheDocument();
+    });
+
+    it("should open dropdown list when selector is clicked", async () => {
+        const user = userEvent.setup();
+
+        render(
+            <InputMultiSelect data-testid={FIELD_TESTID} options={OPTIONS} />
+        );
+
+        await user.click(screen.queryByTestId(FIELD_TESTID));
+
+        await waitFor(() => {
+            expect(screen.queryByTestId(DROPDOWN_TESTID)).toBeVisible();
+        });
+
+        expect(screen.queryByText("Option 1")).toBeVisible();
+        expect(screen.queryByText("Option 2")).toBeVisible();
+        expect(screen.queryByText("Option 3")).toBeVisible();
+    });
+
+    it("should toggle dropdown list when selector is clicked", async () => {
+        const user = userEvent.setup();
+
+        render(
+            <InputMultiSelect data-testid={FIELD_TESTID} options={OPTIONS} />
+        );
+
+        await user.click(screen.queryByTestId(FIELD_TESTID));
+
+        await waitFor(() => {
+            expect(screen.queryByTestId(DROPDOWN_TESTID)).toBeVisible();
+        });
+
+        await user.click(screen.queryByTestId(FIELD_TESTID));
+
+        await waitFor(() => {
+            expect(
+                screen.queryByTestId(DROPDOWN_TESTID)
+            ).not.toBeInTheDocument();
+        });
+    });
+
+    it("should select list item correctly", async () => {
+        const user = userEvent.setup();
+        const mockOnSelectOptions = jest.fn();
+
+        render(
+            <InputMultiSelect
+                data-testid={FIELD_TESTID}
+                options={OPTIONS}
+                onSelectOptions={mockOnSelectOptions}
+            />
+        );
+
+        await user.click(screen.queryByTestId(FIELD_TESTID));
+
+        await waitFor(() => {
+            expect(screen.queryByTestId(DROPDOWN_TESTID)).toBeVisible();
+        });
+
+        await user.click(screen.queryByText("Option 1"));
+
+        expect(screen.queryByTestId(DROPDOWN_TESTID)).toBeVisible();
+        expect(mockOnSelectOptions).toHaveBeenCalledWith(["Option 1"]);
+    });
+
+    describe("focus/blur behaviour", () => {
+        it("should call onBlur via outside click", async () => {
+            const user = userEvent.setup();
+            const mockOnBlur = jest.fn();
+
+            render(
+                <InputMultiSelect
+                    data-testid={FIELD_TESTID}
+                    options={OPTIONS}
+                    onBlur={mockOnBlur}
+                />
+            );
+
+            await user.click(screen.queryByTestId(FIELD_TESTID));
+
+            await waitFor(() => screen.getByTestId(DROPDOWN_TESTID));
+            await waitFor(() =>
+                expect(
+                    screen.queryByRole("option", { name: "Option 1" })
+                ).toHaveFocus()
+            );
+
+            expect(mockOnBlur).toHaveBeenCalledTimes(0);
+
+            await user.click(screen.queryByTestId(FIELD_TESTID));
+
+            await waitForElementToBeRemoved(() =>
+                screen.queryByTestId(DROPDOWN_TESTID)
+            );
+
+            expect(mockOnBlur).toHaveBeenCalledTimes(0);
+
+            await user.click(document.body);
+
+            expect(mockOnBlur).toHaveBeenCalledTimes(1);
+        });
+
+        it("should dismiss dropdown if it is open", async () => {
+            const user = userEvent.setup();
+            const mockOnBlur = jest.fn();
+
+            render(
+                <InputMultiSelect
+                    data-testid={FIELD_TESTID}
+                    options={OPTIONS}
+                    onBlur={mockOnBlur}
+                />
+            );
+
+            await user.click(screen.queryByTestId(FIELD_TESTID));
+
+            await waitFor(() => screen.getByTestId(DROPDOWN_TESTID));
+            await waitFor(() =>
+                expect(
+                    screen.queryByRole("option", { name: "Option 1" })
+                ).toHaveFocus()
+            );
+
+            expect(mockOnBlur).toHaveBeenCalledTimes(0);
+
+            await user.click(document.body);
+
+            await waitForElementToBeRemoved(() =>
+                screen.queryByTestId(DROPDOWN_TESTID)
+            );
+
+            expect(mockOnBlur).toHaveBeenCalledTimes(1);
+        });
+
+        it("should dismiss dropdown via Esc key", async () => {
+            const user = userEvent.setup();
+            const mockOnBlur = jest.fn();
+
+            render(
+                <InputMultiSelect
+                    data-testid={FIELD_TESTID}
+                    options={OPTIONS}
+                    onBlur={mockOnBlur}
+                />
+            );
+
+            await act(async () => {
+                await user.click(screen.queryByTestId(FIELD_TESTID));
+            });
+
+            await waitFor(() => screen.getByTestId(DROPDOWN_TESTID));
+            await waitFor(() =>
+                expect(
+                    screen.queryByRole("option", { name: "Option 1" })
+                ).toHaveFocus()
+            );
+
+            expect(mockOnBlur).toHaveBeenCalledTimes(0);
+
+            await act(async () => {
+                await user.keyboard("{Escape}");
+            });
+
+            await waitForElementToBeRemoved(() =>
+                screen.queryByTestId(DROPDOWN_TESTID)
+            );
+
+            expect(screen.queryByTestId(SELECTOR_TESTID)).toHaveFocus();
+            expect(mockOnBlur).toHaveBeenCalledTimes(0);
+
+            await act(async () => {
+                await user.click(document.body);
+            });
+
+            expect(mockOnBlur).toHaveBeenCalledTimes(1);
+        });
+
+        it("should call onFocus and onBlur when cycling through the tab sequence", async () => {
+            const user = userEvent.setup();
+            const mockOnBlur = jest.fn();
+
+            render(
+                <>
+                    <button data-testid="before" />
+                    <InputMultiSelect
+                        data-testid={FIELD_TESTID}
+                        options={OPTIONS}
+                        onBlur={mockOnBlur}
+                        enableSearch
+                    />
+                    <button data-testid="after" />
+                </>
+            );
+
+            await user.keyboard("{Tab}");
+
+            expect(screen.getByTestId("before")).toHaveFocus();
+
+            await user.keyboard("{Tab} ");
+
+            await waitFor(() => screen.getByTestId(DROPDOWN_TESTID));
+            await waitFor(() => {
+                expect(
+                    screen.getByLabelText("Enter text to search")
+                ).toHaveFocus();
+            });
+            expect(mockOnBlur).toHaveBeenCalledTimes(0);
+
+            await act(async () => {
+                await user.keyboard("{Tab}{Tab}");
+            });
+
+            await waitForElementToBeRemoved(() =>
+                screen.queryByTestId(DROPDOWN_TESTID)
+            );
+
+            expect(screen.getByTestId("after")).toHaveFocus();
+            expect(mockOnBlur).toHaveBeenCalledTimes(1);
+
+            await act(async () => {
+                await user.keyboard("{Shift>}{Tab}{/Shift}");
+            });
+
+            await waitFor(() => {
+                expect(screen.queryByTestId(SELECTOR_TESTID)).toHaveFocus();
+                expect(
+                    screen.queryByTestId(DROPDOWN_TESTID)
+                ).not.toBeInTheDocument();
+                expect(mockOnBlur).toHaveBeenCalledTimes(1);
+            });
+        });
+    });
+
+    describe("search behaviour", () => {
+        it("should support default search for string options", async () => {
+            const user = userEvent.setup();
+
+            render(
+                <InputMultiSelect
+                    data-testid={FIELD_TESTID}
+                    options={OPTIONS}
+                    enableSearch
+                />
+            );
+
+            await user.click(screen.queryByTestId(FIELD_TESTID));
+
+            await waitFor(() => {
+                expect(screen.queryByTestId(DROPDOWN_TESTID)).toBeVisible();
+            });
+            await waitFor(() => {
+                expect(
+                    screen.getByLabelText("Enter text to search")
+                ).toHaveFocus();
+            });
+
+            await act(async () => {
+                await user.keyboard("1");
+            });
+
+            expect(screen.queryByText("Option 1")).toBeVisible();
+            expect(screen.queryByText("Option 2")).not.toBeInTheDocument();
+        });
+
+        it("should support default search for title", async () => {
+            const user = userEvent.setup();
+
+            render(
+                <InputMultiSelect
+                    data-testid={FIELD_TESTID}
+                    options={OPTIONS}
+                    listExtractor={(item) => ({
+                        title: item + " title",
+                        secondaryLabel: item + " label",
+                    })}
+                    enableSearch
+                />
+            );
+
+            await user.click(screen.queryByTestId(FIELD_TESTID));
+
+            await waitFor(() => {
+                expect(screen.queryByTestId(DROPDOWN_TESTID)).toBeVisible();
+            });
+            await waitFor(() => {
+                expect(
+                    screen.getByLabelText("Enter text to search")
+                ).toHaveFocus();
+            });
+
+            await act(async () => {
+                await user.keyboard("1 t");
+            });
+
+            expect(screen.getByText("Option 1 title")).toBeVisible();
+            expect(
+                screen.queryByText("Option 2 title")
+            ).not.toBeInTheDocument();
+        });
+
+        it("should support default search for label", async () => {
+            const user = userEvent.setup();
+
+            render(
+                <InputMultiSelect
+                    data-testid={FIELD_TESTID}
+                    options={OPTIONS}
+                    listExtractor={(item) => ({
+                        title: item + " title",
+                        secondaryLabel: item + " label",
+                    })}
+                    enableSearch
+                />
+            );
+
+            await user.click(screen.queryByTestId(FIELD_TESTID));
+
+            await waitFor(() => {
+                expect(screen.queryByTestId(DROPDOWN_TESTID)).toBeVisible();
+            });
+            await waitFor(() => {
+                expect(
+                    screen.getByLabelText("Enter text to search")
+                ).toHaveFocus();
+            });
+
+            await act(async () => {
+                await user.keyboard("1 l");
+            });
+
+            expect(screen.getByText("Option 1 label")).toBeVisible();
+            expect(
+                screen.queryByText("Option 2 label")
+            ).not.toBeInTheDocument();
+        });
+
+        it("should support custom search", async () => {
+            const user = userEvent.setup();
+
+            render(
+                <InputMultiSelect
+                    data-testid={FIELD_TESTID}
+                    options={OPTIONS}
+                    enableSearch
+                    searchFunction={() => ["custom 1"]}
+                />
+            );
+
+            await user.click(screen.queryByTestId(FIELD_TESTID));
+
+            await waitFor(() => {
+                expect(screen.queryByTestId(DROPDOWN_TESTID)).toBeVisible();
+            });
+            await waitFor(() => {
+                expect(
+                    screen.getByLabelText("Enter text to search")
+                ).toHaveFocus();
+            });
+
+            await act(async () => {
+                await user.keyboard("custom");
+            });
+
+            expect(screen.queryByText("custom 1")).toBeVisible();
+            expect(screen.queryByText("Option 1")).not.toBeInTheDocument();
+        });
+    });
+});


### PR DESCRIPTION
**Changes**

Fix for MultiSelect in #443

- Updates `MultiSelect` to be similar to the new `InputSelect`
- Enhance list behaviour - only 1 item should be visually hovered at a time, so mouse hover + keyboard + focus should be considered together
- Further style adjustments to match the new Figma specs
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Fix dropdown in `MultiSelect` getting cut off when it exceeds the parent container bounds