### PR TITLE
Rework nested dropdown tree

### DIFF
--- a/src/shared/dropdown-list-v2/dropdown-label.styles.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-label.styles.tsx
@@ -11,6 +11,7 @@ import {
 // STYLE INTERFACE
 // =============================================================================
 interface LabelStyleProps {
+    $bold?: boolean;
     $labelDisplayType?: LabelDisplayType;
     $maxLines?: number;
     $selected?: boolean;
@@ -35,7 +36,7 @@ export const PrimaryText = styled.div<LabelStyleProps>`
     ${(props) =>
         TextStyleHelper.getTextStyle(
             props.$variant === "small" ? "BodySmall" : "Body",
-            "regular"
+            props.$bold ? "semibold" : "regular"
         )}
     color: ${(props) => (props.$selected ? Color.Primary : Color.Neutral[1])};
     width: 100%;

--- a/src/shared/dropdown-list-v2/dropdown-label.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-label.tsx
@@ -14,16 +14,18 @@ import {
 } from "./dropdown-label.styles";
 
 interface DropdownLabelProps {
+    bold?: boolean | undefined;
     displayType?: LabelDisplayType | undefined;
     label: string;
     maxLines?: number | undefined;
     selected?: boolean | undefined;
-    sublabel: string;
+    sublabel?: string | undefined;
     truncationType?: "middle" | "end" | undefined;
     variant?: DropdownVariantType | undefined;
 }
 
 export const DropdownLabel = ({
+    bold,
     displayType = "inline",
     label,
     maxLines = 2,
@@ -98,6 +100,7 @@ export const DropdownLabel = ({
         <Label ref={ref} $labelDisplayType={itemDisplayType}>
             <PrimaryText
                 aria-label={label}
+                $bold={bold}
                 $maxLines={maxLines}
                 $selected={selected}
                 $truncateType={truncationType}

--- a/src/shared/dropdown-list-v2/nested-dropdown-list-helpers.ts
+++ b/src/shared/dropdown-list-v2/nested-dropdown-list-helpers.ts
@@ -213,12 +213,12 @@ export const updateSelectedState = <T>(
                         (index) => draft[index]
                     );
 
-                    const allChildrenSelected =
-                        children.filter((child) => child.checked === true)
-                            .length === children.length;
-                    const mixed =
-                        children.filter((child) => child.checked !== false)
-                            .length > 0;
+                    const allChildrenSelected = children.every(
+                        (child) => child.checked === true
+                    );
+                    const mixed = children.some(
+                        (child) => child.checked !== false
+                    );
 
                     if (allChildrenSelected) {
                         item.checked = true;

--- a/src/shared/dropdown-list-v2/nested-dropdown-list-helpers.ts
+++ b/src/shared/dropdown-list-v2/nested-dropdown-list-helpers.ts
@@ -39,9 +39,7 @@ export const flattenList = <T>(
                     ? [...parentItem.keyPath, option.key]
                     : [option.key],
                 parentIndex: parentItem ? parentItem.index : -1,
-                parentKeyPath: parentItem
-                    ? [...parentItem.parentKeyPath, parentItem.item.key]
-                    : [],
+                parentKeyPath: parentItem ? parentItem.keyPath : [],
                 level,
                 visible: level === 0 || initialExpanded || parentItem.expanded,
                 expanded: initialExpanded,
@@ -64,12 +62,12 @@ export const flattenList = <T>(
                 const children = flatten(option.subItems, item);
 
                 if (multiSelect && item.checked !== true) {
-                    const allChildrenSelected =
-                        children.filter((child) => child.checked === true)
-                            .length === children.length;
-                    const mixed =
-                        children.filter((child) => child.checked !== false)
-                            .length > 0;
+                    const allChildrenSelected = children.every(
+                        (child) => child.checked === true
+                    );
+                    const mixed = children.some(
+                        (child) => child.checked !== false
+                    );
 
                     if (allChildrenSelected) {
                         item.checked = true;

--- a/src/shared/dropdown-list-v2/nested-dropdown-list-helpers.ts
+++ b/src/shared/dropdown-list-v2/nested-dropdown-list-helpers.ts
@@ -1,0 +1,262 @@
+import { produce } from "immer";
+import isEqual from "lodash/isEqual";
+import {
+    NestedDropdownListItemProps,
+    NestedDropdownListLocalItem,
+} from "./types";
+
+/**
+ * builds a flattened representation of the tree
+ * the items are listed in their visual order
+ */
+export const flattenList = <T>(
+    nestedList: NestedDropdownListItemProps<T>[],
+    selectedKeyPaths: string[][],
+    multiSelect: boolean,
+    searchTerm: string,
+    initialExpanded: boolean
+): NestedDropdownListLocalItem<T>[] => {
+    const items: NestedDropdownListLocalItem<T>[] = [];
+
+    const flatten = (
+        list: NestedDropdownListItemProps<T>[],
+        parentItem: NestedDropdownListLocalItem<T>
+    ) => {
+        const current: NestedDropdownListLocalItem<T>[] = [];
+        const hasNestedSiblings = !!list.find(
+            (option) => option.subItems?.length
+        );
+
+        for (let i = 0; i < list.length; i++) {
+            const option = list[i];
+            const level = parentItem ? parentItem.level + 1 : 0;
+            const item: (typeof items)[number] = {
+                item: option,
+                index: items.length,
+                indexInParent: i,
+                parentSetSize: list.length,
+                keyPath: parentItem
+                    ? [...parentItem.keyPath, option.key]
+                    : [option.key],
+                parentIndex: parentItem ? parentItem.index : -1,
+                parentKeyPath: parentItem
+                    ? [...parentItem.parentKeyPath, parentItem.item.key]
+                    : [],
+                level,
+                visible: level === 0 || initialExpanded || parentItem.expanded,
+                expanded: initialExpanded,
+                checked: false,
+                hasSubItems: !!option.subItems?.length,
+                subItemIndexes: [],
+                hasNestedSiblings,
+                matched: searchTerm
+                    ? option.label.toLowerCase().indexOf(searchTerm) !== -1
+                    : false,
+                hasMatchedSubItems: false,
+            };
+            item.checked = !!selectedKeyPaths.find((keyPath) =>
+                isEqual(keyPath, item.keyPath)
+            );
+            current.push(item);
+            items.push(item);
+
+            if (option.subItems?.length) {
+                const children = flatten(option.subItems, item);
+
+                if (multiSelect && item.checked !== true) {
+                    const allChildrenSelected =
+                        children.filter((child) => child.checked === true)
+                            .length === children.length;
+                    const mixed =
+                        children.filter((child) => child.checked !== false)
+                            .length > 0;
+
+                    if (allChildrenSelected) {
+                        item.checked = true;
+                    } else if (mixed) {
+                        item.checked = "mixed";
+                    }
+                }
+
+                item.hasMatchedSubItems = children.some(
+                    (child) => child.matched || child.hasMatchedSubItems
+                );
+                item.subItemIndexes = children.map((child) => child.index);
+            }
+        }
+        return current;
+    };
+
+    flatten(nestedList, undefined);
+
+    return items;
+};
+
+export const expandSelectedSubtrees = <T>(
+    list: NestedDropdownListLocalItem<T>[]
+) => {
+    return produce(list, (draft) => {
+        const selectedItems = draft.filter((item) => item.checked === true);
+        for (const selectedItem of selectedItems) {
+            let parentIndex = selectedItem.parentIndex;
+            while (parentIndex >= 0) {
+                const parent = draft[parentIndex];
+                parent.visible = true;
+                parent.expanded = true;
+
+                for (const i of parent.subItemIndexes) {
+                    draft[i].visible = true;
+                }
+
+                parentIndex = parent.parentIndex;
+            }
+        }
+    });
+};
+
+export const expandMatchedSubtrees = <T>(
+    list: NestedDropdownListLocalItem<T>[]
+) => {
+    return produce(list, (draft) => {
+        for (const item of draft) {
+            if (item.matched) {
+                item.visible = true;
+            }
+
+            if (item.hasMatchedSubItems) {
+                item.visible = true;
+                item.expanded = true;
+
+                for (const i of item.subItemIndexes) {
+                    draft[i].visible = true;
+                }
+            }
+        }
+    });
+};
+
+export const expandFirstSubtree = <T>(
+    list: NestedDropdownListLocalItem<T>[]
+) => {
+    return produce(list, (draft) => {
+        const firstSubtreeIndex = draft.findIndex((item) => item.hasSubItems);
+        if (firstSubtreeIndex < 0) {
+            return;
+        }
+        let index = firstSubtreeIndex;
+        let length = 0;
+        // find the first subtree
+        for (let i = index; i < draft.length; i++) {
+            const nextItemLength = draft[i].keyPath.length;
+            if (nextItemLength > length) {
+                length = nextItemLength;
+            } else if (nextItemLength < length) {
+                break;
+            }
+
+            index = i;
+            draft[i].visible = true;
+            draft[i].expanded = true;
+        }
+
+        // expand siblings of ancestors
+        for (let i = 0; i < draft.length; i++) {
+            const item = draft[i];
+            const parentKeyPath = item.keyPath.slice(0, -1);
+            const ancestorKeyPath = draft[index].keyPath.slice(
+                0,
+                parentKeyPath.length
+            );
+            if (isEqual(parentKeyPath, ancestorKeyPath)) {
+                item.visible = true;
+            }
+        }
+        return draft;
+    });
+};
+
+export const toggleSubtree = <T>(
+    list: NestedDropdownListLocalItem<T>[],
+    index: number,
+    expanded: boolean
+) => {
+    return produce(list, (draft) => {
+        draft[index].expanded = expanded;
+        const keyPath = draft[index].keyPath;
+        for (let i = index + 1; i < draft.length; i++) {
+            const item = draft[i];
+            const parent = draft[item.parentIndex];
+            const ancestorKeyPath = item.keyPath.slice(0, keyPath.length);
+            if (isEqual(keyPath, ancestorKeyPath)) {
+                item.visible = expanded && parent.expanded && parent.visible;
+            } else {
+                // no more descendents
+                break;
+            }
+        }
+    });
+};
+
+export const updateSelectedState = <T>(
+    list: NestedDropdownListLocalItem<T>[],
+    selectedKeyPaths: string[][],
+    multiSelect: boolean
+) => {
+    return produce(list, (draft) => {
+        for (let i = draft.length - 1; i >= 0; i--) {
+            const item = draft[i];
+            item.checked = !!selectedKeyPaths.find((keyPath) =>
+                isEqual(keyPath, item.keyPath)
+            );
+
+            if (item.hasSubItems) {
+                if (multiSelect && item.checked !== true) {
+                    const children = item.subItemIndexes.map(
+                        (index) => draft[index]
+                    );
+
+                    const allChildrenSelected =
+                        children.filter((child) => child.checked === true)
+                            .length === children.length;
+                    const mixed =
+                        children.filter((child) => child.checked !== false)
+                            .length > 0;
+
+                    if (allChildrenSelected) {
+                        item.checked = true;
+                    } else if (mixed) {
+                        item.checked = "mixed";
+                    }
+                }
+            }
+        }
+    });
+};
+
+export const findIndexFromStart = <T>(
+    arr: T[],
+    predicate: (e: T) => boolean,
+    start: number
+): number => {
+    for (let i = start; i < arr.length; i++) {
+        if (predicate(arr[i])) {
+            return i;
+        }
+    }
+
+    return -1;
+};
+
+export const findIndexFromEnd = <T>(
+    arr: T[],
+    predicate: (e: T) => boolean,
+    end: number
+): number => {
+    for (let i = end; i >= 0; i--) {
+        if (predicate(arr[i])) {
+            return i;
+        }
+    }
+
+    return -1;
+};

--- a/src/shared/dropdown-list-v2/nested-dropdown-list.styles.tsx
+++ b/src/shared/dropdown-list-v2/nested-dropdown-list.styles.tsx
@@ -57,12 +57,9 @@ export const ListItem = styled.div<ListItemStyleProps>`
 export const Indent = styled.div<IndentStyleProps>`
     height: 1px;
     width: ${(props) => {
-        let total = 0;
-        for (let i = 0; i < props.$level; i++) {
-            total += 1.625; // expand button
-            total += 0.5; // space
-        }
-        return total;
+        const expandButtonWidth = 1.625;
+        const spaceWidth = 0.5;
+        return (expandButtonWidth + spaceWidth) * props.$level;
     }}rem;
 `;
 

--- a/src/shared/dropdown-list-v2/nested-dropdown-list.styles.tsx
+++ b/src/shared/dropdown-list-v2/nested-dropdown-list.styles.tsx
@@ -1,0 +1,117 @@
+import { MinusSquareFillIcon } from "@lifesg/react-icons/minus-square-fill";
+import { TickIcon } from "@lifesg/react-icons/tick";
+import styled, { css } from "styled-components";
+import { Color } from "../../color";
+
+// =============================================================================
+// STYLE INTERFACE
+// =============================================================================
+interface ListItemStyleProps {
+    $active?: boolean;
+    $visible?: boolean;
+    $toggleable?: boolean;
+}
+
+interface IndentStyleProps {
+    $level?: number;
+}
+
+interface IndicatorStyleProps {
+    $hasNestedSiblings?: boolean;
+}
+
+interface ExpandButtonStyleProps {
+    $expanded?: boolean;
+}
+
+// =============================================================================
+// STYLING
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// LIST ITEM STYLES
+// -----------------------------------------------------------------------------
+
+export const ListItemContainer = styled.li<ListItemStyleProps>`
+    display: ${(props) => (props.$visible ? "flex" : "none")};
+`;
+
+export const ListItem = styled.div<ListItemStyleProps>`
+    flex: 1;
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding: 0.75rem 0.5rem;
+    cursor: ${(props) => (props.$toggleable ? "default" : "pointer")};
+    overflow: hidden; // required for label to truncate properly
+
+    outline-color: ${Color.Accent.Light[3]};
+
+    ${(props) =>
+        props.$active &&
+        css`
+            background: ${Color.Accent.Light[5]};
+        `}
+`;
+
+export const Indent = styled.div<IndentStyleProps>`
+    height: 1px;
+    width: ${(props) => {
+        let total = 0;
+        for (let i = 0; i < props.$level; i++) {
+            total += 1.625; // expand button
+            total += 0.5; // space
+        }
+        return total;
+    }}rem;
+`;
+
+export const ExpandButton = styled.div<ExpandButtonStyleProps>`
+    width: 1.625rem;
+    height: 1.625rem;
+    color: ${Color.Primary};
+    cursor: pointer;
+
+    svg {
+        width: 1.625rem;
+        height: 1.625rem;
+        transition: transform 250ms ease-in-out;
+
+        ${(props) => {
+            if (props.$expanded) {
+                return css`
+                    transform: rotate(90deg);
+                `;
+            }
+        }}
+    }
+`;
+
+export const UnexpandableIndicator = styled.div`
+    width: 1.625rem;
+    height: 1.625rem;
+    margin-right: 0.5rem;
+`;
+
+export const SelectionIndicator = styled.div<IndicatorStyleProps>`
+    flex-shrink: 0;
+    height: 1.625rem;
+    width: ${(props) => (props.$hasNestedSiblings ? "1.625rem" : "1rem")};
+
+    display: flex;
+    justify-content: center;
+`;
+
+export const SelectedIndicator = styled(TickIcon)`
+    flex-shrink: 0;
+    height: 1.625rem;
+    width: 1rem;
+    color: ${Color.Primary};
+`;
+
+export const CheckboxMixedIndicator = styled(MinusSquareFillIcon)`
+    flex-shrink: 0;
+    height: 1.625rem;
+    width: 1.625rem;
+    color: ${Color.Primary};
+`;

--- a/src/shared/dropdown-list-v2/nested-dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/nested-dropdown-list.tsx
@@ -1,0 +1,556 @@
+import { CaretRightIcon } from "@lifesg/react-icons/caret-right";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Spinner } from "../../button/button.style";
+import { useEvent, useEventListener, useIsMounted } from "../../util";
+import { DropdownLabel } from "./dropdown-label";
+import {
+    CheckboxSelectedIndicator,
+    CheckboxUnselectedIndicator,
+    Container,
+    LabelIcon,
+    List,
+    ResultStateContainer,
+    ResultStateText,
+    SelectAllButton,
+    SelectAllContainer,
+    TryAgainButton,
+} from "./dropdown-list.styles";
+import { DropdownSearch } from "./dropdown-search";
+import {
+    expandFirstSubtree,
+    expandMatchedSubtrees,
+    expandSelectedSubtrees,
+    findIndexFromEnd,
+    findIndexFromStart,
+    flattenList,
+    toggleSubtree,
+    updateSelectedState,
+} from "./nested-dropdown-list-helpers";
+import {
+    CheckboxMixedIndicator,
+    ExpandButton,
+    Indent,
+    ListItem,
+    ListItemContainer,
+    SelectedIndicator,
+    SelectionIndicator,
+    UnexpandableIndicator,
+} from "./nested-dropdown-list.styles";
+import {
+    NestedDropdownListItemProps,
+    NestedDropdownListLocalItem,
+    NestedDropdownListProps,
+} from "./types";
+
+export const NestedDropdownList = <T,>({
+    listItems,
+    multiSelect,
+    selectedKeyPaths,
+    itemsLoadState = "success",
+    itemTruncationType = "end",
+    itemMaxLines = 2,
+    variant = "default",
+    listboxId,
+    width,
+    mode = "default",
+    selectableCategory: _selectableCategory,
+    onSelectItem,
+    onSelectAll,
+    onRetry,
+    /* DropdownSearchProps */
+    enableSearch,
+    hideNoResultsDisplay,
+    searchPlaceholder = "Search",
+    searchFunction,
+    onSearch,
+}: NestedDropdownListProps<T>) => {
+    // =========================================================================
+    // CONST, STATE, REF
+    // =========================================================================
+    const selectableCategory = multiSelect || _selectableCategory;
+    const [searchValue, setSearchValue] = useState<string>("");
+    const searchTerm = searchValue.toLowerCase().trim();
+    const [searchActive, setSearchActive] = useState<boolean>(false);
+    const nodeRef = useRef<HTMLDivElement>();
+    const listRef = useRef<HTMLDivElement>();
+    const listItemRefs = useRef<HTMLElement[]>([]);
+    const searchInputRef = useRef<HTMLInputElement>();
+    const mounted = useIsMounted();
+
+    // maintaining a separate list for search and non-search as we need to
+    // preserve the original expanded state
+    const [unfilteredListItems, setUnfilteredListItems] = useState<
+        NestedDropdownListLocalItem<T>[]
+    >([]);
+    const [filteredListItems, setFilteredListItems] = useState<
+        NestedDropdownListLocalItem<T>[]
+    >([]);
+
+    const maxLevel = useMemo(() => {
+        let currentMaxLevel = 0;
+        for (const item of unfilteredListItems) {
+            if (item.level > currentMaxLevel) {
+                currentMaxLevel = item.level;
+            }
+        }
+        return currentMaxLevel;
+    }, [unfilteredListItems]);
+
+    // TODO: persist in context?
+    const [focusedIndex, setFocusedIndex] = useState(0);
+
+    // =========================================================================
+    // EVENT HANDLERS
+    // =========================================================================
+    const handleKeyboardPress = (event: KeyboardEvent) => {
+        const activeList = searchActive
+            ? filteredListItems
+            : unfilteredListItems;
+
+        switch (event.code) {
+            case "ArrowDown": {
+                event.preventDefault();
+                const upcomingIndex = findIndexFromStart(
+                    activeList,
+                    (item) => item.visible,
+                    focusedIndex + 1
+                );
+                if (upcomingIndex >= 0) {
+                    setFocusedIndex(upcomingIndex);
+                    listItemRefs.current[upcomingIndex].focus();
+                }
+                break;
+            }
+            case "ArrowUp": {
+                event.preventDefault();
+                const upcomingIndex = findIndexFromEnd(
+                    activeList,
+                    (item) => item.visible,
+                    focusedIndex - 1
+                );
+                if (upcomingIndex >= 0) {
+                    setFocusedIndex(upcomingIndex);
+                    listItemRefs.current[upcomingIndex].focus();
+                } else if (focusedIndex === 0 && searchInputRef.current) {
+                    searchInputRef.current.focus();
+                    setFocusedIndex(-1);
+                }
+                break;
+            }
+            case "ArrowRight": {
+                event.preventDefault();
+                toggleCategory(focusedIndex, true);
+                break;
+            }
+            case "ArrowLeft": {
+                event.preventDefault();
+                toggleCategory(focusedIndex, false);
+                break;
+            }
+            case "Space": {
+                if (
+                    document.activeElement ===
+                    listItemRefs.current[focusedIndex]
+                ) {
+                    event.preventDefault();
+                    const target = activeList[focusedIndex];
+                    if (target.hasSubItems && !selectableCategory) {
+                        return;
+                    }
+                    onSelectItem?.(target.keyPath);
+                }
+                break;
+            }
+        }
+    };
+
+    const handleSearchInputChange = (
+        event: React.ChangeEvent<HTMLInputElement>
+    ) => {
+        const value = event.target.value;
+        setSearchValue(value);
+
+        if (value === "") {
+            setSearchActive(false);
+        } else if (value.trim().length >= 3) {
+            setSearchActive(true);
+        }
+
+        onSearch?.();
+    };
+
+    const handleOnClear = () => {
+        setSearchValue("");
+        setSearchActive(false);
+        searchInputRef.current.focus();
+
+        onSearch?.();
+    };
+
+    const handleTryAgain = () => {
+        onRetry?.();
+    };
+
+    // =========================================================================
+    // HELPER FUNCTIONS
+    // =========================================================================
+    const flatten = useEvent(
+        (
+            nestedList: NestedDropdownListItemProps<T>[],
+            initialExpanded: boolean
+        ): NestedDropdownListLocalItem<T>[] => {
+            return flattenList(
+                nestedList,
+                selectedKeyPaths,
+                multiSelect,
+                searchTerm,
+                initialExpanded
+            );
+        }
+    );
+
+    const flattenDefaultMode = useEvent(
+        (nestedList: NestedDropdownListItemProps<T>[]) => {
+            if (selectedKeyPaths.length) {
+                return expandSelectedSubtrees(flatten(nestedList, false));
+            } else {
+                return expandFirstSubtree(flatten(nestedList, false));
+            }
+        }
+    );
+
+    const filter = useEvent((nestedList: NestedDropdownListItemProps<T>[]) => {
+        const filterMatchedItems = (list: NestedDropdownListItemProps<T>[]) => {
+            const matchedItems: NestedDropdownListItemProps<T>[] = [];
+            for (const item of list) {
+                const match =
+                    item.label.toLowerCase().indexOf(searchTerm) !== -1;
+
+                if (match) {
+                    matchedItems.push(item);
+                    continue;
+                }
+
+                if (item.subItems) {
+                    const matchedSubItems = filterMatchedItems(item.subItems);
+                    if (matchedSubItems.length > 0) {
+                        matchedItems.push({
+                            ...item,
+                            subItems: matchedSubItems,
+                        });
+                        continue;
+                    }
+                }
+            }
+            return matchedItems;
+        };
+        return filterMatchedItems(nestedList);
+    });
+
+    const toggleCategory = (index: number, nextExpanded: boolean) => {
+        const activeList = searchActive
+            ? filteredListItems
+            : unfilteredListItems;
+
+        const list = toggleSubtree(activeList, index, nextExpanded);
+        setFocusedIndex(index);
+
+        if (searchActive) {
+            setFilteredListItems(list);
+        } else {
+            setUnfilteredListItems(list);
+        }
+    };
+
+    // =========================================================================
+    // EFFECTS
+    // =========================================================================
+    useEventListener("keydown", handleKeyboardPress);
+
+    useEffect(() => {
+        let list: NestedDropdownListLocalItem<T>[];
+        if (mode === "default") {
+            list = flattenDefaultMode(listItems);
+        } else if (mode === "expand") {
+            list = flatten(listItems, true);
+        } else if (mode === "collapse") {
+            list = flatten(listItems, false);
+        }
+        setUnfilteredListItems(list);
+    }, [flatten, flattenDefaultMode, listItems, mode]);
+
+    useEffect(() => {
+        // update paths
+        setUnfilteredListItems((unfilteredListItems) =>
+            updateSelectedState(
+                unfilteredListItems,
+                selectedKeyPaths,
+                multiSelect
+            )
+        );
+    }, [multiSelect, selectedKeyPaths]);
+
+    useEffect(() => {
+        if (searchActive && searchValue.trim().length >= 3) {
+            const filteredListItems = filter(listItems);
+            const list = expandMatchedSubtrees(
+                flatten(filteredListItems, false)
+            );
+
+            setFilteredListItems(list);
+        }
+    }, [filter, flatten, listItems, searchActive, searchValue]);
+
+    useEffect(() => {
+        if (mounted) {
+            // only run on mount
+            return;
+        }
+
+        // Focus search input if there is one
+        if (searchInputRef.current) {
+            setFocusedIndex(-1);
+            setTimeout(() => searchInputRef.current?.focus(), 200); // wait for animation
+        } else if (listItemRefs.current[focusedIndex]) {
+            // Else focus on the specified element
+            setTimeout(() => listItemRefs.current[focusedIndex]?.focus(), 200);
+        } else {
+            // Else focus on the first list item
+            setFocusedIndex(0);
+            setTimeout(() => listItemRefs.current[0]?.focus(), 200);
+        }
+    }, [focusedIndex, mounted, setFocusedIndex]);
+
+    // =========================================================================
+    // RENDER FUNCTIONS
+    // =========================================================================
+    const renderSearchInput = () => {
+        if ((enableSearch || searchFunction) && itemsLoadState === "success") {
+            return (
+                <DropdownSearch
+                    ref={searchInputRef}
+                    onChange={handleSearchInputChange}
+                    value={searchValue}
+                    placeholder={searchPlaceholder}
+                    data-testid="search-input"
+                    aria-label="Enter text to search"
+                    onClear={handleOnClear}
+                    variant={variant}
+                />
+            );
+        }
+    };
+
+    const renderSelectAll = () => {
+        if (
+            multiSelect &&
+            filteredListItems.length > 0 &&
+            !searchValue &&
+            itemsLoadState === "success"
+        ) {
+            return (
+                <SelectAllContainer>
+                    <SelectAllButton
+                        onClick={onSelectAll}
+                        type="button"
+                        $variant={variant}
+                    >
+                        {selectedKeyPaths.length === 0
+                            ? "Select all"
+                            : "Clear all"}
+                    </SelectAllButton>
+                </SelectAllContainer>
+            );
+        }
+    };
+
+    const renderNoResults = () => {
+        if (
+            !hideNoResultsDisplay &&
+            searchActive &&
+            filteredListItems.length === 0 &&
+            itemsLoadState === "success"
+        ) {
+            return (
+                <ResultStateContainer data-testid="list-no-results">
+                    <LabelIcon $variant={variant} />
+                    <ResultStateText $variant={variant}>
+                        No results found.
+                    </ResultStateText>
+                </ResultStateContainer>
+            );
+        }
+    };
+
+    const renderLoading = () => {
+        if (onRetry && itemsLoadState === "loading") {
+            const spinnerSize = variant === "small" ? 16 : 18;
+
+            return (
+                <ResultStateContainer data-testid="list-loading">
+                    <Spinner $buttonStyle="secondary" size={spinnerSize} />
+                    <ResultStateText $variant={variant}>
+                        Loading...
+                    </ResultStateText>
+                </ResultStateContainer>
+            );
+        }
+    };
+
+    const renderTryAgain = () => {
+        if (onRetry && itemsLoadState === "fail") {
+            return (
+                <ResultStateContainer data-testid="list-fail">
+                    <LabelIcon
+                        data-testid="load-error-icon"
+                        $variant={variant}
+                    />
+                    <ResultStateText $variant={variant}>
+                        Failed to load.
+                    </ResultStateText>
+                    &nbsp;
+                    <TryAgainButton
+                        onClick={handleTryAgain}
+                        type="button"
+                        $variant={variant}
+                    >
+                        Try again.
+                    </TryAgainButton>
+                </ResultStateContainer>
+            );
+        }
+    };
+    const renderSelectionIcon = (listItem: NestedDropdownListLocalItem<T>) => {
+        if (multiSelect) {
+            switch (listItem.checked) {
+                case "mixed":
+                    return <CheckboxMixedIndicator aria-hidden />;
+                case true:
+                    return <CheckboxSelectedIndicator aria-hidden />;
+                default:
+                    return <CheckboxUnselectedIndicator aria-hidden />;
+            }
+        }
+
+        if (listItem.hasSubItems) {
+            // no icon needed
+            return;
+        }
+
+        return (
+            <SelectionIndicator
+                $hasNestedSiblings={
+                    listItem.hasNestedSiblings || listItem.level === 0
+                }
+            >
+                {listItem.checked && <SelectedIndicator aria-hidden />}
+            </SelectionIndicator>
+        );
+    };
+
+    const renderItems = () => {
+        const activeList = searchActive
+            ? filteredListItems
+            : unfilteredListItems;
+        return activeList.map((listItem, i) => {
+            const {
+                item,
+                level,
+                visible,
+                expanded,
+                keyPath,
+                checked,
+                hasSubItems,
+                indexInParent,
+                parentSetSize,
+            } = listItem;
+            const active = focusedIndex === i;
+            const toggleable = hasSubItems && !selectableCategory;
+
+            return (
+                <ListItemContainer
+                    key={`[${keyPath.join("---")}]`}
+                    $visible={visible}
+                >
+                    {maxLevel > 0 && <Indent $level={level} />}
+                    {maxLevel > 0 && !hasSubItems && multiSelect && (
+                        <UnexpandableIndicator />
+                    )}
+                    <ListItem
+                        aria-checked={checked}
+                        aria-expanded={hasSubItems ? expanded : undefined}
+                        aria-level={level + 1}
+                        aria-posinset={indexInParent + 1}
+                        aria-setsize={parentSetSize}
+                        data-testid="list-item"
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            if (toggleable) {
+                                toggleCategory(i, !expanded);
+                            } else {
+                                onSelectItem?.(keyPath);
+                            }
+                        }}
+                        ref={(node) => (listItemRefs.current[i] = node)}
+                        role="treeitem"
+                        tabIndex={active ? 0 : -1}
+                        $active={active}
+                        $toggleable={toggleable}
+                    >
+                        {hasSubItems && (
+                            // not an actual button, only required for visual display
+                            <ExpandButton
+                                data-testid="toggle-category-button"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    toggleCategory(i, !expanded);
+                                }}
+                                $expanded={expanded}
+                            >
+                                <CaretRightIcon />
+                            </ExpandButton>
+                        )}
+                        {renderSelectionIcon(listItem)}
+                        <DropdownLabel
+                            label={item.label}
+                            selected={!!checked}
+                            sublabel={undefined}
+                            truncationType={itemTruncationType}
+                            maxLines={itemMaxLines}
+                        ></DropdownLabel>
+                    </ListItem>
+                </ListItemContainer>
+            );
+        });
+    };
+
+    const renderList = () => {
+        return (
+            <List>
+                {renderSearchInput()}
+                {renderSelectAll()}
+                {renderNoResults()}
+                {renderLoading()}
+                {renderTryAgain()}
+                <div
+                    aria-multiselectable={multiSelect}
+                    id={listboxId}
+                    ref={listRef}
+                    role="tree"
+                >
+                    {renderItems()}
+                </div>
+            </List>
+        );
+    };
+
+    return (
+        <Container
+            data-testid="dropdown-container"
+            ref={nodeRef}
+            $width={width}
+        >
+            {renderList()}
+        </Container>
+    );
+};

