### PR TITLE
[BOOKINGSG-6107][JH] add optional showCurrentMonthOnly prop for Calendar

### DIFF
--- a/src/shared/internal-calendar/day-cell/day-cell.style.tsx
+++ b/src/shared/internal-calendar/day-cell/day-cell.style.tsx
@@ -221,6 +221,10 @@ export const Label = styled(Text.H5)<LabelStyleProps>`
                 return css`
                     color: ${Color.Neutral[4]};
                 `;
+            case "hidden":
+                return css`
+                    visibility: hidden;
+                `;
             case "available":
             default:
                 return css`

--- a/src/shared/internal-calendar/day-cell/types.tsx
+++ b/src/shared/internal-calendar/day-cell/types.tsx
@@ -9,7 +9,12 @@ export type CellType =
     | "hover-dash"
     | "hover-current";
 
-export type LabelType = "available" | "unavailable" | "current" | "selected";
+export type LabelType =
+    | "available"
+    | "unavailable"
+    | "current"
+    | "selected"
+    | "hidden";
 
 export interface CellStyleProps {
     bgLeft?: CellType | undefined;

--- a/src/shared/internal-calendar/internal-calendar.tsx
+++ b/src/shared/internal-calendar/internal-calendar.tsx
@@ -30,7 +30,7 @@ export const Component = (
         selectWithinRange = true,
         initialCalendarDate,
         numberOfDays,
-        showCurrentMonthOnly = false,
+        showActiveMonthDaysOnly = false,
     }: InternalCalendarProps,
     ref: React.ForwardedRef<InternalCalendarRef>
 ) => {
@@ -172,7 +172,7 @@ export const Component = (
                         maxDate={maxDate}
                         isNewSelection={selectWithinRange}
                         allowDisabledSelection={allowDisabledSelection}
-                        showCurrentMonthOnly={showCurrentMonthOnly}
+                        showActiveMonthDaysOnly={showActiveMonthDaysOnly}
                         onSelect={handleDateSelect}
                         onHover={handleDateHover}
                     />

--- a/src/shared/internal-calendar/internal-calendar.tsx
+++ b/src/shared/internal-calendar/internal-calendar.tsx
@@ -30,6 +30,7 @@ export const Component = (
         selectWithinRange = true,
         initialCalendarDate,
         numberOfDays,
+        showCurrentMonthOnly = false,
     }: InternalCalendarProps,
     ref: React.ForwardedRef<InternalCalendarRef>
 ) => {
@@ -171,6 +172,7 @@ export const Component = (
                         maxDate={maxDate}
                         isNewSelection={selectWithinRange}
                         allowDisabledSelection={allowDisabledSelection}
+                        showCurrentMonthOnly={showCurrentMonthOnly}
                         onSelect={handleDateSelect}
                         onHover={handleDateHover}
                     />

--- a/src/shared/internal-calendar/standard/standard-calendar-day-view.tsx
+++ b/src/shared/internal-calendar/standard/standard-calendar-day-view.tsx
@@ -38,7 +38,7 @@ export const StandardCalendarDayView = ({
     minDate,
     maxDate,
     allowDisabledSelection,
-    showCurrentMonthOnly,
+    showActiveMonthDaysOnly,
 }: CalendarDayViewProps) => {
     // =============================================================================
     // CONST, STATE, REF
@@ -100,7 +100,9 @@ export const StandardCalendarDayView = ({
                                 disabledDates={disabledDates}
                                 allowDisabledSelection={allowDisabledSelection}
                                 isNewSelection={isNewSelection}
-                                showCurrentMonthOnly={showCurrentMonthOnly}
+                                showActiveMonthDaysOnly={
+                                    showActiveMonthDaysOnly
+                                }
                                 onSelect={handleDayClick}
                                 onHover={handleHoverCell}
                             />

--- a/src/shared/internal-calendar/standard/standard-calendar-day-view.tsx
+++ b/src/shared/internal-calendar/standard/standard-calendar-day-view.tsx
@@ -38,6 +38,7 @@ export const StandardCalendarDayView = ({
     minDate,
     maxDate,
     allowDisabledSelection,
+    showCurrentMonthOnly,
 }: CalendarDayViewProps) => {
     // =============================================================================
     // CONST, STATE, REF
@@ -99,6 +100,7 @@ export const StandardCalendarDayView = ({
                                 disabledDates={disabledDates}
                                 allowDisabledSelection={allowDisabledSelection}
                                 isNewSelection={isNewSelection}
+                                showCurrentMonthOnly={showCurrentMonthOnly}
                                 onSelect={handleDayClick}
                                 onHover={handleHoverCell}
                             />

--- a/src/shared/internal-calendar/standard/standard-cell.tsx
+++ b/src/shared/internal-calendar/standard/standard-cell.tsx
@@ -16,6 +16,7 @@ interface Props {
     allowDisabledSelection?: boolean | undefined;
     isNewSelection?: boolean | undefined;
     currentFocus?: FocusType | undefined;
+    showCurrentMonthOnly?: boolean | undefined;
     onSelect: (value: Dayjs, disabled: boolean) => void;
     onHover: (value: string, disabled: boolean) => void;
 }
@@ -32,6 +33,7 @@ export const StandardCell = ({
     disabledDates,
     allowDisabledSelection,
     isNewSelection,
+    showCurrentMonthOnly,
     onSelect,
     onHover,
 }: Props) => {
@@ -64,7 +66,7 @@ export const StandardCell = ({
         const props: CellStyleProps = {};
 
         if (calendarDate.month() !== date.month()) {
-            props.labelType = "unavailable";
+            props.labelType = showCurrentMonthOnly ? "hidden" : "unavailable";
         } else if (dayjs().isSame(date, "day") && !disabled) {
             props.labelType = "current";
             props.circleLeft = "current";

--- a/src/shared/internal-calendar/standard/standard-cell.tsx
+++ b/src/shared/internal-calendar/standard/standard-cell.tsx
@@ -91,6 +91,11 @@ export const StandardCell = ({
         const isStart = date.isSame(startDate, "day");
         const isEnd = date.isSame(endDate, "day");
 
+        if (showCurrentMonthOnly && calendarDate.month() !== date.month()) {
+            props.labelType = "hidden";
+            return props;
+        }
+
         if ((startDate && isStart) || (endDate && isEnd)) {
             props.labelType = "selected";
             props.circleLeft = "selected-outline";

--- a/src/shared/internal-calendar/standard/standard-cell.tsx
+++ b/src/shared/internal-calendar/standard/standard-cell.tsx
@@ -16,7 +16,7 @@ interface Props {
     allowDisabledSelection?: boolean | undefined;
     isNewSelection?: boolean | undefined;
     currentFocus?: FocusType | undefined;
-    showCurrentMonthOnly?: boolean | undefined;
+    showActiveMonthDaysOnly?: boolean | undefined;
     onSelect: (value: Dayjs, disabled: boolean) => void;
     onHover: (value: string, disabled: boolean) => void;
 }
@@ -33,7 +33,7 @@ export const StandardCell = ({
     disabledDates,
     allowDisabledSelection,
     isNewSelection,
-    showCurrentMonthOnly,
+    showActiveMonthDaysOnly,
     onSelect,
     onHover,
 }: Props) => {
@@ -66,7 +66,9 @@ export const StandardCell = ({
         const props: CellStyleProps = {};
 
         if (calendarDate.month() !== date.month()) {
-            props.labelType = showCurrentMonthOnly ? "hidden" : "unavailable";
+            props.labelType = showActiveMonthDaysOnly
+                ? "hidden"
+                : "unavailable";
         } else if (dayjs().isSame(date, "day") && !disabled) {
             props.labelType = "current";
             props.circleLeft = "current";
@@ -91,7 +93,7 @@ export const StandardCell = ({
         const isStart = date.isSame(startDate, "day");
         const isEnd = date.isSame(endDate, "day");
 
-        if (showCurrentMonthOnly && calendarDate.month() !== date.month()) {
+        if (showActiveMonthDaysOnly && calendarDate.month() !== date.month()) {
             props.labelType = "hidden";
             return props;
         }

--- a/src/shared/internal-calendar/types.ts
+++ b/src/shared/internal-calendar/types.ts
@@ -14,7 +14,7 @@ export interface CommonCalendarProps {
     /** Specifies if dates normally disabled by `minDate`, `maxDate` and `disabledDates` are still selectable */
     allowDisabledSelection?: boolean | undefined;
     /** Specifies if the calendar should display only dates for the selected month */
-    showCurrentMonthOnly?: boolean | undefined;
+    showActiveMonthDaysOnly?: boolean | undefined;
 }
 
 // =============================================================================

--- a/src/shared/internal-calendar/types.ts
+++ b/src/shared/internal-calendar/types.ts
@@ -13,6 +13,8 @@ export interface CommonCalendarProps {
     disabledDates?: string[] | undefined;
     /** Specifies if dates normally disabled by `minDate`, `maxDate` and `disabledDates` are still selectable */
     allowDisabledSelection?: boolean | undefined;
+    /** Specifies if the calendar should display only dates for the selected month */
+    showCurrentMonthOnly?: boolean | undefined;
 }
 
 // =============================================================================

--- a/stories/calendar/calendar.mdx
+++ b/stories/calendar/calendar.mdx
@@ -37,6 +37,12 @@ When `allowDisabledSelection` is set, dates are visually disabled, but still sel
 
 <Canvas of={CalendarStories.AllowDisabledSelection} />
 
+<Heading3>Show current month only</Heading3>
+
+You can use `showCurrentMonthOnly` to display only dates for the selected month.
+
+<Canvas of={CalendarStories.ShowCurrentMonthOnly} />
+
 <Secondary>Component API</Secondary>
 
 <PropsTable />

--- a/stories/calendar/calendar.mdx
+++ b/stories/calendar/calendar.mdx
@@ -37,11 +37,11 @@ When `allowDisabledSelection` is set, dates are visually disabled, but still sel
 
 <Canvas of={CalendarStories.AllowDisabledSelection} />
 
-<Heading3>Show current month only</Heading3>
+<Heading3>Show active month days only</Heading3>
 
-You can use `showCurrentMonthOnly` to display only dates for the selected month.
+You can use `showActiveMonthDaysOnly` to display only dates for the selected month.
 
-<Canvas of={CalendarStories.ShowCurrentMonthOnly} />
+<Canvas of={CalendarStories.ShowActiveMonthDaysOnly} />
 
 <Secondary>Component API</Secondary>
 

--- a/stories/calendar/calendar.stories.tsx
+++ b/stories/calendar/calendar.stories.tsx
@@ -70,11 +70,11 @@ export const AllowDisabledSelection: StoryObj<Component> = {
     },
 };
 
-export const ShowCurrentMonthOnly: StoryObj<Component> = {
+export const ShowActiveMonthDaysOnly: StoryObj<Component> = {
     render: () => {
         return (
             <FullWidthStoryContainer>
-                <Calendar showCurrentMonthOnly={true} />
+                <Calendar showActiveMonthDaysOnly={true} />
             </FullWidthStoryContainer>
         );
     },

--- a/stories/calendar/calendar.stories.tsx
+++ b/stories/calendar/calendar.stories.tsx
@@ -69,3 +69,13 @@ export const AllowDisabledSelection: StoryObj<Component> = {
         );
     },
 };
+
+export const ShowCurrentMonthOnly: StoryObj<Component> = {
+    render: () => {
+        return (
+            <FullWidthStoryContainer>
+                <Calendar showCurrentMonthOnly={true} />
+            </FullWidthStoryContainer>
+        );
+    },
+};

--- a/stories/calendar/props-table.tsx
+++ b/stories/calendar/props-table.tsx
@@ -82,7 +82,7 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["(value: YearMonthDisplay) => void"],
             },
             {
-                name: "showCurrentMonthOnly",
+                name: "showActiveMonthDaysOnly",
                 description:
                     "Specifies if the calendar should display only dates for the selected month",
                 propTypes: ["boolean"],

--- a/stories/calendar/props-table.tsx
+++ b/stories/calendar/props-table.tsx
@@ -82,6 +82,13 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["(value: YearMonthDisplay) => void"],
             },
             {
+                name: "showCurrentMonthOnly",
+                description:
+                    "Specifies if the calendar should display only dates for the selected month",
+                propTypes: ["boolean"],
+                defaultValue: `false`,
+            },
+            {
                 name: "onHover",
                 description: (
                     <>


### PR DESCRIPTION
**Changes**
Add optional `showActiveMonthDaysOnly` prop for `Calendar`, setting to true will hide all dates outside the current selected month

- delete branch

**Changelog entry**

- Add optional `showActiveMonthDaysOnly` prop for `Calendar` component

**Additional information**

- You may refer to this [BOOKINGSG-6107](https://jira.ship.gov.sg/browse/BOOKINGSG-6107)