### PR TITLE
[BOOKINGSG-6108][JH] Modify behavior when selecting end date of DateRangeInput

### DIFF
--- a/src/date-range-input/date-range-input.tsx
+++ b/src/date-range-input/date-range-input.tsx
@@ -316,6 +316,16 @@ export const DateRangeInput = ({
             return;
         }
 
+        const isInvalidRange = dayjs(val).isBefore(selectedStart, "day");
+
+        // if date range is invalid, set selected value as start and reselect end
+        if (isInvalidRange) {
+            actions.changeStart(val);
+            calendarRef.current.setCalendarDate(val);
+            actions.reselectEnd();
+            return;
+        }
+
         actions.changeEnd(val);
         calendarRef.current.setCalendarDate(val);
 
@@ -331,25 +341,10 @@ export const DateRangeInput = ({
 
         /*
         - if next input is empty, focus it
-        - else if date range is invalid, clear and focus the next input
-        - else if date range is valid
-            - if next input is still pristine, focus it
-            - else if !withButton, confirm the selection and "blur" the field
+        - else if !withButton, confirm the selection and "blur" the field
         */
 
         if (!selectedStart) {
-            actions.focus("start");
-            return;
-        }
-
-        const isInvalidRange = dayjs(val).isBefore(selectedStart, "day");
-
-        if (isInvalidRange) {
-            actions.reselectStart();
-            return;
-        }
-
-        if (!isStartDirty) {
             actions.focus("start");
             return;
         }

--- a/src/shared/standalone-date-input/standalone-date-input.tsx
+++ b/src/shared/standalone-date-input/standalone-date-input.tsx
@@ -87,6 +87,15 @@ export const Component = (
         setDayValue(day);
         setMonthValue(month);
         setYearValue(year);
+
+        // re-focus on day input if all 3 inputs get cleared while typing
+        if (
+            !day &&
+            !month &&
+            !year &&
+            nodeRef.current.contains(document.activeElement)
+        )
+            dayInputRef.current.focus();
     }, [value]);
 
     useEffect(() => {


### PR DESCRIPTION
**Changes**
Changes for `DateRangeInput` when selecting the END date:
- END < START: it’ll reset the values and treat this as the new START date. User will have to select an end date. 
- END >= START: it’ll just replace the existing END date with this new value, and close the date picker. (Previously, the user will have to reselect the start date again)

- [delete] branch

**Changelog entry**

- Modify behavior when selecting end date of `DateRangeInput`

**Additional information**

- You may refer to this [BOOKINGSG-6108](https://jira.ship.gov.sg/browse/BOOKINGSG-6108)
