### PR TITLE
[BOOKINGSG-5935][JS] prevent rendering of empty div in Accordion

### DIFF
--- a/src/accordion/accordion.style.tsx
+++ b/src/accordion/accordion.style.tsx
@@ -1,7 +1,7 @@
 import styled, { css } from "styled-components";
 import { Button } from "../button";
-import { MediaQuery } from "../media";
 import { Color } from "../color";
+import { MediaQuery } from "../media";
 import { Text } from "../text/text";
 import { TitleStyleProps, TitleWrapperStyleProps } from "./types";
 
@@ -15,13 +15,23 @@ export const Content = styled.div`
 
 export const TitleWrapper = styled.div<TitleWrapperStyleProps>`
     display: flex;
-    flex-direction: ${(props) => (props.$hasTitle ? "row" : "column")};
-    align-items: ${(props) => (props.$hasTitle ? "center" : "flex-end")};
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-end;
     padding-bottom: 1rem;
 
     ${MediaQuery.MaxWidth.mobileL} {
         justify-content: flex-end;
     }
+
+    ${(props) => {
+        if (!props.$showTitleInMobile && !props.$hasExpandAll) {
+            return css`
+                display: none;
+                visibility: hidden;
+            `;
+        }
+    }}
 `;
 
 export const Title = styled(Text.H2)<TitleStyleProps>`

--- a/src/accordion/accordion.style.tsx
+++ b/src/accordion/accordion.style.tsx
@@ -27,8 +27,9 @@ export const TitleWrapper = styled.div<TitleWrapperStyleProps>`
     ${(props) => {
         if (!props.$showTitleInMobile && !props.$hasExpandAll) {
             return css`
