### PR TITLE
[MOL-15934][AT] Add support for an isReady state to handle situation when download is still being generated or not available to the user.

### DIFF
--- a/src/file-download/file-list-card/file-list-card.tsx
+++ b/src/file-download/file-list-card/file-list-card.tsx
@@ -33,7 +33,7 @@ const Component = ({ fileItem, onDownload }: FileListItemProps) => {
         errorMessage,
         thumbnailImageDataUrl,
         truncateText = true,
-        isReady = true,
+        ready = true,
     } = fileItem;
 
     // Local variables
@@ -73,7 +73,7 @@ const Component = ({ fileItem, onDownload }: FileListItemProps) => {
     };
 
     const handleDownload = async () => {
-        if (!isReady || isLoading) {
+        if (!ready || isLoading) {
             return;
         }
 
@@ -170,7 +170,7 @@ const Component = ({ fileItem, onDownload }: FileListItemProps) => {
                     sizeType="small"
                     aria-label={`download ${name}`}
                 >
-                    {isLoading || !isReady ? (
+                    {isLoading || !ready ? (
                         <Spinner
                             $buttonStyle="light"
                             $buttonSizeStyle="small"

--- a/src/file-download/file-list-card/file-list-card.tsx
+++ b/src/file-download/file-list-card/file-list-card.tsx
@@ -45,7 +45,6 @@ const Component = ({ fileItem, onDownload }: FileListItemProps) => {
     });
     const [displayText, setDisplayText] = useState<string>();
     const containerRef = useRef<HTMLDivElement>();
-    const downloadButtonRef = useRef<HTMLDivElement>();
 
     // =========================================================================
     // EFFECTS
@@ -188,7 +187,7 @@ const Component = ({ fileItem, onDownload }: FileListItemProps) => {
 
     return (
         <Item data-testid={id}>
-            <Box ref={downloadButtonRef} onClick={handleDownload}>
+            <Box onClick={handleDownload}>
                 {renderContents()}
                 {renderActions()}
             </Box>

--- a/src/file-download/file-list-card/file-list-card.tsx
+++ b/src/file-download/file-list-card/file-list-card.tsx
@@ -33,6 +33,7 @@ const Component = ({ fileItem, onDownload }: FileListItemProps) => {
         errorMessage,
         thumbnailImageDataUrl,
         truncateText = true,
+        isReady = true,
     } = fileItem;
 
     // Local variables
@@ -44,6 +45,7 @@ const Component = ({ fileItem, onDownload }: FileListItemProps) => {
     });
     const [displayText, setDisplayText] = useState<string>();
     const containerRef = useRef<HTMLDivElement>();
+    const downloadButtonRef = useRef<HTMLDivElement>();
 
     // =========================================================================
     // EFFECTS
@@ -72,6 +74,10 @@ const Component = ({ fileItem, onDownload }: FileListItemProps) => {
     };
 
     const handleDownload = async () => {
+        if (!isReady || isLoading) {
+            return;
+        }
+
         setIsLoading(true);
         try {
             setIsError(false);
@@ -165,7 +171,7 @@ const Component = ({ fileItem, onDownload }: FileListItemProps) => {
                     sizeType="small"
                     aria-label={`download ${name}`}
                 >
-                    {isLoading ? (
+                    {isLoading || !isReady ? (
                         <Spinner
                             $buttonStyle="light"
                             $buttonSizeStyle="small"
@@ -182,7 +188,7 @@ const Component = ({ fileItem, onDownload }: FileListItemProps) => {
 
     return (
         <Item data-testid={id}>
-            <Box onClick={handleDownload}>
+            <Box ref={downloadButtonRef} onClick={handleDownload}>
                 {renderContents()}
                 {renderActions()}
             </Box>

--- a/src/file-download/types.ts
+++ b/src/file-download/types.ts
@@ -14,6 +14,8 @@ export interface FileItemDownloadProps {
     thumbnailImageDataUrl?: string | undefined;
     /** Indicates if text should be truncated */
     truncateText?: boolean | undefined;
+    /** Indicate if file is ready for download, defaults to true */
+    isReady?: boolean;
 }
 
 export type FileDownloadStyle = "bordered" | "no-border";
@@ -30,4 +32,6 @@ export interface FileDownloadProps {
     id?: string | undefined;
     /** Called when file item is clicked  */
     onDownload: (file: FileItemDownloadProps) => void | Promise<void>;
+    /** controlled loading state*/
+    isLoading?: boolean;
 }

--- a/src/file-download/types.ts
+++ b/src/file-download/types.ts
@@ -32,6 +32,4 @@ export interface FileDownloadProps {
     id?: string | undefined;
     /** Called when file item is clicked  */
     onDownload: (file: FileItemDownloadProps) => void | Promise<void>;
-    /** controlled loading state*/
-    isLoading?: boolean;
 }

--- a/src/file-download/types.ts
+++ b/src/file-download/types.ts
@@ -15,7 +15,7 @@ export interface FileItemDownloadProps {
     /** Indicates if text should be truncated */
     truncateText?: boolean | undefined;
     /** Indicate if file is ready for download, defaults to true */
-    isReady?: boolean;
+    ready?: boolean | undefined;
 }
 
 export type FileDownloadStyle = "bordered" | "no-border";

--- a/stories/file-download/file-download.mdx
+++ b/stories/file-download/file-download.mdx
@@ -27,6 +27,13 @@ A custom error message can be specified for each item.
 
 <Canvas of={FileDownloadStories.WithCustomError} />
 
+<Heading3>Download Readiness Control</Heading3>
+
+The `ready` prop allows users to manage the availability of a file.<br/>
+This can be used in scenarios where an image needs time to be generated and is not immediately available.
+
+<Canvas of={FileDownloadStories.DownloadReadinessControl} />
+
 <Secondary>Component API</Secondary>
 
 <PropsTable />

--- a/stories/file-download/file-download.mdx
+++ b/stories/file-download/file-download.mdx
@@ -27,12 +27,13 @@ A custom error message can be specified for each item.
 
 <Canvas of={FileDownloadStories.WithCustomError} />
 
-<Heading3>Download Readiness Control</Heading3>
+<Heading3>Download readiness</Heading3>
 
-The `ready` prop allows users to manage the availability of a file.<br/>
+The `ready` prop allows users to manage the availability of a file.
+
 This can be used in scenarios where an image needs time to be generated and is not immediately available.
 
-<Canvas of={FileDownloadStories.DownloadReadinessControl} />
+<Canvas of={FileDownloadStories.DownloadReadiness} />
 
 <Secondary>Component API</Secondary>
 

--- a/stories/file-download/file-download.stories.tsx
+++ b/stories/file-download/file-download.stories.tsx
@@ -118,24 +118,23 @@ export const WithCustomError: StoryObj<Component> = {
     },
 };
 
-export const DownloadReadinessControl: StoryObj<Component> = {
+export const DownloadReadiness: StoryObj<Component> = {
     render: () => {
-        const [fileItems, setFileItem] = useState<FileItemDownloadProps[]>([
+        const [fileItems, setFileItems] = useState<FileItemDownloadProps[]>([
             {
                 id: "1",
-                name: "Your file is being generate...",
+                name: "Your file is being generated...",
                 mimeType: "application/pdf",
                 filePath: "",
-                errorMessage: "This is custom error message!",
                 ready: false,
             },
         ]);
 
         useEffect(() => {
             setTimeout(() => {
-                const isReadyFileItem = structuredClone(fileItems);
-                isReadyFileItem[0] = {
-                    ...isReadyFileItem[0],
+                const readyFileItems = structuredClone(fileItems);
+                readyFileItems[0] = {
+                    ...readyFileItems[0],
                     ready: true,
                     name: "ready.pdf",
                     size: 6000,
@@ -144,21 +143,19 @@ export const DownloadReadinessControl: StoryObj<Component> = {
                         "https://picsum.photos/seed/picsum/200/300",
                 };
 
-                setFileItem(isReadyFileItem);
+                setFileItems(readyFileItems);
             }, 5000);
         }, []);
 
         return (
-            <>
-                <FileDownload
-                    fileItems={fileItems}
-                    title={"Download Readiness Control"}
-                    description={
-                        "Ready status will be set to true after 5 seconds."
-                    }
-                    onDownload={handleDemoDownload}
-                />
-            </>
+            <FileDownload
+                fileItems={fileItems}
+                title={"Download readiness"}
+                description={
+                    "Ready status will be set to true after 5 seconds."
+                }
+                onDownload={handleDemoDownload}
+            />
         );
     },
 };

--- a/stories/file-download/file-download.stories.tsx
+++ b/stories/file-download/file-download.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { FileDownload, FileItemDownloadProps } from "../../src/file-download";
 
 type Component = typeof FileDownload;
@@ -52,7 +52,7 @@ export const Default: StoryObj<Component> = {
 
         return (
             <FileDownload
-                fileItems={fileItems}
+                fileItems={[fileItems[2]]}
                 onDownload={handleDemoDownload}
                 title={"Content title"}
                 description={
@@ -113,6 +113,45 @@ export const WithCustomError: StoryObj<Component> = {
                     "File download will fail after 3 seconds. A custom error message can be set"
                 }
                 onDownload={handleDemoError}
+            />
+        );
+    },
+};
+
+export const WithReadyState: StoryObj<Component> = {
+    render: () => {
+        const [fileItems, setFileItem] = useState<FileItemDownloadProps[]>([
+            {
+                id: "1",
+                name: "not-ready.txt",
+                mimeType: "application/txt",
+                filePath: "",
+                errorMessage: "This is custom error message!",
+                isReady: false,
+            },
+        ]);
+
+        useEffect(() => {
+            setInterval(() => {
+                const isReadyFileItem = structuredClone(fileItems);
+                isReadyFileItem[0] = {
+                    ...isReadyFileItem[0],
+                    isReady: true,
+                    name: "ready.txt",
+                };
+
+                setFileItem(isReadyFileItem);
+            }, 10000);
+        }, []);
+
+        return (
+            <FileDownload
+                fileItems={fileItems}
+                title={"Content title"}
+                description={
+                    "File will not be avaialble until 10 seconds later"
+                }
+                onDownload={handleDemoDownload}
             />
         );
     },

--- a/stories/file-download/file-download.stories.tsx
+++ b/stories/file-download/file-download.stories.tsx
@@ -123,7 +123,7 @@ export const DownloadReadinessControl: StoryObj<Component> = {
         const [fileItems, setFileItem] = useState<FileItemDownloadProps[]>([
             {
                 id: "1",
-                name: "not-ready.pdf",
+                name: "Your file is being generate...",
                 mimeType: "application/pdf",
                 filePath: "",
                 errorMessage: "This is custom error message!",
@@ -132,7 +132,7 @@ export const DownloadReadinessControl: StoryObj<Component> = {
         ]);
 
         useEffect(() => {
-            setInterval(() => {
+            setTimeout(() => {
                 const isReadyFileItem = structuredClone(fileItems);
                 isReadyFileItem[0] = {
                     ...isReadyFileItem[0],

--- a/stories/file-download/file-download.stories.tsx
+++ b/stories/file-download/file-download.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { useEffect, useState } from "react";
-import { Text } from "../../src";
 import { FileDownload, FileItemDownloadProps } from "../../src/file-download";
 
 type Component = typeof FileDownload;
@@ -48,14 +47,6 @@ export const Default: StoryObj<Component> = {
                 filePath: "https://picsum.photos/200",
                 thumbnailImageDataUrl:
                     "https://picsum.photos/seed/picsum/200/300",
-            },
-            {
-                id: "5",
-                name: "not-ready.pdf",
-                mimeType: "application/pdf",
-                filePath: "",
-                errorMessage: "This is custom error message!",
-                ready: false,
             },
         ]);
 
@@ -163,17 +154,7 @@ export const DownloadReadinessControl: StoryObj<Component> = {
                     fileItems={fileItems}
                     title={"Download Readiness Control"}
                     description={
-                        <Text.XSmall>
-                            The ready prop allows users to manage the
-                            availability of a file.
-                            <br />
-                            This can be used in scenarios where an image needs
-                            time to be generated and is not immediately
-                            available.
-                            <br />
-                            This demo shows the ready prop change after 5
-                            seconds
-                        </Text.XSmall>
+                        "Ready status will be set to true after 5 seconds."
                     }
                     onDownload={handleDemoDownload}
                 />

--- a/stories/file-download/file-download.stories.tsx
+++ b/stories/file-download/file-download.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { useEffect, useState } from "react";
+import { Text } from "../../src";
 import { FileDownload, FileItemDownloadProps } from "../../src/file-download";
 
 type Component = typeof FileDownload;
@@ -48,11 +49,19 @@ export const Default: StoryObj<Component> = {
                 thumbnailImageDataUrl:
                     "https://picsum.photos/seed/picsum/200/300",
             },
+            {
+                id: "5",
+                name: "not-ready.pdf",
+                mimeType: "application/pdf",
+                filePath: "",
+                errorMessage: "This is custom error message!",
+                ready: false,
+            },
         ]);
 
         return (
             <FileDownload
-                fileItems={[fileItems[2]]}
+                fileItems={fileItems}
                 onDownload={handleDemoDownload}
                 title={"Content title"}
                 description={
@@ -118,16 +127,16 @@ export const WithCustomError: StoryObj<Component> = {
     },
 };
 
-export const WithReadyState: StoryObj<Component> = {
+export const DownloadReadinessControl: StoryObj<Component> = {
     render: () => {
         const [fileItems, setFileItem] = useState<FileItemDownloadProps[]>([
             {
                 id: "1",
-                name: "not-ready.txt",
-                mimeType: "application/txt",
+                name: "not-ready.pdf",
+                mimeType: "application/pdf",
                 filePath: "",
                 errorMessage: "This is custom error message!",
-                isReady: false,
+                ready: false,
             },
         ]);
 
@@ -136,23 +145,39 @@ export const WithReadyState: StoryObj<Component> = {
                 const isReadyFileItem = structuredClone(fileItems);
                 isReadyFileItem[0] = {
                     ...isReadyFileItem[0],
-                    isReady: true,
-                    name: "ready.txt",
+                    ready: true,
+                    name: "ready.pdf",
+                    size: 6000,
+                    filePath: "https://picsum.photos/200",
+                    thumbnailImageDataUrl:
+                        "https://picsum.photos/seed/picsum/200/300",
                 };
 
                 setFileItem(isReadyFileItem);
-            }, 10000);
+            }, 5000);
         }, []);
 
         return (
-            <FileDownload
-                fileItems={fileItems}
-                title={"Content title"}
-                description={
-                    "File will not be avaialble until 10 seconds later"
-                }
-                onDownload={handleDemoDownload}
-            />
+            <>
+                <FileDownload
+                    fileItems={fileItems}
+                    title={"Download Readiness Control"}
+                    description={
+                        <Text.XSmall>
+                            The ready prop allows users to manage the
+                            availability of a file.
+                            <br />
+                            This can be used in scenarios where an image needs
+                            time to be generated and is not immediately
+                            available.
+                            <br />
+                            This demo shows the ready prop change after 5
+                            seconds
+                        </Text.XSmall>
+                    }
+                    onDownload={handleDemoDownload}
+                />
+            </>
         );
     },
 };

--- a/stories/file-download/props-table.tsx
+++ b/stories/file-download/props-table.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { ApiTable } from "../storybook-common/api-table";
 import { ApiTableSectionProps } from "../storybook-common/api-table/types";
 
@@ -99,6 +98,12 @@ const DATA: ApiTableSectionProps[] = [
             {
                 name: "truncateText",
                 description: "Indicates if text should be truncated",
+                propTypes: ["boolean"],
+                defaultValue: `true`,
+            },
+            {
+                name: "ready",
+                description: "Indicates if the file is ready for download",
                 propTypes: ["boolean"],
                 defaultValue: `true`,
             },


### PR DESCRIPTION
**Changes**

**FileDownload Component**
Add a `isReady` prop to fileItemDownload which is defaulted to `true`
Add a check in handleDownload that prevents user from downloading the file when either isLoading  is true or when isReady is false

- delete branch

**Changelog entry**
Add support for an `isReady` state to handle situation when download is still being generated or not available to the user.

**Additional information**

- You may refer to this [MOL-15934](https://jira.ship.gov.sg/browse/MOL-15934)

**demo**

[Demo.webm](https://github.com/user-attachments/assets/0dd4fa4b-58fc-4422-bfc4-09b38a36dd2e)
