### PR TITLE
[BOOKINGSG-6086][JH] add optional timestamp prop for CountdownTimer

### DIFF
--- a/src/countdown-timer/countdown-timer.tsx
+++ b/src/countdown-timer/countdown-timer.tsx
@@ -19,6 +19,7 @@ export const CountdownTimer = ({
     className,
     align = "right",
     timer,
+    timestamp,
     notifyTimer,
     offset,
     mobileOffset,
@@ -41,7 +42,7 @@ export const CountdownTimer = ({
     const [clientRectX, setClientRectX] = useState<number>(0);
     const [isPlaying, setIsPlaying] = useState(false);
 
-    const [remainingSeconds] = useTimer(timer, isPlaying);
+    const [remainingSeconds] = useTimer(timer, isPlaying, timestamp);
     const { ref: stickyRef, inView } = useInView({
         threshold: 1,
         rootMargin: `${offsetY * -1}px 0px 0px 0px`,

--- a/src/countdown-timer/types.ts
+++ b/src/countdown-timer/types.ts
@@ -12,16 +12,11 @@ interface MobileOffset {
     top?: number | undefined;
 }
 
-export interface CountdownTimerProps
-    extends React.HTMLAttributes<HTMLDivElement> {
+interface CountdownTimerBaseProps extends React.HTMLAttributes<HTMLDivElement> {
     "data-testid"?: string | undefined;
     /** To show/play the countdown timer */
     show: boolean;
     fixed?: boolean | undefined;
-    /** Specifies the countdown timer (in seconds) */
-    timer: number;
-    /** Specifies the timestamp at which the countdown ends (milliseconds since Jan 1, 1970) */
-    timestamp?: number;
     /** Specifies a timer (in seconds) for notifications */
     notifyTimer?: number | undefined;
     /** Allows customization of the sticky position in tablet/desktop view */
@@ -37,3 +32,17 @@ export interface CountdownTimerProps
     /** Called when countdown reaches 0 */
     onFinish?: (() => void) | undefined;
 }
+
+interface TimerProps extends CountdownTimerBaseProps {
+    /** Specifies the countdown timer (in seconds) */
+    timer: number;
+    timestamp?: number | undefined;
+}
+
+interface TimestampProps extends CountdownTimerBaseProps {
+    /** Specifies the timestamp at which the countdown ends (milliseconds since Jan 1, 1970) */
+    timestamp: number;
+    timer?: number | undefined;
+}
+
+export type CountdownTimerProps = TimerProps | TimestampProps;

--- a/src/countdown-timer/types.ts
+++ b/src/countdown-timer/types.ts
@@ -20,6 +20,8 @@ export interface CountdownTimerProps
     fixed?: boolean | undefined;
     /** Specifies the countdown timer (in seconds) */
     timer: number;
+    /** Specifies the timestamp at which the countdown ends (milliseconds since Jan 1, 1970) */
+    timestamp?: number;
     /** Specifies a timer (in seconds) for notifications */
     notifyTimer?: number | undefined;
     /** Allows customization of the sticky position in tablet/desktop view */

--- a/src/countdown-timer/use-timer.tsx
+++ b/src/countdown-timer/use-timer.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from "react";
 
-export const useTimer = (seconds: number, isPlaying: boolean) => {
+export const useTimer = (
+    seconds: number,
+    isPlaying: boolean,
+    endTime?: number // Takes precedence over seconds
+) => {
     // =============================================================================
     // CONST, STATE, REF
     // =============================================================================
@@ -11,31 +15,29 @@ export const useTimer = (seconds: number, isPlaying: boolean) => {
     // =============================================================================
     useEffect(() => {
         if (!isPlaying) return;
-        const cleanup = start();
+        if (endTime)
+            setRemainingSeconds(
+                calculateRemainingSecondsFromTimestamp(endTime)
+            );
 
-        return () => cleanup();
-    }, [isPlaying, seconds]);
+        const startTime = Date.now();
+        const intervalId = setInterval(() => {
+            const countdown = calculateRemainingSecondsFromTimestamp(
+                endTime ?? startTime + seconds * 1000
+            );
+
+            setRemainingSeconds(countdown);
+            if (countdown <= 0) clearInterval(intervalId);
+        }, 1000);
+
+        return () => clearInterval(intervalId);
+    }, [endTime, isPlaying, seconds]);
 
     // =========================================================================
     // HELPER FUNCTIONS
     // =========================================================================
-    const start = () => {
-        const timestamp = Date.now();
-
-        const interval = setInterval(() => {
-            const currentTime = Date.now();
-            const milliseconds = seconds * 1000;
-
-            const countdown = Math.ceil(
-                (timestamp + milliseconds - currentTime) / 1000
-            );
-
-            setRemainingSeconds(Math.max(countdown, 0));
-            if (countdown <= 0) clearInterval(interval);
-        }, 1000);
-
-        return () => clearInterval(interval);
-    };
+    const calculateRemainingSecondsFromTimestamp = (timestamp: number) =>
+        Math.max(Math.ceil((timestamp - Date.now()) / 1000), 0);
 
     return [remainingSeconds] as const;
 };

--- a/src/countdown-timer/use-timer.tsx
+++ b/src/countdown-timer/use-timer.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 export const useTimer = (
     seconds: number,
     isPlaying: boolean,
-    endTime?: number // Takes precedence over seconds
+    endTime?: number | undefined // Takes precedence over seconds
 ) => {
     // =============================================================================
     // CONST, STATE, REF

--- a/stories/countdown-timer/countdown-timer.mdx
+++ b/stories/countdown-timer/countdown-timer.mdx
@@ -19,7 +19,7 @@ import { CountdownTimer } from "@lifesg/react-design-system/countdown-timer";
 
 <Heading3>Timestamp</Heading3>
 
-A timestamp for the end of the countdown can be used. This takes precedence over `timer`.
+A timestamp for the end of the countdown can be used instead of `timer` (timestamp takes precedence if both are provided).
 
 <Canvas of={CountdownTimerStories.Timestamp} />
 

--- a/stories/countdown-timer/countdown-timer.mdx
+++ b/stories/countdown-timer/countdown-timer.mdx
@@ -17,6 +17,12 @@ import { CountdownTimer } from "@lifesg/react-design-system/countdown-timer";
 
 <Canvas of={CountdownTimerStories.Default} />
 
+<Heading3>Timestamp</Heading3>
+
+A timestamp for the end of the countdown can be used. This takes precedence over `timer`.
+
+<Canvas of={CountdownTimerStories.Timestamp} />
+
 <Heading3>Scroll behaviour</Heading3>
 
 The countdown timer is fixed to the top when scrolled out of view. By default it is aligned right, relative to its original position. It can also be aligned left.

--- a/stories/countdown-timer/countdown-timer.stories.tsx
+++ b/stories/countdown-timer/countdown-timer.stories.tsx
@@ -84,7 +84,6 @@ export const Timestamp: StoryObj<Component> = {
                 </Button.Default>
                 <CountdownTimer
                     show={showTimer}
-                    timer={5}
                     notifyTimer={10}
                     timestamp={timestamp}
                 />

--- a/stories/countdown-timer/countdown-timer.stories.tsx
+++ b/stories/countdown-timer/countdown-timer.stories.tsx
@@ -72,3 +72,23 @@ export const CustomOffset: StoryObj<Component> = {
         docs: { story: { inline: false, iframeHeight: 500 } },
     },
 };
+
+export const Timestamp: StoryObj<Component> = {
+    render: () => {
+        const [showTimer, setShowTimer] = useState(false);
+        const timestamp = Date.now() + 20000;
+        return (
+            <div>
+                <Button.Default onClick={() => setShowTimer(true)}>
+                    Start
+                </Button.Default>
+                <CountdownTimer
+                    show={showTimer}
+                    timer={5}
+                    notifyTimer={10}
+                    timestamp={timestamp}
+                />
+            </div>
+        );
+    },
+};

--- a/stories/countdown-timer/props-table.tsx
+++ b/stories/countdown-timer/props-table.tsx
@@ -30,8 +30,14 @@ const DATA: ApiTableSectionProps[] = [
             },
             {
                 name: "timestamp",
-                description:
-                    "Specifies the timestamp at which the countdown ends (milliseconds since Jan 1, 1970)",
+                description: (
+                    <>
+                        Specifies the timestamp at which the countdown ends
+                        (milliseconds since Jan 1, 1970),
+                        <br />
+                        <strong>Note:</strong> required if timer is not provided
+                    </>
+                ),
                 propTypes: ["number"],
             },
             {

--- a/stories/countdown-timer/props-table.tsx
+++ b/stories/countdown-timer/props-table.tsx
@@ -29,6 +29,12 @@ const DATA: ApiTableSectionProps[] = [
                 mandatory: true,
             },
             {
+                name: "timestamp",
+                description:
+                    "Specifies the timestamp at which the countdown ends (milliseconds since Jan 1, 1970)",
+                propTypes: ["number"],
+            },
+            {
                 name: "notifyTimer",
                 description:
                     "Specifies the notification threshold timer (in seconds)",


### PR DESCRIPTION
**Changes**
Add optional `timestamp` prop for `CountdownTimer`. `timestamp` signifies the time at which the countdown should end, and takes precedence over `timer`

- delete branch

**Changelog entry**

- Add optional `timestamp` prop for `CountdownTimer` component

**Additional information**

- You may refer to this [BOOKINGSG-6086](https://jira.ship.gov.sg/browse/BOOKINGSG-6086)
