### PR TITLE
[BOOKINGSG-5999][JH] add optional useContentWidth for Toggle & Filter.Checkbox

### DIFF
--- a/src/filter/addons/filter-item-checkbox.tsx
+++ b/src/filter/addons/filter-item-checkbox.tsx
@@ -18,6 +18,7 @@ export const FilterItemCheckbox = <T,>({
     onSelect,
     labelExtractor,
     valueExtractor,
+    useContentWidth,
     ...filterItemProps
 }: FilterItemCheckboxProps<T>) => {
     // =============================================================================
@@ -180,6 +181,7 @@ export const FilterItemCheckbox = <T,>({
                     (minimisedHeight && index <= lastVisibleElementIndex)
                 }
                 onChange={handleItemClick(option)}
+                useContentWidth={useContentWidth}
             >
                 {optionLabel}
             </StyledToggle>

--- a/src/filter/addons/filter-item-checkbox.tsx
+++ b/src/filter/addons/filter-item-checkbox.tsx
@@ -18,7 +18,7 @@ export const FilterItemCheckbox = <T,>({
     onSelect,
     labelExtractor,
     valueExtractor,
-    useContentWidth,
+    useToggleContentWidth,
     ...filterItemProps
 }: FilterItemCheckboxProps<T>) => {
     // =============================================================================
@@ -181,7 +181,7 @@ export const FilterItemCheckbox = <T,>({
                     (minimisedHeight && index <= lastVisibleElementIndex)
                 }
                 onChange={handleItemClick(option)}
-                useContentWidth={useContentWidth}
+                useContentWidth={useToggleContentWidth}
             >
                 {optionLabel}
             </StyledToggle>

--- a/src/filter/types.ts
+++ b/src/filter/types.ts
@@ -60,6 +60,6 @@ export interface FilterItemCheckboxProps<T>
     labelExtractor?: ((item: T) => React.ReactNode) | undefined;
     /** Function to derive value from an item. If not set, checks `item.value`. */
     valueExtractor?: ((item: T) => string) | undefined;
-    /** Changes min-width to fit content */
-    useContentWidth?: boolean | undefined;
+    /** Changes min-width of toggle in mobile view to fit content */
+    useToggleContentWidth?: boolean | undefined;
 }

--- a/src/filter/types.ts
+++ b/src/filter/types.ts
@@ -60,4 +60,6 @@ export interface FilterItemCheckboxProps<T>
     labelExtractor?: ((item: T) => React.ReactNode) | undefined;
     /** Function to derive value from an item. If not set, checks `item.value`. */
     valueExtractor?: ((item: T) => string) | undefined;
+    /** Changes min-width to fit content */
+    useContentWidth?: boolean | undefined;
 }

--- a/src/toggle/toggle.styles.tsx
+++ b/src/toggle/toggle.styles.tsx
@@ -66,7 +66,7 @@ export const Container = styled.div<ContainerStyleProps>`
     ${(props) => {
         if (props.$useContentWidth) {
             return css`
-                min-width: fit-content;
+                min-width: unset;
             `;
         }
     }}

--- a/src/toggle/toggle.styles.tsx
+++ b/src/toggle/toggle.styles.tsx
@@ -20,6 +20,7 @@ interface StyleProps {
 interface ContainerStyleProps extends StyleProps {
     $styleType?: ToggleStyleType;
     $error?: boolean;
+    $useContentWidth?: boolean;
 }
 
 interface IndicatorLabelContainerStyleProps {
@@ -57,6 +58,15 @@ export const Container = styled.div<ContainerStyleProps>`
         if (!props.$indicator) {
             return css`
                 justify-content: center;
+            `;
+        }
+    }}
+
+    // Container min width to fit content
+    ${(props) => {
+        if (props.$useContentWidth) {
+            return css`
+                min-width: fit-content;
             `;
         }
     }}

