### PR TITLE
[BOOKINGSG-6120][JH] additional timeRangePicker combobox fixes

### DIFF
--- a/src/time-range-picker/combobox-picker/combobox-picker.tsx
+++ b/src/time-range-picker/combobox-picker/combobox-picker.tsx
@@ -241,6 +241,7 @@ export const ComboboxPicker = ({
         if (
             nodeRef.current &&
             !nodeRef.current.contains(event.relatedTarget) &&
+            activeTimeSelector &&
             !dropdownOpen // Necessary because dropdown floating ui is not a child
         ) {
             handleTimeChange(startTimeVal, endTimeVal, { triggerOnBlur: true });
@@ -253,6 +254,7 @@ export const ComboboxPicker = ({
             // No handleTimeChange to avoid duplicate call from handleBlur
             setActiveTimeSelector(null);
             setDropdownOpen(false);
+            onBlur?.();
         } else {
             // Dropdown closed via exiting component (eg. tab)
             handleTimeChange(startTimeVal, endTimeVal, { triggerOnBlur: true });


### PR DESCRIPTION
**Changes**
- fixed `errorMessage` prop to hide dropdown as well (only internal validation was doing this previously)
- modified invalid time range validation behavior to keep values instead of auto clearing end value
- fixed bug where clicking outside the input, on the error message was not triggering the blur event
- split tab behavior test case to (hopefully) fix test case sometimes failing on gitlab pipeline

- [delete] branch
