### PR TITLE
Support interactive elements in toggle label

### DIFF
--- a/src/shared/input-wrapper/input-wrapper.tsx
+++ b/src/shared/input-wrapper/input-wrapper.tsx
@@ -164,3 +164,17 @@ export const BasicButton = styled.button<InputStyleProps>`
         outline: 2px auto ${Color.Primary};
     }
 `;
+
+/**
+ * visually hide input while keeping it accessible to screen readers
+ * referenced from https://www.scottohara.me/blog/2017/04/14/inclusively-hidden.html
+ * */
+export const VisuallyHiddenInput = styled.input`
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+`;

--- a/src/toggle/toggle.styles.tsx
+++ b/src/toggle/toggle.styles.tsx
@@ -3,6 +3,7 @@ import { Alert } from "../alert";
 import { Color } from "../color";
 import { MediaQuery } from "../media";
 import { applyHtmlContentStyle } from "../shared/html-content/html-content";
+import { VisuallyHiddenInput } from "../shared/input-wrapper/input-wrapper";
 import { Text, TextStyleHelper } from "../text";
 import { TextList } from "../text-list";
 import { ToggleStyleType } from "./types";
@@ -79,7 +80,8 @@ export const Container = styled.div<ContainerStyleProps>`
                     return css`
                         border-color: ${Color.Validation.Red.Icon};
 
-                        :hover {
+                        :hover,
+                        :has(${VisuallyHiddenInput}:focus-visible) {
                             box-shadow: 0 0 4px 1px ${Color.Shadow.Red};
                         }
                     `;
@@ -87,7 +89,8 @@ export const Container = styled.div<ContainerStyleProps>`
                     return css`
                         border-color: transparent;
 
-                        :hover {
+                        :hover,
+                        :has(${VisuallyHiddenInput}:focus-visible) {
                             background: ${Color.Accent.Light[6]};
                         }
                     `;
@@ -111,7 +114,8 @@ export const Container = styled.div<ContainerStyleProps>`
                     return css`
                         border-color: ${Color.Validation.Red.Border};
 
-                        :hover {
+                        :hover,
+                        :has(${VisuallyHiddenInput}:focus-visible) {
                             box-shadow: 0 0 4px 1px ${Color.Shadow.Red};
                         }
                     `;
@@ -119,7 +123,8 @@ export const Container = styled.div<ContainerStyleProps>`
                     return css`
                         border-color: ${Color.Primary};
 
-                        :hover {
+                        :hover,
+                        :has(${VisuallyHiddenInput}:focus-visible) {
                             box-shadow: 0 0 4px 1px ${Color.Shadow.Accent};
                         }
                     `;
@@ -128,7 +133,8 @@ export const Container = styled.div<ContainerStyleProps>`
                         background: ${Color.Neutral[8]};
                         border-color: ${Color.Neutral[5]};
 
-                        :hover {
+                        :hover,
+                        :has(${VisuallyHiddenInput}:focus-visible) {
                             box-shadow: 0 0 4px 1px ${Color.Shadow.Accent};
                             border-color: ${Color.Accent.Light[1]};
                         }
@@ -137,20 +143,6 @@ export const Container = styled.div<ContainerStyleProps>`
             }
         }
     }}
-`;
-
-export const Input = styled.input`
-    position: absolute;
-    height: 100%;
-    width: 100%;
-    cursor: ${(props) => (props.disabled ? "not-allowed" : "pointer")};
-    top: 0;
-    left: 0;
-
-    /* Hide appearance but keep it focusable using keyboard interactions */
-    appearance: none;
-    background: transparent;
-    border: none;
 `;
 
 export const TextContainer = styled.div`
@@ -162,6 +154,9 @@ export const TextContainer = styled.div`
 `;
 
 export const Label = styled.label<LabelStyleProps>`
+    flex: 1;
+    color: ${Color.Neutral[1]};
+
     ${(props) => {
         if (props.$selected && !props.$indicator) {
             return css`
@@ -173,6 +168,7 @@ export const Label = styled.label<LabelStyleProps>`
             `;
         }
     }}
+
     overflow: hidden;
     display: -webkit-box;
     text-overflow: ellipsis;
