### PR TITLE
Accessibility improvements to PopoverTrigger and new inline popover

### DIFF
--- a/src/popover-v2/index.ts
+++ b/src/popover-v2/index.ts
@@ -1,3 +1,4 @@
-export * from "./popover-trigger";
 export * from "./popover";
+export * from "./popover-inline";
+export * from "./popover-trigger";
 export * from "./types";

--- a/src/popover-v2/popover-inline/index.ts
+++ b/src/popover-v2/popover-inline/index.ts
@@ -1,0 +1,1 @@
+export * from "./popover-inline";

--- a/src/popover-v2/popover-inline/popover-inline.styles.ts
+++ b/src/popover-v2/popover-inline/popover-inline.styles.ts
@@ -1,0 +1,52 @@
+import { Color } from "../../color";
+import styled from "styled-components";
+import { PopoverInlineStyle } from "../types";
+
+// =============================================================================
+// STYLE INTERFACE
+// =============================================================================
+
+interface StyledTextProps {
+    $defaultStyle: PopoverInlineStyle;
+    $hoverStyle: PopoverInlineStyle;
+}
+
+interface StyledIconProps {
+    $standalone: boolean;
+}
+
+// =============================================================================
+// STYLING
+// =============================================================================
+const getTextStyle = (style: PopoverInlineStyle) => {
+    switch (style) {
+        case "underline":
+            return "text-decoration: underline 1px;";
+        case "underline-dashed":
+            return "text-decoration: underline dashed 1px;";
+    }
+};
+
+export const StyledText = styled.span<StyledTextProps>`
+    color: ${Color.Primary};
+    font-weight: 600;
+    text-underline-position: under;
+
+    ${({ $defaultStyle }) => getTextStyle($defaultStyle)}
+
+    &:hover,
+    &:focus-visible {
+        color: ${Color.Secondary};
+        ${({ $hoverStyle }) => getTextStyle($hoverStyle)}
+    }
+
+    svg {
+        height: 1lh; // align vertically
+        width: 1em; // scale icon with font size
+        vertical-align: top;
+    }
+`;
+
+export const StyledIcon = styled.span<StyledIconProps>`
+    ${(props) => !props.$standalone && "margin-left: 0.25rem;"}
+`;

--- a/src/popover-v2/popover-inline/popover-inline.tsx
+++ b/src/popover-v2/popover-inline/popover-inline.tsx
@@ -1,0 +1,29 @@
+import { PopoverTrigger } from "../popover-trigger";
+import { PopoverInlineProps } from "../types";
+import { StyledIcon, StyledText } from "./popover-inline.styles";
+
+export const PopoverInline = ({
+    content,
+    icon,
+    underlineStyle = "default",
+    underlineHoverStyle = "default",
+    ...otherProps
+}: PopoverInlineProps) => {
+    // =========================================================================
+    // RENDER FUNCTIONS
+    // =========================================================================
+    return (
+        <PopoverTrigger {...otherProps}>
+            <StyledText
+                role="button"
+                aria-haspopup="dialog"
+                tabIndex={0}
+                $defaultStyle={underlineStyle}
+                $hoverStyle={underlineHoverStyle}
+            >
+                {content}
+                {icon && <StyledIcon $standalone={!content}>{icon}</StyledIcon>}
+            </StyledText>
+        </PopoverTrigger>
+    );
+};

--- a/src/popover-v2/popover-trigger.tsx
+++ b/src/popover-v2/popover-trigger.tsx
@@ -1,24 +1,29 @@
 import {
+    FloatingFocusManager,
     FloatingPortal,
     autoUpdate,
     flip,
     limitShift,
     offset,
     shift,
+    useClick,
+    useDismiss,
     useFloating,
+    useHover,
+    useInteractions,
 } from "@floating-ui/react";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { useMediaQuery } from "react-responsive";
 import { MediaWidths } from "../media";
 import { useFloatingChild } from "../overlay/use-floating-context";
 import { PopoverV2 } from "./popover";
 import { TriggerContainer } from "./popover-trigger.styles";
