### PR TITLE
[MOL-16838][MA] Set focus to the selected item when loading the input-select component

### DIFF
--- a/src/input-select/input-select.tsx
+++ b/src/input-select/input-select.tsx
@@ -259,6 +259,7 @@ export const InputSelect = <T, V>({
                 renderCustomCallToAction={renderCustomCallToAction}
                 variant={variant}
                 width={elementWidth}
+                topScrollItem={selected}
             />
         );
     };


### PR DESCRIPTION
**Changes**

- Specify the `topScrollItem` prop in the `DropdownList` component in `InputSelect` to apply focus on the selected option when loading the `InputSelect` component
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Add `topScrollItem` prop to the `DropdownList` component in `InputSelect` to apply focus on the selected option

**Additional information**

- You may refer to this ticket [MOL-16838](https://jira.ship.gov.sg/browse/MOL-16838)
