### PR TITLE
[MOL-16433][RP] Add customize offset props to input select

### DIFF
--- a/src/input-select/input-select.tsx
+++ b/src/input-select/input-select.tsx
@@ -50,6 +50,7 @@ export const InputSelect = <T, V>({
     readOnly,
     alignment,
     dropdownZIndex,
+    offset = 8,
 }: InputSelectProps<T, V>): JSX.Element => {
     // =============================================================================
     // CONST, STATE
@@ -274,7 +275,7 @@ export const InputSelect = <T, V>({
                 onClose={handleClose}
                 onDismiss={handleDismiss}
                 clickToToggle
-                offset={8}
+                offset={offset}
                 alignment={alignment}
                 fitAvailableHeight
                 zIndex={dropdownZIndex}

--- a/src/input-select/types.ts
+++ b/src/input-select/types.ts
@@ -58,6 +58,8 @@ export interface InputSelectProps<T, V>
     onBlur?: (() => void) | undefined;
     variant?: DropdownVariantType | undefined;
     alignment?: DropdownAlignmentType | undefined;
+    /* the distance between the reference element and the dropdown */
+    offset?: number | undefined;
     dropdownZIndex?: number | undefined;
     /** @deprecated this has no effect as the dropdown will automatically resize */
     listStyleWidth?: string | undefined;

--- a/stories/form/form-select/props-table.tsx
+++ b/stories/form/form-select/props-table.tsx
@@ -196,6 +196,13 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["number"],
                 defaultValue: "50",
             },
+            {
+                name: "offset",
+                description:
+                    "The distance between the reference element and the dropdown",
+                propTypes: ["number"],
+                defaultValue: "8",
+            },
         ],
     },
     {


### PR DESCRIPTION
**Changes**
- Add custom offset props to the input select.

- [delete] branch


**Changelog entry**

Add a custom `offset` prop to the input select. This prop will adjust the distance between the reference element and the dropdown. default set to 8