### PR TITLE
fix dropdown animation bug

### DIFF
--- a/src/shared/dropdown-wrapper/dropdown-wrapper.styles.tsx
+++ b/src/shared/dropdown-wrapper/dropdown-wrapper.styles.tsx
@@ -91,6 +91,7 @@ const zindexPositionHide = keyframes`
 
 	to {
 		position: relative;
+        width: 100%;
 	}
 `;
 


### PR DESCRIPTION
**Changes**
- ensure dropdown width stays at 100% throughout animation
- [delete] branch

**Changelog entry**
- Fixed shrinking width bug in Chrome v129 for these components
 - `NestedMultiSelect`
 - `NestedSelect`
 - `PhoneNumberInput`
 - `PredictiveTextInput`

**Additional information**
- component / dropdown is shrinking on mount / collapse due to animation changes in chrome 129 https://developer.chrome.com/blog/new-in-chrome-129#animate