-import { PopoverV2TriggerProps } from "./types";
+import { PopoverV2TriggerProps, PopoverV2TriggerType } from "./types";
 
 export const PopoverTrigger = ({
     children,
     popoverContent,
-    trigger = "click",
+    trigger: _trigger = "click",
     position = "top",
     zIndex,
     rootNode,
@@ -35,7 +40,7 @@ export const PopoverTrigger = ({
     const isMobile = useMediaQuery({
         maxWidth: MediaWidths.mobileL,
     });
-    const { refs, floatingStyles } = useFloating({
+    const { refs, floatingStyles, context } = useFloating({
         open: visible,
         placement: position,
         whileElementsMounted: autoUpdate,
@@ -46,63 +51,46 @@ export const PopoverTrigger = ({
                 limiter: limitShift(),
             }),
         ],
+        onOpenChange: (isOpen) => {
+            setVisible(isOpen);
+
+            // this callback is triggering twice on hover, the check here prevents extra calls
+            if (visible !== isOpen) {
+                handleVisibilityChange(isOpen);
+            }
+        },
     });
     const parentZIndex = useFloatingChild();
 
-    // =========================================================================
-    // EFFECTS
-    // =========================================================================
-    useEffect(() => {
-        // NOTE: Do not add mouse down event if it's mobile
-        if (isMobile || !visible) {
-            return;
-        }
-        document.addEventListener("mousedown", handleMouseDownEvent);
+    const trigger: PopoverV2TriggerType = isMobile ? "click" : _trigger;
+    const click = useClick(context, {
+        // allow trigger by Space/Enter, but disable mouse click in hover mode
+        ignoreMouse: trigger === "hover",
+    });
+    const dismiss = useDismiss(context);
+    const hover = useHover(context, {
+        enabled: trigger === "hover",
+        // short window to enter the floating element without it closing
+        delay: { close: 500 },
+    });
 
-        return () => {
-            document.removeEventListener("mousedown", handleMouseDownEvent);
-        };
-    }, [visible]);
+    const { getReferenceProps, getFloatingProps } = useInteractions([
+        click,
+        dismiss,
+        hover,
+    ]);
 
     // =========================================================================
     // EVENT HANDLERS
     // =========================================================================
-    const handleMouseDownEvent = (event: MouseEvent) => {
-        if (
-            !nodeRef.current?.contains(event.target as Node) &&
-            !popoverRef.current?.contains(event.target as Node)
-        ) {
-            // outside click
-            setVisible(false);
-
-            if (onPopoverDismiss) onPopoverDismiss();
-        }
-    };
-
-    const handleClick = (event: React.MouseEvent) => {
-        event.preventDefault();
-        if (trigger === "click" || isMobile) {
-            setVisible(!visible);
-
-            if (!visible && onPopoverAppear) onPopoverAppear();
-            if (visible && onPopoverDismiss) onPopoverDismiss();
-        }
-    };
-
-    const handleOnMouseEnter = () => {
-        if (trigger === "hover" && !isMobile) {
-            setVisible(true);
-        }
-    };
-
-    const handleOnMouseLeave = () => {
-        if (trigger === "hover" && visible && !isMobile) {
-            setVisible(false);
-        }
-    };
-
     const handlePopoverMobileClose = () => {
         setVisible(false);
+        handleVisibilityChange(false);
+    };
+
+    const handleVisibilityChange = (nextVisible: boolean) => {
+        if (nextVisible && onPopoverAppear) onPopoverAppear();
+        if (!nextVisible && onPopoverDismiss) onPopoverDismiss();
     };
 
     // =========================================================================
@@ -122,34 +110,41 @@ export const PopoverTrigger = ({
 
     return (
         <>
-            {visible && (
-                <FloatingPortal root={rootNode}>
-                    <div
-                        ref={(node) => {
-                            popoverRef.current = node;
-                            refs.setFloating(node);
-                        }}
-                        style={{
-                            ...floatingStyles,
-                            zIndex: zIndex ?? parentZIndex,
-                        }}
-                    >
-                        {renderPopover()}
-                    </div>
-                </FloatingPortal>
-            )}
             <TriggerContainer
                 ref={(node) => {
                     nodeRef.current = node;
                     refs.setReference(node);
                 }}
-                onClick={handleClick}
-                onMouseEnter={handleOnMouseEnter}
-                onMouseLeave={handleOnMouseLeave}
+                {...getReferenceProps({
+                    onClick: (event) => {
+                        // prevent popover interaction from triggering click events on parents
+                        event.stopPropagation();
+                        event.preventDefault();
+                    },
+                })}
                 {...otherProps}
             >
                 {children}
             </TriggerContainer>
+            {visible && (
+                <FloatingPortal root={rootNode}>
+                    <FloatingFocusManager context={context}>
+                        <div
+                            ref={(node) => {
+                                popoverRef.current = node;
+                                refs.setFloating(node);
+                            }}
+                            style={{
+                                ...floatingStyles,
+                                zIndex: zIndex ?? parentZIndex,
+                            }}
+                            {...getFloatingProps()}
+                        >
+                            {renderPopover()}
+                        </div>
+                    </FloatingFocusManager>
+                </FloatingPortal>
+            )}
         </>
     );
 };

--- a/src/popover-v2/types.ts
+++ b/src/popover-v2/types.ts
@@ -36,3 +36,13 @@ export interface PopoverV2TriggerProps {
     onPopoverAppear?: (() => void) | undefined;
     onPopoverDismiss?: (() => void) | undefined;
 }
+
+export type PopoverInlineStyle = "default" | "underline" | "underline-dashed";
+
+export interface PopoverInlineProps
+    extends Omit<PopoverV2TriggerProps, "children"> {
+    content?: React.ReactNode | undefined;
+    icon?: JSX.Element | undefined;
+    underlineStyle?: PopoverInlineStyle | undefined;
+    underlineHoverStyle?: PopoverInlineStyle | undefined;
+}

--- a/stories/popover-v2/popover-inline/popover-inline.mdx
+++ b/stories/popover-v2/popover-inline/popover-inline.mdx
@@ -1,0 +1,30 @@
+import { Canvas, Meta } from "@storybook/blocks";
+import { Heading3, Heading4, Secondary, Title } from "../../storybook-common";
+import * as PopoverInlineStories from "./popover-inline.stories";
+import { PropsTable } from "./props-table";
+
+<Meta of={PopoverInlineStories} />
+
+<Title>PopoverInline</Title>
+
+<Secondary>Overview</Secondary>
+
+Provides additional information for content within a text block.
+
+<Canvas of={PopoverInlineStories.InlineTextAndIcon} />
+
+<Heading3>Text style</Heading3>
+
+The text and icon inherit the font size of the surrounding text.
+
+<Canvas of={PopoverInlineStories.InlineText} />
+
+<Canvas of={PopoverInlineStories.InlineIcon} />
+
+<Heading3>Underline style</Heading3>
+
+<Canvas of={PopoverInlineStories.UnderlineStyle} />
+
+<Secondary>Component API</Secondary>
+
+<PropsTable />

--- a/stories/popover-v2/popover-inline/popover-inline.stories.tsx
+++ b/stories/popover-v2/popover-inline/popover-inline.stories.tsx
@@ -1,0 +1,108 @@
+import { ICircleFillIcon } from "@lifesg/react-icons";
+import type { Meta, StoryObj } from "@storybook/react";
+import { PopoverInline } from "src/popover-v2";
+import { Text } from "src/text";
+
+type Component = typeof PopoverInline;
+
+const meta: Meta<Component> = {
+    title: "Modules/PopoverV2/PopoverInline",
+    component: PopoverInline,
+};
+
+export default meta;
+
+export const InlineText: StoryObj<Component> = {
+    render: () => {
+        return (
+            <>
+                <Text.H3>
+                    The{" "}
+                    <PopoverInline
+                        content="fox"
+                        popoverContent="It is quick and brown"
+                    />{" "}
+                    jumps over the dog
+                </Text.H3>
+                <br />
+                <Text.Body>
+                    The{" "}
+                    <PopoverInline
+                        content="fox"
+                        popoverContent="It is quick and brown"
+                    />{" "}
+                    jumps over the dog
+                </Text.Body>
+            </>
+        );
+    },
+};
+
+export const InlineIcon: StoryObj<Component> = {
+    render: () => {
+        return (
+            <>
+                <Text.H3>
+                    Get a free slice of pizza today{" "}
+                    <PopoverInline
+                        popoverContent="Terms and conditions apply"
+                        icon={<ICircleFillIcon />}
+                    />
+                </Text.H3>
+                <br />
+                <Text.Body>
+                    Get a free slice of pizza today{" "}
+                    <PopoverInline
+                        popoverContent="Terms and conditions apply"
+                        icon={<ICircleFillIcon />}
+                    />
+                </Text.Body>
+            </>
+        );
+    },
+};
+
+export const InlineTextAndIcon: StoryObj<Component> = {
+    render: () => {
+        return (
+            <Text.Body>
+                Only available on{" "}
+                <PopoverInline
+                    content="Fridays"
+                    popoverContent="Operating hours: 9am to 5pm"
+                    icon={<ICircleFillIcon />}
+                ></PopoverInline>
+            </Text.Body>
+        );
+    },
+};
+
+export const UnderlineStyle: StoryObj<Component> = {
+    render: () => {
+        return (
+            <>
+                <Text.Body>
+                    This is the{" "}
+                    <PopoverInline
+                        content="underlined style"
+                        popoverContent="I am a tooltip!"
+                        icon={<ICircleFillIcon />}
+                        underlineStyle="underline"
+                        underlineHoverStyle="underline"
+                    />
+                </Text.Body>
+                <br />
+                <Text.Body>
+                    This is the{" "}
+                    <PopoverInline
+                        content="dashed style"
+                        popoverContent="I am a tooltip!"
+                        icon={<ICircleFillIcon />}
+                        underlineStyle="underline-dashed"
+                        underlineHoverStyle="underline-dashed"
+                    />
+                </Text.Body>
+            </>
+        );
+    },
+};

--- a/stories/popover-v2/popover-inline/props-table.tsx
+++ b/stories/popover-v2/popover-inline/props-table.tsx
@@ -1,0 +1,50 @@
+import { ApiTable } from "../../storybook-common/api-table";
+import { ApiTableSectionProps } from "../../storybook-common/api-table/types";
+import { COMMON_POPOVER_ATTRIBUTES } from "../props-table";
+
+const DATA: ApiTableSectionProps[] = [
+    {
+        attributes: [
+            {
+                name: "className",
+                description: "Class selector for the component",
+                propTypes: ["string"],
+            },
+            {
+                name: "id",
+                description: "The unique identifier for the component",
+                propTypes: ["string"],
+            },
+            {
+                name: "data-testid",
+                description: "The test identifier for the component",
+                propTypes: ["string"],
+            },
+            {
+                name: "content",
+                description: "The text content to display",
+                propTypes: ["React.ReactNode"],
+            },
+            {
+                name: "icon",
+                description: "The icon to display",
+                propTypes: ["React.ReactNode"],
+            },
+            {
+                name: "underlineStyle",
+                description: "The underline style of the text",
+                propTypes: ["React.ReactNode"],
+                defaultValue: `"default"`,
+            },
+            {
+                name: "underlineHoverStyle",
+                description: "The underline style of the text when hovered",
+                propTypes: ["React.ReactNode"],
+                defaultValue: `"default"`,
+            },
+            ...COMMON_POPOVER_ATTRIBUTES,
+        ],
+    },
+];
+
+export const PropsTable = () => <ApiTable sections={DATA} />;

--- a/stories/popover-v2/popover-inline/props-table.tsx
+++ b/stories/popover-v2/popover-inline/props-table.tsx
@@ -33,13 +33,13 @@ const DATA: ApiTableSectionProps[] = [
             {
                 name: "underlineStyle",
                 description: "The underline style of the text",
-                propTypes: ["React.ReactNode"],
+                propTypes: [`"default"`, `"underline"`, `"underline-dashed"`],
                 defaultValue: `"default"`,
             },
             {
                 name: "underlineHoverStyle",
                 description: "The underline style of the text when hovered",
-                propTypes: ["React.ReactNode"],
+                propTypes: [`"default"`, `"underline"`, `"underline-dashed"`],
                 defaultValue: `"default"`,
             },
             ...COMMON_POPOVER_ATTRIBUTES,

--- a/stories/popover-v2/popover.mdx
+++ b/stories/popover-v2/popover.mdx
@@ -25,12 +25,20 @@ import { PopoverTrigger } from "@lifesg/react-design-system/popover-v2";
 
 <Canvas of={PopoverStories.HoverInteraction} />
 
-<Heading4>Appearance information</Heading4>
+<Heading4>Behaviour</Heading4>
+
+**Appearance**
 
 -   The `Popover` component automatically positions itself based on the amount of space available. It will always attempt to display itself at the preferred position by default
 -   The `Popover` appears as a modal in mobile viewports
 
-The example below illustrates the default behaviour.
+**Keyboard support**
+
+The trigger should be included in the page's tab sequence. This way, users who
+navigate via keyboard can open the popover with `Space`/`Enter`. On open, focus
+will move to the popover. Press `Escape` to dismiss the popover.
+
+The example below illustrates the positioning behaviour when viewed on desktop.
 
 <Canvas of={PopoverStories.Appearance} />
 

--- a/stories/popover-v2/popover.mdx
+++ b/stories/popover-v2/popover.mdx
@@ -11,6 +11,12 @@ import { PropsTable } from "./props-table";
 
 A component which appears when hovering or clicking on a target element and displays information about a certain element in the page.
 
+This module contains:
+
+-   PopoverV2 - the presentational component
+-   PopoverTrigger - a utility component that handles triggering of the popover
+-   [PopoverInline](/docs/modules-popoverv2-popoverinline--docs) - a utility component that displays a text or icon-based trigger
+
 ```tsx
 import { PopoverTrigger } from "@lifesg/react-design-system/popover-v2";
 ```
@@ -53,5 +59,7 @@ If you still encounter z-index issues, try setting a custom `zIndex` or
 `rootNode`.
 
 <Canvas of={PopoverStories.UsageInOverlay} />
+
+<Secondary>Component API</Secondary>
 
 <PropsTable />

--- a/stories/popover-v2/props-table.tsx
+++ b/stories/popover-v2/props-table.tsx
@@ -2,6 +2,102 @@ import { ApiTable } from "../storybook-common/api-table";
 import { ApiTableSectionProps } from "../storybook-common/api-table/types";
 import { TabAttribute, Tabs } from "../storybook-common/tabs";
 
+export const COMMON_POPOVER_ATTRIBUTES: ApiTableSectionProps["attributes"] = [
+    {
+        name: "popoverContent",
+        description: (
+            <>
+                The content of the <code>Popover</code>
+            </>
+        ),
+        propTypes: ["string", "JSX.Element", "() => React.ReactNode"],
+        mandatory: true,
+    },
+    {
+        name: "trigger",
+        description: (
+            <>
+                The trigger for the appearance of the <code>Popover</code>
+            </>
+        ),
+        propTypes: [`"click"`, `"hover"`],
+        defaultValue: `"click"`,
+    },
+    {
+        name: "position",
+        description: (
+            <>
+                The visual position of the <code>Popover</code> in relation to
+                its trigger
+            </>
+        ),
+        propTypes: [
+            `"top"`,
+            `"top-start"`,
+            `"top-end"`,
+            `"bottom"`,
+            `"bottom-start"`,
+            `"bottom-end"`,
+            `"left"`,
+            `"left-start"`,
+            `"left-end"`,
+            `"right"`,
+            `"right-start"`,
+            `"right-end"`,
+        ],
+        defaultValue: `"top"`,
+    },
+    {
+        name: "zIndex",
+        description: (
+            <>
+                The custom z-index of the <code>Popover</code>. Try specifying
+                this if you encounter z-index conflicts.
+            </>
+        ),
+        propTypes: ["number"],
+    },
+    {
+        name: "rootNode",
+        description: (
+            <>
+                The root element that hosts the popover element. Try specifying
+                this if <code>zIndex</code> does not work.
+                <br />
+                <br />
+                For example, if the parent of the trigger element has a higher
+                z-index than the popover, the popover may not be visible.
+                Specify the parent here instead so that they share the same
+                stacking context.
+            </>
+        ),
+        propTypes: ["RefObject<HTMLElement>"],
+        defaultValue: (
+            <>
+                document<code>body</code>
+            </>
+        ),
+    },
+    {
+        name: "onPopoverAppear",
+        description: (
+            <>
+                The callback when the <code>Popover</code> appears
+            </>
+        ),
+        propTypes: ["() => void"],
+    },
+    {
+        name: "onPopoverDismiss",
+        description: (
+            <>
+                The callback when the <code>Popover</code> dismisses
+            </>
+        ),
+        propTypes: ["() => void"],
+    },
+];
+
 const POPOVER_TRIGGER_DATA: ApiTableSectionProps[] = [
     {
         attributes: [
@@ -31,100 +127,7 @@ const POPOVER_TRIGGER_DATA: ApiTableSectionProps[] = [
                 propTypes: ["React.ReactNode"],
                 mandatory: true,
             },
-            {
-                name: "popoverContent",
-                description: (
-                    <>
-                        The content of the <code>Popover</code>
-                    </>
-                ),
-                propTypes: ["string", "JSX.Element", "() => React.ReactNode"],
-                mandatory: true,
-            },
-            {
-                name: "trigger",
-                description: (
-                    <>
-                        The trigger for the appearance of the{" "}
-                        <code>Popover</code>
-                    </>
-                ),
-                propTypes: [`"click"`, `"hover"`],
-                defaultValue: `"click"`,
-            },
-            {
-                name: "position",
-                description: (
-                    <>
-                        The visual position of the <code>Popover</code> in
-                        relation to it&rsquo;s trigger
-                    </>
-                ),
-                propTypes: [
-                    `"top"`,
-                    `"top-start"`,
-                    `"top-end"`,
-                    `"bottom"`,
-                    `"bottom-start"`,
-                    `"bottom-end"`,
-                    `"left"`,
-                    `"left-start"`,
-                    `"left-end"`,
-                    `"right"`,
-                    `"right-start"`,
-                    `"right-end"`,
-                ],
-                defaultValue: `"top"`,
-            },
-            {
-                name: "zIndex",
-                description: (
-                    <>
-                        The custom z-index of the <code>Popover</code>. Try
-                        specifying this if you encounter z-index conflicts.
-                    </>
-                ),
-                propTypes: ["number"],
-            },
-            {
-                name: "rootNode",
-                description: (
-                    <>
-                        The root element that hosts the popover element. Try
-                        specifying this if <code>zIndex</code> does not work.
-                        <br />
-                        <br />
-                        For example, if the parent of the trigger element has a
-                        higher z-index than the popover, the popover may not be
-                        visible. Specify the parent here instead so that they
-                        share the same stacking context.
-                    </>
-                ),
-                propTypes: ["RefObject<HTMLElement>"],
-                defaultValue: (
-                    <>
-                        document<code>body</code>
-                    </>
-                ),
-            },
-            {
-                name: "onPopoverAppear",
-                description: (
-                    <>
-                        The callback when the <code>Popover</code> appears
-                    </>
-                ),
-                propTypes: ["() => void"],
-            },
-            {
-                name: "onPopoverDismiss",
-                description: (
-                    <>
-                        The callback when the <code>Popover</code> dismisses
-                    </>
-                ),
-                propTypes: ["() => void"],
-            },
+            ...COMMON_POPOVER_ATTRIBUTES,
         ],
     },
 ];

--- a/tests/popover/popover-inline.spec.tsx
+++ b/tests/popover/popover-inline.spec.tsx
@@ -1,0 +1,73 @@
+import { CircleIcon } from "@lifesg/react-icons";
+import {
+    render,
+    screen,
+    waitFor,
+    waitForElementToBeRemoved,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PopoverInline } from "../../src/popover-v2";
+
+const TEXT_CONTENT = "Text";
+const TOOLTIP_CONTENT = "Tooltip";
+
+// =============================================================================
+// UNIT TESTS
+// =============================================================================
+describe("PopoverInline", () => {
+    it("should render the popover text and icon", () => {
+        render(
+            <PopoverInline
+                content={TEXT_CONTENT}
+                icon={<CircleIcon />}
+                popoverContent={TOOLTIP_CONTENT}
+            />
+        );
+
+        const text = screen.getByText(TEXT_CONTENT);
+        const icon = document.querySelector("svg");
+
+        expect(text).toBeInTheDocument();
+        expect(icon).toBeInTheDocument();
+        expect(
+            text.compareDocumentPosition(icon) &
+                Node.DOCUMENT_POSITION_FOLLOWING
+        ).toBeTruthy();
+        expect(screen.queryByText(TOOLTIP_CONTENT)).not.toBeInTheDocument();
+    });
+
+    describe("trigger", () => {
+        it("should display the popover when clicked", async () => {
+            render(
+                <PopoverInline
+                    content={TEXT_CONTENT}
+                    popoverContent={TOOLTIP_CONTENT}
+                />
+            );
+
+            userEvent.click(screen.getByText(TEXT_CONTENT));
+
+            await waitFor(() => screen.getByText(TOOLTIP_CONTENT));
+        });
+
+        it("should display the popover when hovered", async () => {
+            render(
+                <PopoverInline
+                    content={TEXT_CONTENT}
+                    popoverContent={TOOLTIP_CONTENT}
+                    trigger="hover"
+                />
+            );
+
+            userEvent.hover(screen.getByText(TEXT_CONTENT));
+
+            await waitFor(() => screen.getByText(TOOLTIP_CONTENT));
+
+            userEvent.unhover(screen.getByText("Text"));
+
+            await waitForElementToBeRemoved(() =>
+                screen.queryByText(TOOLTIP_CONTENT)
+            );
+        });
+    });
+});


### PR DESCRIPTION
**Changes**

- Enhancement to `PopoverTrigger`
  - Switch implementation to use floating-ui's built in interactions
  - This comes with keyboard support and focus trapping
- New `PopoverInline` component
  - Displays text/icon to trigger a popover, intended to be used inline within a block of text
  - Built on top of `PopoverTrigger` and so exposes similar props
  - Supports underline styling
  - The dashed style is to cater for MyLegacy's usage https://dev.designsystem.lifesg.io/storybook/mylegacy/index.html?path=/docs/components--tooltip
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- New `PopoverInline` to support text and/or icon as a popover trigger
- Improve `PopoverTrigger` accessibility with keyboard support and automatic focus trapping
  -  [WARNING] If you use `PopoverTrigger` for custom popovers, verify that your interaction is not affected