@@ -185,7 +181,6 @@ export const Label = styled.label<LabelStyleProps>`
     ${MediaQuery.MaxWidth.mobileL} {
         -webkit-line-clamp: ${(props) => props.$maxLines?.mobile ?? "none"};
     }
-    color: ${Color.Neutral[1]};
 
     ${(props) => {
         if (props.$disabled) {
@@ -203,9 +198,6 @@ export const Label = styled.label<LabelStyleProps>`
 export const SubLabel = styled.div<LabelStyleProps>`
     ${TextStyleHelper.getTextStyle("BodySmall", "regular")}
     margin-top: 0.5rem;
-
-    z-index: 1; // forces sublabel to render above the input
-    pointer-events: none; // to allow click events to be passed to the input
 
     strong,
     b {

--- a/src/toggle/toggle.tsx
+++ b/src/toggle/toggle.tsx
@@ -1,6 +1,7 @@
 import { ChevronDownIcon } from "@lifesg/react-icons/chevron-down";
 import { ChevronUpIcon } from "@lifesg/react-icons/chevron-up";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { VisuallyHiddenInput } from "../shared/input-wrapper/input-wrapper";
 import { ToggleIcon, ToggleIconType } from "../shared/toggle-icon/toggle-icon";
 import { SimpleIdGenerator } from "../util";
 import {
@@ -13,7 +14,6 @@ import {
     ExpandButton,
     HeaderContainer,
     IndicatorLabelContainer,
-    Input,
     Label,
     RemoveButton,
     SubLabel,
@@ -101,6 +101,17 @@ export const Toggle = ({
                     break;
             }
         }
+    };
+
+    const handleToggleClick = () => {
+        // simulate change event on the input
+        inputRef.current.click();
+    };
+
+    const handleLabelClick = (e: React.MouseEvent) => {
+        // the associated input is automatically toggled, this prevents the
+        // parent container from receiving the click and triggering change twice
+        e.stopPropagation();
     };
 
     const handleExpandCollapseClick = () => {
@@ -213,17 +224,20 @@ export const Toggle = ({
                 $indicator={indicator}
                 $styleType={styleType}
             >
-                <IndicatorLabelContainer $addPadding={removable}>
-                    <Input
-                        ref={inputRef}
-                        name={name}
-                        id={`${generatedId}-input`}
-                        type={type === "checkbox" ? "checkbox" : "radio"}
-                        data-testid="toggle-input"
-                        disabled={disabled}
-                        onChange={handleOnChange}
-                        checked={selected}
-                    />
+                <VisuallyHiddenInput
+                    ref={inputRef}
+                    name={name}
+                    id={`${generatedId}-input`}
+                    type={type === "checkbox" ? "checkbox" : "radio"}
+                    data-testid="toggle-input"
+                    disabled={disabled}
+                    onChange={handleOnChange}
+                    checked={selected}
+                />
+                <IndicatorLabelContainer
+                    $addPadding={removable}
+                    onClick={handleToggleClick}
+                >
                     {indicator && renderIndicator()}
                     <TextContainer>
                         <Label
@@ -233,13 +247,13 @@ export const Toggle = ({
                             $disabled={disabled}
                             data-testid={`${generatedId}-toggle-label`}
                             $maxLines={childrenMaxLines}
+                            onClick={handleLabelClick}
                         >
                             {children}
                         </Label>
                         {subLabel && renderSubLabel()}
                     </TextContainer>
                 </IndicatorLabelContainer>
-
                 {removable && (
                     <RemoveButton
                         type="button"

--- a/stories/toggle/toggle-6-examples.mdx
+++ b/stories/toggle/toggle-6-examples.mdx
@@ -24,9 +24,6 @@ also remove this custom option afterwards. This variant cannot be collapsed.
 
 <Canvas of={ToggleExampleStories.DynamicOption} />
 
-<Heading3>Interactive sublabel</Heading3>
+<Heading3>With tooltip</Heading3>
 
-By default, clicking on the sublabel will activate the `Toggle`. If you require interactive content such as links,
-you may opt out of this behaviour as such:
-
-<Canvas of={ToggleExampleStories.InteractiveSublabel} />
+<Canvas of={ToggleExampleStories.WithTooltip} />

--- a/stories/toggle/toggle-6-examples.stories.tsx
+++ b/stories/toggle/toggle-6-examples.stories.tsx
@@ -1,8 +1,8 @@
+import { ICircleFillIcon } from "@lifesg/react-icons";
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
-import { Toggle } from "../../src";
+import { PopoverInline, Toggle } from "../../src";
 import { Form } from "../../src/form";
-import { Text } from "../../src/text";
 
 type Component = typeof Toggle;
 
@@ -96,30 +96,15 @@ export const DynamicOption: StoryObj<Component> = {
     },
 };
 
-export const InteractiveSublabel: StoryObj<Component> = {
+export const WithTooltip: StoryObj<Component> = {
     render: () => {
         return (
-            <Toggle
-                indicator
-                subLabel={() => (
-                    <div>
-                        Clicking here toggles the button.
-                        <div style={{ pointerEvents: "auto" }}>
-                            Clicking here does not and{" "}
-                            <Text.Hyperlink.Small
-                                href="https://example.com"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                external
-                            >
-                                this link
-                            </Text.Hyperlink.Small>{" "}
-                            is accessible
-                        </div>
-                    </div>
-                )}
-            >
-                Hello
+            <Toggle>
+                Hawaiian pizza{" "}
+                <PopoverInline
+                    popoverContent="Ham and pineapple"
+                    icon={<ICircleFillIcon />}
+                />
             </Toggle>
         );
     },


### PR DESCRIPTION
**Changes**

- The current implementation applies an `input` over the toggle label + sublabel to preserve the native accessibility and keyboard behaviour. But this prevents elements in the toggle from being targeted, e.g. tooltips
- This PR does the following:
  - Style input to be invisible and out-of-the-way. It can still be tabbed to via keyboard, and the screen reader is able to read out its associated label
  - Let clicks on the toggle container trigger the input change event
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- [WARNING] Modify click behaviour in `Toggle` to support interactive elements in label