--- a/src/toggle/toggle.tsx
+++ b/src/toggle/toggle.tsx
@@ -39,6 +39,7 @@ export const Toggle = ({
     onRemove,
     "data-testid": testId,
     onChange,
+    useContentWidth,
 }: ToggleProps) => {
     // =============================================================================
     // CONST, STATE, REF
@@ -324,6 +325,7 @@ export const Toggle = ({
             $styleType={styleType}
             $error={error}
             $indicator={indicator}
+            $useContentWidth={useContentWidth}
             id={id}
             data-testid={testId}
         >

--- a/src/toggle/types.ts
+++ b/src/toggle/types.ts
@@ -46,6 +46,8 @@ export interface ToggleProps
     /** Specifies if the remove button should be displayed */
     removable?: boolean | undefined;
     onRemove?: (() => void) | undefined;
+    /** Changes min-width to fit content */
+    useContentWidth?: boolean | undefined;
 }
 
 export interface ToggleCompositeSectionProps {

--- a/stories/filter/addon-props-table.tsx
+++ b/stories/filter/addon-props-table.tsx
@@ -38,6 +38,13 @@ const FILTER_CHECKBOX_DATA: ApiTableSectionProps[] = [
                 propTypes: ["(options: T[]) => void"],
             },
             {
+                name: "useContentWidth",
+                description:
+                    "Changes the minimum width of the container to fit its content",
+                propTypes: ["boolean"],
+                defaultValue: `false`,
+            },
+            {
                 name: "labelExtractor",
                 description: (
                     <>

--- a/stories/filter/addon-props-table.tsx
+++ b/stories/filter/addon-props-table.tsx
@@ -38,11 +38,10 @@ const FILTER_CHECKBOX_DATA: ApiTableSectionProps[] = [
                 propTypes: ["(options: T[]) => void"],
             },
             {
-                name: "useContentWidth",
+                name: "useToggleContentWidth",
                 description:
                     "Changes the minimum width of the checkbox toggle to fit its content (on mobile)",
                 propTypes: ["boolean"],
-                defaultValue: `false`,
             },
             {
                 name: "labelExtractor",

--- a/stories/filter/addon-props-table.tsx
+++ b/stories/filter/addon-props-table.tsx
@@ -40,7 +40,7 @@ const FILTER_CHECKBOX_DATA: ApiTableSectionProps[] = [
             {
                 name: "useContentWidth",
                 description:
-                    "Changes the minimum width of the container to fit its content",
+                    "Changes the minimum width of the checkbox toggle to fit its content (on mobile)",
                 propTypes: ["boolean"],
                 defaultValue: `false`,
             },

--- a/stories/toggle/props-table.tsx
+++ b/stories/toggle/props-table.tsx
@@ -129,7 +129,6 @@ const DATA: ApiTableSectionProps[] = [
                 description:
                     "Changes the minimum width of the container to fit its content",
                 propTypes: ["boolean"],
-                defaultValue: `false`,
             },
         ],
     },

--- a/stories/toggle/props-table.tsx
+++ b/stories/toggle/props-table.tsx
@@ -124,6 +124,13 @@ const DATA: ApiTableSectionProps[] = [
                 ),
                 propTypes: ["CompositeSectionProps"],
             },
+            {
+                name: "useContentWidth",
+                description:
+                    "Changes the minimum width of the container to fit its content",
+                propTypes: ["boolean"],
+                defaultValue: `false`,
+            },
         ],
     },
 


### PR DESCRIPTION
**Changes**
Add optional `useContentWidth` prop for `Toggle` and `Filter.Checkbox` (mobile), to change container's `min-width` from fixed length to `fit-content`

- delete branch

**Changelog entry**

- Add optional `useContentWidth` prop for `Toggle` & `Filter.Checkbox` components

**Additional information**

- You may refer to this [BOOKINGSG-5999](https://jira.ship.gov.sg/browse/BOOKINGSG-5999)