--- a/src/shared/dropdown-list-v2/nested-dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/nested-dropdown-list.tsx
@@ -512,9 +512,9 @@ export const NestedDropdownList = <T,>({
                         )}
                         {renderSelectionIcon(listItem)}
                         <DropdownLabel
+                            bold={hasSubItems}
                             label={item.label}
                             selected={!!checked}
-                            sublabel={undefined}
                             truncationType={itemTruncationType}
                             maxLines={itemMaxLines}
                         ></DropdownLabel>

--- a/src/shared/dropdown-list-v2/nested-dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/nested-dropdown-list.tsx
@@ -191,6 +191,15 @@ export const NestedDropdownList = <T,>({
         onRetry?.();
     };
 
+    const handleListItemClick = (index: number, keyPath: string[]) => {
+        setFocusedIndex(index);
+        onSelectItem?.(keyPath);
+    };
+
+    const handleListItemHover = (index: number) => {
+        setFocusedIndex(index);
+    };
+
     // =========================================================================
     // HELPER FUNCTIONS
     // =========================================================================
@@ -488,9 +497,10 @@ export const NestedDropdownList = <T,>({
                             if (toggleable) {
                                 toggleCategory(i, !expanded);
                             } else {
-                                onSelectItem?.(keyPath);
+                                handleListItemClick(i, keyPath);
                             }
                         }}
+                        onMouseEnter={() => handleListItemHover(i)}
                         ref={(node) => (listItemRefs.current[i] = node)}
                         role="treeitem"
                         tabIndex={active ? 0 : -1}

--- a/src/shared/dropdown-list-v2/types.ts
+++ b/src/shared/dropdown-list-v2/types.ts
@@ -1,3 +1,6 @@
+// =============================================================================
+// SHARED PROPS
+// =============================================================================
 export type TruncateType = "middle" | "end";
 export type ItemsLoadStateType = "loading" | "fail" | "success";
 export type LabelDisplayType = "inline" | "next-line";
@@ -43,14 +46,8 @@ export interface DropdownSearchProps<T> {
     onSearch?: (() => void) | undefined;
 }
 
-export interface DropdownListProps<T, V>
-    extends DropdownDisplayProps<T, V>,
-        DropdownSearchProps<T> {
-    listItems?: T[] | undefined;
+export interface DropdownConfigProps {
     multiSelect?: boolean | undefined;
-    selectedItems?: T[] | undefined;
-    disableItemFocus?: boolean | undefined;
-    listboxId?: string | undefined;
     width?: number | undefined;
     /**
      * Used when items are loaded from an api call.
@@ -61,13 +58,87 @@ export interface DropdownListProps<T, V>
     itemTruncationType?: TruncateType | undefined;
     /** Specifies the maximum number of lines visible before the label is truncated for "end" type */
     itemMaxLines?: number | undefined;
-    /** Specifying flex direction within item */
-    labelDisplayType?: LabelDisplayType | undefined;
     /** Specifies the variant type. Small type will have shorter height. Values: "default" | "small" */
     variant?: DropdownVariantType | undefined;
+}
+
+// =============================================================================
+// DROPDOWN PROPS
+// =============================================================================
+
+export interface DropdownListProps<T, V>
+    extends DropdownDisplayProps<T, V>,
+        DropdownSearchProps<T>,
+        DropdownConfigProps {
+    listItems?: T[] | undefined;
+    selectedItems?: T[] | undefined;
+    disableItemFocus?: boolean | undefined;
+    listboxId?: string | undefined;
+    /** Specifying flex direction within item */
+    labelDisplayType?: LabelDisplayType | undefined;
 
     onSelectItem?: ((item: T, extractedValue: V) => void) | undefined;
     onSelectAll?: (() => void) | undefined;
     onDismiss?: ((setSelectorFocus?: boolean | undefined) => void) | undefined;
+    onRetry?: (() => void) | undefined;
+}
+
+// =============================================================================
+// NESTED DROPDOWN PROPS
+// =============================================================================
+
+export interface NestedDropdownListLeafItem<T> {
+    key: string;
+    label: string;
+    value: T;
+    subItems?: never | undefined;
+}
+
+export interface NestedDropdownListParentItem<T> {
+    key: string;
+    label: string;
+    value: T;
+    subItems: NestedDropdownListItemProps<T>[];
+}
+
+export type NestedDropdownListItemProps<T> =
+    | NestedDropdownListLeafItem<T>
+    | NestedDropdownListParentItem<T>;
+
+// internal representation of a list item
+export interface NestedDropdownListLocalItem<T> {
+    item: NestedDropdownListItemProps<T>;
+    index: number;
+    indexInParent: number;
+    parentSetSize: number;
+    keyPath: string[];
+    parentIndex: number;
+    parentKeyPath: string[];
+    level: number;
+    visible: boolean;
+    expanded: boolean;
+    checked: "mixed" | true | false;
+    hasSubItems: boolean;
+    subItemIndexes: number[];
+    hasNestedSiblings: boolean;
+    matched: boolean;
+    hasMatchedSubItems: boolean;
+}
+
+export type ExpandMode = "default" | "expand" | "collapse";
+
+export interface NestedDropdownListProps<T>
+    extends DropdownSearchProps<NestedDropdownListItemProps<T>>,
+        DropdownConfigProps {
+    listItems: NestedDropdownListItemProps<T>[];
+    selectedKeyPaths: string[][];
+    listboxId?: string | undefined;
+    /** Specifies if items are expanded or collapsed when the dropdown is opened */
+    mode?: ExpandMode | undefined;
+    /** If specified, the category label is selectable */
+    selectableCategory?: boolean | undefined;
+
+    onSelectItem?: ((keyPath: string[]) => void) | undefined;
+    onSelectAll?: (() => void) | undefined;
     onRetry?: (() => void) | undefined;
 }

--- a/stories/form/form-nested-select/test.stories.tsx
+++ b/stories/form/form-nested-select/test.stories.tsx
@@ -1,0 +1,367 @@
+// TODO: to be removed
+
+import type { Meta } from "@storybook/react";
+import { useState } from "react";
+import { NestedDropdownList } from "../../../src/shared/dropdown-list-v2/nested-dropdown-list";
+import isEqual from "lodash/isEqual";
+
+const meta: Meta = {
+    title: "Test",
+};
+
+export default meta;
+
+const selected = false; // update this to test pre-selected behaviour
+const initialKeyPath = ["1", "20", "300", "2000"];
+
+export const Single = {
+    render: () => {
+        const [selectedKeyPath, setSelectedKeyPath] = useState(
+            selected ? initialKeyPath : undefined
+        );
+        return (
+            <div style={{ width: "23rem" }}>
+                <NestedDropdownList
+                    selectedKeyPaths={selectedKeyPath ? [selectedKeyPath] : []}
+                    onSelectItem={setSelectedKeyPath}
+                    listItems={options}
+                />
+            </div>
+        );
+    },
+};
+
+export const SingleExpanded = {
+    render: () => {
+        const [selectedKeyPath, setSelectedKeyPath] = useState(
+            selected ? initialKeyPath : undefined
+        );
+        return (
+            <div style={{ width: "23rem" }}>
+                <NestedDropdownList
+                    selectedKeyPaths={selectedKeyPath ? [selectedKeyPath] : []}
+                    onSelectItem={setSelectedKeyPath}
+                    listItems={options}
+                    mode="expand"
+                />
+            </div>
+        );
+    },
+};
+
+export const SingleCollapsed = {
+    render: () => {
+        const [selectedKeyPath, setSelectedKeyPath] = useState(
+            selected ? initialKeyPath : undefined
+        );
+        return (
+            <div style={{ width: "23rem" }}>
+                <NestedDropdownList
+                    selectedKeyPaths={selectedKeyPath ? [selectedKeyPath] : []}
+                    onSelectItem={setSelectedKeyPath}
+                    listItems={options}
+                    mode="collapse"
+                />
+            </div>
+        );
+    },
+};
+
+export const SingleWithSearch = {
+    render: () => {
+        const [selectedKeyPath, setSelectedKeyPath] = useState(
+            selected ? initialKeyPath : undefined
+        );
+        return (
+            <div style={{ width: "23rem" }}>
+                <NestedDropdownList
+                    selectedKeyPaths={selectedKeyPath ? [selectedKeyPath] : []}
+                    onSelectItem={setSelectedKeyPath}
+                    enableSearch
+                    listItems={optionsForSearch}
+                />
+            </div>
+        );
+    },
+};
+
+export const SingleWithSelectableCategory = {
+    render: () => {
+        const [selectedKeyPath, setSelectedKeyPath] = useState(
+            selected ? initialKeyPath : undefined
+        );
+        return (
+            <div style={{ width: "23rem" }}>
+                <NestedDropdownList
+                    selectedKeyPaths={selectedKeyPath ? [selectedKeyPath] : []}
+                    onSelectItem={setSelectedKeyPath}
+                    selectableCategory
+                    listItems={options}
+                />
+            </div>
+        );
+    },
+};
+
+export const Multi = {
+    render: () => {
+        const [selectedKeyPaths, setSelectedKeyPaths] = useState(
+            selected ? [initialKeyPath] : []
+        );
+        const handleSelectItem = (keyPath: string[]) => {
+            const index = selectedKeyPaths.findIndex((selectedKeyPath) =>
+                isEqual(selectedKeyPath, keyPath)
+            );
+            if (index >= 0) {
+                setSelectedKeyPaths([
+                    ...selectedKeyPaths.slice(0, index),
+                    ...selectedKeyPaths.slice(index + 1),
+                ]);
+            } else {
+                setSelectedKeyPaths([...selectedKeyPaths, keyPath]);
+            }
+        };
+        return (
+            <div style={{ width: "23rem" }}>
+                <NestedDropdownList
+                    selectedKeyPaths={selectedKeyPaths}
+                    onSelectItem={handleSelectItem}
+                    multiSelect
+                    listItems={options}
+                />
+            </div>
+        );
+    },
+};
+
+export const MultiWithSearch = {
+    render: () => {
+        const [selectedKeyPaths, setSelectedKeyPaths] = useState(
+            selected ? [initialKeyPath] : []
+        );
+        const handleSelectItem = (keyPath: string[]) => {
+            const index = selectedKeyPaths.findIndex((selectedKeyPath) =>
+                isEqual(selectedKeyPath, keyPath)
+            );
+            if (index >= 0) {
+                setSelectedKeyPaths([
+                    ...selectedKeyPaths.slice(0, index),
+                    ...selectedKeyPaths.slice(index + 1),
+                ]);
+            } else {
+                setSelectedKeyPaths([...selectedKeyPaths, keyPath]);
+            }
+        };
+        return (
+            <div style={{ width: "23rem" }}>
+                <NestedDropdownList
+                    selectedKeyPaths={selectedKeyPaths}
+                    onSelectItem={handleSelectItem}
+                    multiSelect
+                    enableSearch
+                    listItems={optionsForSearch}
+                />
+            </div>
+        );
+    },
+};
+
+const options = [
+    {
+        label: "1",
+        value: "1",
+        key: "1",
+        subItems: [
+            {
+                label: "1.1",
+                value: "1.1",
+                key: "10",
+            },
+            {
+                label: "1.2",
+                value: "1.2",
+                key: "20",
+                subItems: [
+                    {
+                        label: "1.2.1",
+                        value: "1.2.1",
+                        key: "100",
+                    },
+                    {
+                        label: "1.2.2",
+                        value: "1.2.2",
+                        key: "200",
+                        subItems: [
+                            {
+                                label: "1.2.2.1",
+                                value: "1.2.2.1",
+                                key: "1000",
+                            },
+                            {
+                                label: "1.2.2.2",
+                                value: "1.2.2.2",
+                                key: "2000",
+                            },
+                        ],
+                    },
+                    {
+                        label: "1.2.3",
+                        value: "1.2.3",
+                        key: "300",
+                        subItems: [
+                            {
+                                label: "1.2.3.1",
+                                value: "1.2.3.1",
+                                key: "1000",
+                            },
+                            {
+                                label: "1.2.3.2",
+                                value: "1.2.3.2",
+                                key: "2000",
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                label: "1.3",
+                value: "1.3",
+                key: "30",
+                subItems: [
+                    {
+                        label: "1.3.1",
+                        value: "1.3.1",
+                        key: "100",
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        label: "2",
+        value: "2",
+        key: "2",
+        subItems: [
+            {
+                label: "2.1",
+                value: "2.1",
+                key: "10",
+            },
+            {
+                label: "2.2",
+                value: "2.2",
+                key: "20",
+                subItems: [
+                    {
+                        label: "2.2.1",
+                        value: "2.2.1",
+                        key: "100",
+                    },
+                    {
+                        label: "2.2.2",
+                        value: "2.2.2",
+                        key: "200",
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        label: "3",
+        value: "3",
+        key: "3",
+    },
+];
+
+const optionsForSearch = [
+    {
+        label: "Perishables",
+        value: "1",
+        key: "1",
+        subItems: [
+            {
+                label: "Banana milk",
+                value: "1.1",
+                key: "10",
+            },
+            {
+                label: "Fruits",
+                value: "1.2",
+                key: "20",
+                subItems: [
+                    {
+                        label: "Avocado",
+                        value: "1.2.1",
+                        key: "100",
+                    },
+                    {
+                        label: "Berries",
+                        value: "1.2.2",
+                        key: "200",
+                        subItems: [
+                            {
+                                label: "Banana",
+                                value: "1.2.2.1",
+                                key: "1000",
+                            },
+                            {
+                                label: "Blueberry",
+                                value: "1.2.2.2",
+                                key: "2000",
+                            },
+                        ],
+                    },
+                    {
+                        label: "Not berries",
+                        value: "1.2.3",
+                        key: "300",
+                        subItems: [
+                            {
+                                label: "Strawberry",
+                                value: "1.2.3.1",
+                                key: "1000",
+                            },
+                            {
+                                label: "Raspberry",
+                                value: "1.2.3.2",
+                                key: "2000",
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                label: "Cooking oil",
+                value: "1.3",
+                key: "30",
+            },
+            {
+                label: "Skimmed milk",
+                value: "1.4",
+                key: "40",
+            },
+        ],
+    },
+    {
+        label: "Toiletries",
+        value: "2",
+        key: "2",
+        subItems: [
+            {
+                label: "Toilet paper",
+                value: "2.1",
+                key: "10",
+            },
+            {
+                label: "Shampoo",
+                value: "2.2",
+                key: "20",
+            },
+        ],
+    },
+    {
+        label: "Cats conserve energy by sleeping more than most animals, especially as they grow older",
+        value: "3",
+        key: "3",
+    },
+];

--- a/tests/shared/dropdown-list-v2/nested-dropdown-list.spec.tsx
+++ b/tests/shared/dropdown-list-v2/nested-dropdown-list.spec.tsx
@@ -1,0 +1,618 @@
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import { NestedDropdownList } from "../../../src/shared/dropdown-list-v2/nested-dropdown-list";
+import { NestedDropdownListItemProps } from "../../../src/shared/dropdown-list-v2/types";
+import userEvent from "@testing-library/user-event";
+
+describe("NestedDropdownList", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        global.ResizeObserver = jest.fn().mockImplementation(() => ({
+            observe: jest.fn(),
+            unobserve: jest.fn(),
+            disconnect: jest.fn(),
+        }));
+    });
+
+    describe("mode = default", () => {
+        it("should expand the first subtree (1 tier)", () => {
+            const options = buildOptions([["1"], ["2"]]);
+            render(
+                <NestedDropdownList listItems={options} selectedKeyPaths={[]} />
+            );
+
+            expect(screen.queryByText("Child 1 item")).toBeVisible();
+            expect(screen.queryByText("Child 2 item")).toBeVisible();
+        });
+
+        it("should expand the first subtree (2 tier)", () => {
+            const options = buildOptions([
+                ["1", [["1.1"], ["1.2"]]],
+                ["2", [["2.1"], ["2.2"]]],
+            ]);
+            render(
+                <NestedDropdownList listItems={options} selectedKeyPaths={[]} />
+            );
+
+            expect(screen.queryByText("Parent 1 item")).toBeVisible();
+            expect(screen.queryByText("Child 1.1 item")).toBeVisible();
+            expect(screen.queryByText("Child 1.2 item")).toBeVisible();
+            expect(screen.queryByText("Parent 2 item")).toBeVisible();
+            expect(screen.queryByText("Child 2.1 item")).not.toBeVisible();
+            expect(screen.queryByText("Child 2.2 item")).not.toBeVisible();
+
+            expect(
+                screen.getByRole("treeitem", { name: "Parent 1 item" })
+            ).toHaveAttribute("aria-expanded", "true");
+            expect(
+                screen.getByRole("treeitem", { name: "Parent 2 item" })
+            ).toHaveAttribute("aria-expanded", "false");
+        });
+
+        it("should expand the first subtree (3 tier)", () => {
+            const options = buildOptions([
+                [
+                    "1",
+                    [
+                        ["1.1"],
+                        ["1.2", [["1.2.1"], ["1.2.2"]]],
+                        ["1.3", [["1.3.1"]]],
+                    ],
+                ],
+                ["2", [["2.1"], ["2.2", [["2.2.1"]]]]],
+            ]);
+            render(
+                <NestedDropdownList listItems={options} selectedKeyPaths={[]} />
+            );
+
+            expect(screen.queryByText("Parent 1 item")).toBeVisible();
+            expect(screen.queryByText("Child 1.1 item")).toBeVisible();
+            expect(screen.queryByText("Parent 1.2 item")).toBeVisible();
+            expect(screen.queryByText("Child 1.2.1 item")).toBeVisible();
+            expect(screen.queryByText("Parent 1.3 item")).toBeVisible();
+            expect(screen.queryByText("Child 1.3.1 item")).not.toBeVisible();
+            expect(screen.queryByText("Parent 2 item")).toBeVisible();
+            expect(screen.queryByText("Child 2.1 item")).not.toBeVisible();
+            expect(screen.queryByText("Parent 2.2 item")).not.toBeVisible();
+            expect(screen.queryByText("Child 2.2.1 item")).not.toBeVisible();
+
+            expect(
+                screen.getByRole("treeitem", { name: "Parent 1 item" })
+            ).toHaveAttribute("aria-expanded", "true");
+            expect(
+                screen.getByRole("treeitem", { name: "Parent 1.2 item" })
+            ).toHaveAttribute("aria-expanded", "true");
+            expect(
+                screen.getByRole("treeitem", { name: "Parent 1.3 item" })
+            ).toHaveAttribute("aria-expanded", "false");
+            expect(
+                screen.getByRole("treeitem", { name: "Parent 2 item" })
+            ).toHaveAttribute("aria-expanded", "false");
+        });
+    });
+
+    describe("mode = expand", () => {
+        it("should expand all subtrees (1 tier)", () => {
+            const options = buildOptions([["1"], ["2"]]);
+            render(
+                <NestedDropdownList
+                    listItems={options}
+                    selectedKeyPaths={[]}
+                    mode="expand"
+                />
+            );
+
+            expect(screen.queryByText("Child 1 item")).toBeVisible();
+            expect(screen.queryByText("Child 2 item")).toBeVisible();
+        });
+
+        it("should expand all subtrees (2 tier)", () => {
+            const options = buildOptions([
+                ["1", [["1.1"], ["1.2"]]],
+                ["2", [["2.1"], ["2.2"]]],
+            ]);
+            render(
+                <NestedDropdownList
+                    listItems={options}
+                    selectedKeyPaths={[]}
+                    mode="expand"
+                />
+            );
+
+            expect(screen.queryByText("Parent 1 item")).toBeVisible();
+            expect(screen.queryByText("Child 1.1 item")).toBeVisible();
+            expect(screen.queryByText("Child 1.2 item")).toBeVisible();
+            expect(screen.queryByText("Parent 2 item")).toBeVisible();
+            expect(screen.queryByText("Child 2.1 item")).toBeVisible();
+            expect(screen.queryByText("Child 2.2 item")).toBeVisible();
+
+            expect(
+                screen.getByRole("treeitem", { name: "Parent 1 item" })
+            ).toHaveAttribute("aria-expanded", "true");
+            expect(
+                screen.getByRole("treeitem", { name: "Parent 2 item" })
+            ).toHaveAttribute("aria-expanded", "true");
+        });
+
+        it("should expand all subtrees (3 tier)", () => {
+            const options = buildOptions([
+                [
+                    "1",
+                    [
+                        ["1.1"],
+                        ["1.2", [["1.2.1"], ["1.2.2"]]],
+                        ["1.3", [["1.3.1"]]],
+                    ],
+                ],
+                ["2", [["2.1"], ["2.2", [["2.2.1"]]]]],
+            ]);
+            render(
+                <NestedDropdownList
+                    listItems={options}
+                    selectedKeyPaths={[]}
+                    mode="expand"
+                />
+            );
+
+            expect(screen.queryByText("Parent 1 item")).toBeVisible();
+            expect(screen.queryByText("Child 1.1 item")).toBeVisible();
+            expect(screen.queryByText("Parent 1.2 item")).toBeVisible();
+            expect(screen.queryByText("Child 1.2.1 item")).toBeVisible();
+            expect(screen.queryByText("Parent 1.3 item")).toBeVisible();
+            expect(screen.queryByText("Child 1.3.1 item")).toBeVisible();
+            expect(screen.queryByText("Parent 2 item")).toBeVisible();
+            expect(screen.queryByText("Child 2.1 item")).toBeVisible();
+            expect(screen.queryByText("Parent 2.2 item")).toBeVisible();
+            expect(screen.queryByText("Child 2.2.1 item")).toBeVisible();
+
+            expect(
+                screen.getByRole("treeitem", { name: "Parent 1 item" })
+            ).toHaveAttribute("aria-expanded", "true");
+            expect(
+                screen.getByRole("treeitem", { name: "Parent 1.2 item" })
+            ).toHaveAttribute("aria-expanded", "true");
+            expect(
+                screen.getByRole("treeitem", { name: "Parent 1.3 item" })
+            ).toHaveAttribute("aria-expanded", "true");
+            expect(
+                screen.getByRole("treeitem", { name: "Parent 2 item" })
+            ).toHaveAttribute("aria-expanded", "true");
+        });
+    });
+
+    describe("mode = collapse", () => {
+        it("should collapse all subtrees (1 tier)", () => {
+            const options = buildOptions([["1"], ["2"]]);
+            render(
+                <NestedDropdownList
+                    listItems={options}
+                    selectedKeyPaths={[]}
+                    mode="collapse"
+                />
+            );
+
+            expect(screen.queryByText("Child 1 item")).toBeVisible();
+            expect(screen.queryByText("Child 2 item")).toBeVisible();
+        });
+
+        it("should collapse all subtrees (2 tier)", () => {
+            const options = buildOptions([
+                ["1", [["1.1"], ["1.2"]]],
+                ["2", [["2.1"], ["2.2"]]],
+            ]);
+            render(
+                <NestedDropdownList
+                    listItems={options}
+                    selectedKeyPaths={[]}
+                    mode="collapse"
+                />
+            );
+
+            expect(screen.queryByText("Parent 1 item")).toBeVisible();
+            expect(screen.queryByText("Child 1.1 item")).not.toBeVisible();
+            expect(screen.queryByText("Child 1.2 item")).not.toBeVisible();
+            expect(screen.queryByText("Parent 2 item")).toBeVisible();
+            expect(screen.queryByText("Child 2.1 item")).not.toBeVisible();
+            expect(screen.queryByText("Child 2.2 item")).not.toBeVisible();
+
+            expect(
+                screen.getByRole("treeitem", { name: "Parent 1 item" })
+            ).toHaveAttribute("aria-expanded", "false");
+            expect(
+                screen.getByRole("treeitem", { name: "Parent 2 item" })
+            ).toHaveAttribute("aria-expanded", "false");
+        });
+
+        it("should collapse all subtrees (3 tier)", () => {
+            const options = buildOptions([
+                [
+                    "1",
+                    [
+                        ["1.1"],
+                        ["1.2", [["1.2.1"], ["1.2.2"]]],
+                        ["1.3", [["1.3.1"]]],
+                    ],
+                ],
+                ["2", [["2.1"], ["2.2", [["2.2.1"]]]]],
+            ]);
+            render(
+                <NestedDropdownList
+                    listItems={options}
+                    selectedKeyPaths={[]}
+                    mode="collapse"
+                />
+            );
+
+            expect(screen.queryByText("Parent 1 item")).toBeVisible();
+            expect(screen.queryByText("Child 1.1 item")).not.toBeVisible();
+            expect(screen.queryByText("Parent 1.2 item")).not.toBeVisible();
+            expect(screen.queryByText("Child 1.2.1 item")).not.toBeVisible();
+            expect(screen.queryByText("Parent 1.3 item")).not.toBeVisible();
+            expect(screen.queryByText("Child 1.3.1 item")).not.toBeVisible();
+            expect(screen.queryByText("Parent 2 item")).toBeVisible();
+            expect(screen.queryByText("Child 2.1 item")).not.toBeVisible();
+            expect(screen.queryByText("Parent 2.2 item")).not.toBeVisible();
+            expect(screen.queryByText("Child 2.2.1 item")).not.toBeVisible();
+
+            expect(
+                screen.getByRole("treeitem", { name: "Parent 1 item" })
+            ).toHaveAttribute("aria-expanded", "false");
+            expect(
+                screen.getByRole("treeitem", { name: "Parent 2 item" })
+            ).toHaveAttribute("aria-expanded", "false");
+        });
+    });
+
+    it("should expand a collapsed category on item click", async () => {
+        const user = userEvent.setup();
+        const mockOnSelectItem = jest.fn();
+        const options = buildOptions([
+            [
+                "1",
+                [
+                    ["1.1", [["1.1.1"]]],
+                    ["1.2", [["1.2.1"]]],
+                    ["1.3", [["1.3.1"]]],
+                ],
+            ],
+        ]);
+        render(
+            <NestedDropdownList
+                listItems={options}
+                selectedKeyPaths={[]}
+                mode="collapse"
+                onSelectItem={mockOnSelectItem}
+            />
+        );
+
+        await user.click(screen.queryByText("Parent 1 item"));
+
+        expect(screen.queryByText("Parent 1 item")).toBeVisible();
+        expect(screen.queryByText("Parent 1.1 item")).toBeVisible();
+        expect(screen.queryByText("Child 1.1.1 item")).not.toBeVisible();
+        expect(screen.queryByText("Parent 1.2 item")).toBeVisible();
+        expect(screen.queryByText("Child 1.2.1 item")).not.toBeVisible();
+        expect(screen.queryByText("Parent 1.3 item")).toBeVisible();
+        expect(screen.queryByText("Child 1.3.1 item")).not.toBeVisible();
+
+        await user.click(screen.queryByText("Parent 1.1 item"));
+
+        expect(screen.queryByText("Parent 1 item")).toBeVisible();
+        expect(screen.queryByText("Parent 1.1 item")).toBeVisible();
+        expect(screen.queryByText("Child 1.1.1 item")).toBeVisible();
+        expect(screen.queryByText("Parent 1.2 item")).toBeVisible();
+        expect(screen.queryByText("Child 1.2.1 item")).not.toBeVisible();
+        expect(screen.queryByText("Parent 1.3 item")).toBeVisible();
+        expect(screen.queryByText("Child 1.3.1 item")).not.toBeVisible();
+
+        expect(mockOnSelectItem).not.toHaveBeenCalled();
+    });
+
+    it("should expand a collapsed category with right arrow key", async () => {
+        const user = userEvent.setup();
+        const mockOnSelectItem = jest.fn();
+        const options = buildOptions([
+            [
+                "1",
+                [
+                    ["1.1", [["1.1.1"]]],
+                    ["1.2", [["1.2.1"]]],
+                    ["1.3", [["1.3.1"]]],
+                ],
+            ],
+        ]);
+        render(
+            <NestedDropdownList
+                listItems={options}
+                selectedKeyPaths={[]}
+                mode="collapse"
+                onSelectItem={mockOnSelectItem}
+            />
+        );
+
+        await waitFor(() =>
+            expect(
+                screen.queryByRole("treeitem", { name: "Parent 1 item" })
+            ).toHaveFocus()
+        );
+
+        await act(async () => {
+            await user.keyboard("{ArrowRight}");
+        });
+
+        expect(screen.queryByText("Parent 1 item")).toBeVisible();
+        expect(screen.queryByText("Parent 1.1 item")).toBeVisible();
+        expect(screen.queryByText("Child 1.1.1 item")).not.toBeVisible();
+        expect(screen.queryByText("Parent 1.2 item")).toBeVisible();
+        expect(screen.queryByText("Child 1.2.1 item")).not.toBeVisible();
+        expect(screen.queryByText("Parent 1.3 item")).toBeVisible();
+        expect(screen.queryByText("Child 1.3.1 item")).not.toBeVisible();
+
+        await act(async () => {
+            await user.keyboard("{ArrowDown}{ArrowRight}");
+        });
+
+        expect(screen.queryByText("Parent 1 item")).toBeVisible();
+        expect(screen.queryByText("Parent 1.1 item")).toBeVisible();
+        expect(screen.queryByText("Child 1.1.1 item")).toBeVisible();
+        expect(screen.queryByText("Parent 1.2 item")).toBeVisible();
+        expect(screen.queryByText("Child 1.2.1 item")).not.toBeVisible();
+        expect(screen.queryByText("Parent 1.3 item")).toBeVisible();
+        expect(screen.queryByText("Child 1.3.1 item")).not.toBeVisible();
+
+        expect(mockOnSelectItem).not.toHaveBeenCalled();
+    });
+
+    it("should collapse an expanded category on item click", async () => {
+        const user = userEvent.setup();
+        const mockOnSelectItem = jest.fn();
+        const options = buildOptions([
+            [
+                "1",
+                [
+                    ["1.1", [["1.1.1"]]],
+                    ["1.2", [["1.2.1"]]],
+                    ["1.3", [["1.3.1"]]],
+                ],
+            ],
+        ]);
+        render(
+            <NestedDropdownList
+                listItems={options}
+                selectedKeyPaths={[]}
+                mode="expand"
+                onSelectItem={mockOnSelectItem}
+            />
+        );
+
+        await user.click(screen.queryByText("Parent 1.1 item"));
+
+        expect(screen.queryByText("Parent 1 item")).toBeVisible();
+        expect(screen.queryByText("Parent 1.1 item")).toBeVisible();
+        expect(screen.queryByText("Child 1.1.1 item")).not.toBeVisible();
+        expect(screen.queryByText("Parent 1.2 item")).toBeVisible();
+        expect(screen.queryByText("Child 1.2.1 item")).toBeVisible();
+        expect(screen.queryByText("Parent 1.3 item")).toBeVisible();
+        expect(screen.queryByText("Child 1.3.1 item")).toBeVisible();
+
+        await user.click(screen.queryByText("Parent 1 item"));
+
+        expect(screen.queryByText("Parent 1 item")).toBeVisible();
+        expect(screen.queryByText("Parent 1.1 item")).not.toBeVisible();
+        expect(screen.queryByText("Child 1.1.1 item")).not.toBeVisible();
+        expect(screen.queryByText("Parent 1.2 item")).not.toBeVisible();
+        expect(screen.queryByText("Child 1.2.1 item")).not.toBeVisible();
+        expect(screen.queryByText("Parent 1.3 item")).not.toBeVisible();
+        expect(screen.queryByText("Child 1.3.1 item")).not.toBeVisible();
+
+        expect(mockOnSelectItem).not.toHaveBeenCalled();
+    });
+
+    it("should collapse an expanded category with right arrow key", async () => {
+        const user = userEvent.setup();
+        const mockOnSelectItem = jest.fn();
+        const options = buildOptions([
+            [
+                "1",
+                [
+                    ["1.1", [["1.1.1"]]],
+                    ["1.2", [["1.2.1"]]],
+                    ["1.3", [["1.3.1"]]],
+                ],
+            ],
+        ]);
+        render(
+            <NestedDropdownList
+                listItems={options}
+                selectedKeyPaths={[]}
+                mode="expand"
+                onSelectItem={mockOnSelectItem}
+            />
+        );
+
+        await waitFor(() =>
+            expect(
+                screen.queryByRole("treeitem", { name: "Parent 1 item" })
+            ).toHaveFocus()
+        );
+
+        await act(async () => {
+            await user.keyboard("{ArrowDown}{ArrowLeft}");
+        });
+
+        expect(screen.queryByText("Parent 1 item")).toBeVisible();
+        expect(screen.queryByText("Parent 1.1 item")).toBeVisible();
+        expect(screen.queryByText("Child 1.1.1 item")).not.toBeVisible();
+        expect(screen.queryByText("Parent 1.2 item")).toBeVisible();
+        expect(screen.queryByText("Child 1.2.1 item")).toBeVisible();
+        expect(screen.queryByText("Parent 1.3 item")).toBeVisible();
+        expect(screen.queryByText("Child 1.3.1 item")).toBeVisible();
+
+        await act(async () => {
+            await user.keyboard("{ArrowUp}{ArrowLeft}");
+        });
+
+        expect(screen.queryByText("Parent 1 item")).toBeVisible();
+        expect(screen.queryByText("Parent 1.1 item")).not.toBeVisible();
+        expect(screen.queryByText("Child 1.1.1 item")).not.toBeVisible();
+        expect(screen.queryByText("Parent 1.2 item")).not.toBeVisible();
+        expect(screen.queryByText("Child 1.2.1 item")).not.toBeVisible();
+        expect(screen.queryByText("Parent 1.3 item")).not.toBeVisible();
+        expect(screen.queryByText("Child 1.3.1 item")).not.toBeVisible();
+
+        expect(mockOnSelectItem).not.toHaveBeenCalled();
+    });
+
+    describe("selectableCategory = true", () => {
+        it("should select instead of toggling category on click", async () => {
+            const user = userEvent.setup();
+            const mockOnSelectItem = jest.fn();
+            const options = buildOptions([
+                [
+                    "1",
+                    [
+                        ["1.1", [["1.1.1"]]],
+                        ["1.2", [["1.2.1"]]],
+                        ["1.3", [["1.3.1"]]],
+                    ],
+                ],
+            ]);
+            render(
+                <NestedDropdownList
+                    listItems={options}
+                    selectedKeyPaths={[]}
+                    selectableCategory
+                    onSelectItem={mockOnSelectItem}
+                />
+            );
+
+            await user.click(screen.queryByText("Parent 1.1 item"));
+
+            expect(mockOnSelectItem).toHaveBeenCalledWith(["1", "1.1"]);
+            expect(screen.queryByText("Child 1.1.1 item")).toBeVisible();
+            expect(
+                screen.getByRole("treeitem", { name: "Parent 1.1 item" })
+            ).toHaveAttribute("aria-expanded", "true");
+        });
+
+        it("should toggle category on button click", async () => {
+            const user = userEvent.setup();
+            const mockOnSelectItem = jest.fn();
+            const options = buildOptions([
+                [
+                    "1",
+                    [
+                        ["1.1", [["1.1.1"]]],
+                        ["1.2", [["1.2.1"]]],
+                        ["1.3", [["1.3.1"]]],
+                    ],
+                ],
+            ]);
+            render(
+                <NestedDropdownList
+                    listItems={options}
+                    selectedKeyPaths={[]}
+                    selectableCategory
+                    onSelectItem={mockOnSelectItem}
+                />
+            );
+
+            await user.click(
+                within(
+                    screen.getByRole("treeitem", { name: "Parent 1.1 item" })
+                ).queryByTestId("toggle-category-button")
+            );
+
+            expect(mockOnSelectItem).not.toHaveBeenCalled();
+            expect(screen.queryByText("Child 1.1.1 item")).not.toBeVisible();
+            expect(
+                screen.getByRole("treeitem", { name: "Parent 1.1 item" })
+            ).toHaveAttribute("aria-expanded", "false");
+        });
+    });
+
+    describe("multiSelect = true", () => {
+        it("should display selected items as checked", async () => {
+            const options = buildOptions([
+                ["1", [["1.1"], ["1.2", [["1.2.1"], ["1.2.2"]]]]],
+                ["2", [["2.1"], ["2.2", [["2.2.1"], ["2.2.2"]]]]],
+                ["3", [["3.1"], ["3.2", [["3.2.1"], ["3.2.2"]]]]],
+            ]);
+            render(
+                <NestedDropdownList
+                    listItems={options}
+                    multiSelect
+                    selectedKeyPaths={[
+                        ["1", "1.1"],
+                        ["1", "1.2", "1.2.1"],
+                        ["1", "1.2", "1.2.2"],
+                        ["2", "2.2", "2.2.1"],
+                    ]}
+                />
+            );
+
+            expect(
+                screen.getByRole("treeitem", { name: "Parent 1 item" })
+            ).toBeChecked();
+            expect(
+                screen.getByRole("treeitem", { name: "Child 1.1 item" })
+            ).toBeChecked();
+            expect(
+                screen.getByRole("treeitem", { name: "Parent 1.2 item" })
+            ).toBeChecked();
+            expect(
+                screen.getByRole("treeitem", { name: "Child 1.2.1 item" })
+            ).toBeChecked();
+            expect(
+                screen.getByRole("treeitem", { name: "Child 1.2.2 item" })
+            ).toBeChecked();
+            expect(
+                screen.getByRole("treeitem", { name: "Parent 2 item" })
+            ).toHaveAttribute("aria-checked", "mixed");
+            expect(
+                screen.getByRole("treeitem", { name: "Child 2.1 item" })
+            ).not.toBeChecked();
+            expect(
+                screen.getByRole("treeitem", { name: "Parent 2.2 item" })
+            ).not.toBeChecked();
+            expect(
+                screen.getByRole("treeitem", { name: "Child 2.2.1 item" })
+            ).toBeChecked();
+            expect(
+                screen.getByRole("treeitem", { name: "Child 2.2.2 item" })
+            ).not.toBeChecked();
+        });
+    });
+});
+
+// =============================================================================
+// TEST HELPERS
+// =============================================================================
+
+type Leaf = [string];
+type Parent = [string, Node[]];
+type Node = Parent | Leaf;
+
+const buildOptions = (options: Node[]) => {
+    const walk = (node: Node): NestedDropdownListItemProps<string> => {
+        const [key, children] = node;
+        if (children) {
+            // parent
+            return {
+                label: `Parent ${key} item`,
+                value: key,
+                key,
+                subItems: children.map((child) => walk(child)),
+            };
+        } else {
+            // leaf
+            return {
+                label: `Child ${key} item`,
+                value: key,
+                key,
+            };
+        }
+    };
+
+    return options.map((option) => walk(option));
+};


### PR DESCRIPTION
**Changes**

- [delete] branch

Reworks the nested dropdown for floating-ui (related to #443). A temporary story is included to test the new component

Separate PRs will be created for migrating the `NestedSelect` and `NestedMultiSelect` parents

- render the tree as a list
  - the current dropdown uses the map data structure and recursion to process/render the dropdown list items
  - the proposed approach converts the tree structure into a flattened list
  - this is done in implementations like [Fluent UI](https://react.fluentui.dev/?path=/docs/components-tree--default#flat-tree) and [react-virtualized-tree](https://diogofcunha.github.io/react-virtualized-tree/#/examples/basic-tree)
  - pros/cons:
    - ➕ potential for virtualisation
    - ➕ refs are much easier to manage as they just need to be pushed into an array
    - ➕/➖ some operations are easier, some harder
    - ➖ might be less intuitive dealing with trees without recursion 
    - ➖ have to manage visibility of subitems yourself
  - I think it's still overall easier to manage a flattened list (rendering list items is easier via iteration vs recursion)
- mirror the focus and keyboard behaviour in the non-nested dropdown list
- some accessibility rework
  - apply the `tree` and `treeitem` roles
  - replace buttons, in line with recommendations in the [APG](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#keyboardnavigationinsidecomponents) to keep a single tab stop (and also to avoid spamming the Form Controls menu in Voiceover)
  - use left/right arrow keys to collapse/expand subtrees