-                display: none;
-                visibility: hidden;
+                ${MediaQuery.MaxWidth.mobileL} {
+                    display: none;
+                }
             `;
         }
     }}

--- a/src/accordion/accordion.tsx
+++ b/src/accordion/accordion.tsx
@@ -52,7 +52,7 @@ const AccordionBase = ({
                 {title && (
                     <Title
                         $showInMobile={showTitleInMobile}
-                        data-testid={"accordion-title"}
+                        data-testid="accordion-title"
                     >
                         {title}
                     </Title>

--- a/src/accordion/accordion.tsx
+++ b/src/accordion/accordion.tsx
@@ -39,20 +39,30 @@ const AccordionBase = ({
         );
     };
 
+    const renderTitleWrapper = () => {
+        if (!title && !enableExpandAll) {
+            return null;
+        }
+
+        return (
+            <TitleWrapper $hasTitle={!!title || showTitleInMobile}>
+                {title && (
+                    <Title
+                        $showInMobile={showTitleInMobile}
+                        data-testid={"accordion-title"}
+                    >
+                        {title}
+                    </Title>
+                )}
+                {enableExpandAll && renderCollapseExpandAll()}
+            </TitleWrapper>
+        );
+    };
+
     return (
         <AccordionContext.Provider value={expandAll}>
             <Content className={className}>
-                <TitleWrapper $hasTitle={!!title || showTitleInMobile}>
-                    {title && (
-                        <Title
-                            $showInMobile={showTitleInMobile}
-                            data-testid={"accordion-title"}
-                        >
-                            {title}
-                        </Title>
-                    )}
-                    {enableExpandAll && renderCollapseExpandAll()}
-                </TitleWrapper>
+                {renderTitleWrapper()}
                 {children}
             </Content>
         </AccordionContext.Provider>

--- a/src/accordion/accordion.tsx
+++ b/src/accordion/accordion.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { AccordionContext } from "./accordion-context";
 import { AccordionItem } from "./accordion-item";
 import {
     Content,
@@ -7,7 +8,6 @@ import {
     TitleWrapper,
 } from "./accordion.style";
 import { AccordionProps } from "./types";
-import { AccordionContext } from "./accordion-context";
 
 const AccordionBase = ({
     children,
@@ -45,7 +45,10 @@ const AccordionBase = ({
         }
 
         return (
-            <TitleWrapper $hasTitle={!!title || showTitleInMobile}>
+            <TitleWrapper
+                $showTitleInMobile={showTitleInMobile}
+                $hasExpandAll={enableExpandAll}
+            >
                 {title && (
                     <Title
                         $showInMobile={showTitleInMobile}

--- a/src/accordion/types.ts
+++ b/src/accordion/types.ts
@@ -39,5 +39,6 @@ export interface TitleStyleProps {
 }
 
 export interface TitleWrapperStyleProps {
-    $hasTitle: boolean;
+    $showTitleInMobile: boolean;
+    $hasExpandAll: boolean;
 }

--- a/stories/accordion/accordion.mdx
+++ b/stories/accordion/accordion.mdx
@@ -36,6 +36,12 @@ If you do not require a title in the `Accordion`, simply omit the `title` prop.
 
 <Canvas of={AccordionStories.NoTitle} />
 
+<Heading3>No Expand/Collapse</Heading3>
+
+If you do not require a expand/collapse button in the `Accordion`, use `enableExpandAll={false}`.
+
+<Canvas of={AccordionStories.NoExpandCollapse} />
+
 <Secondary>Component API</Secondary>
 
 <PropsTable />

--- a/stories/accordion/accordion.mdx
+++ b/stories/accordion/accordion.mdx
@@ -40,7 +40,7 @@ If you do not require a title in the `Accordion`, simply omit the `title` prop.
 
 If you do not require a expand/collapse all button in the `Accordion`, use `enableExpandAll={false}`.
 
-<Canvas of={AccordionStories.NoExpandCollapse} />
+<Canvas of={AccordionStories.NoExpandCollapseAll} />
 
 <Secondary>Component API</Secondary>
 

--- a/stories/accordion/accordion.mdx
+++ b/stories/accordion/accordion.mdx
@@ -36,9 +36,9 @@ If you do not require a title in the `Accordion`, simply omit the `title` prop.
 
 <Canvas of={AccordionStories.NoTitle} />
 
-<Heading3>No Expand/Collapse</Heading3>
+<Heading3>No Expand/Collapse All</Heading3>
 
-If you do not require a expand/collapse button in the `Accordion`, use `enableExpandAll={false}`.
+If you do not require a expand/collapse all button in the `Accordion`, use `enableExpandAll={false}`.
 
 <Canvas of={AccordionStories.NoExpandCollapse} />
 

--- a/stories/accordion/accordion.stories.tsx
+++ b/stories/accordion/accordion.stories.tsx
@@ -141,3 +141,34 @@ export const NoTitle: StoryObj<Component> = {
         );
     },
 };
+
+export const NoExpandCollapse: StoryObj<Component> = {
+    render: () => {
+        return (
+            <Accordion title="No expand/collapse all" enableExpandAll={false}>
+                <Accordion.Item title="This is the first item">
+                    <Text.Body>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+                        sed do eiusmod tempor incididunt ut labore et dolore
+                        magna aliqua. Ut enim ad minim veniam, quis nostrud
+                        exercitation ullamco laboris nisi ut aliquip ex ea
+                        commodo consequat.
+                    </Text.Body>
+                </Accordion.Item>
+                <Accordion.Item title="This is the second item">
+                    <Text.Body>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+                        sed do eiusmod tempor&nbsp;
+                        <Text.Hyperlink.Default
+                            href="https://www.google.com"
+                            target="_blank"
+                        >
+                            see more here
+                        </Text.Hyperlink.Default>
+                        .
+                    </Text.Body>
+                </Accordion.Item>
+            </Accordion>
+        );
+    },
+};

--- a/stories/accordion/accordion.stories.tsx
+++ b/stories/accordion/accordion.stories.tsx
@@ -142,7 +142,7 @@ export const NoTitle: StoryObj<Component> = {
     },
 };
 
-export const NoExpandCollapse: StoryObj<Component> = {
+export const NoExpandCollapseAll: StoryObj<Component> = {
     render: () => {
         return (
             <Accordion title="No expand/collapse all" enableExpandAll={false}>


### PR DESCRIPTION
**Changes**
- Check for both `title` and `enableExpandAll` to render div

- [delete] branch

**Changelog entry**

- Fix extra div on Accordion when `title` is undefined and `enabledExpandAll` is false

