### PR TITLE
[MOL-17553][RP] Introduce prefix to textarea

### DIFF
--- a/src/form/form-textarea.tsx
+++ b/src/form/form-textarea.tsx
@@ -108,7 +108,6 @@ const FormTextareaComponent = (
                 onChange={handleChange}
                 ref={ref}
                 prefix={prefix}
-                transformValue={transformValue}
                 {...otherProps}
             />
             {renderBottomLabels()}

--- a/src/form/form-textarea.tsx
+++ b/src/form/form-textarea.tsx
@@ -59,6 +59,7 @@ const FormTextareaComponent = (
     const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
         const newValue = event.target.value;
         setStateValue(newValue);
+        if (onChange) onChange(event);
     };
 
     // =============================================================================

--- a/src/form/form-textarea.tsx
+++ b/src/form/form-textarea.tsx
@@ -57,53 +57,8 @@ const FormTextareaComponent = (
     // EVENT HANDLER
     // =============================================================================
     const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-        let newValue = event.target.value;
-
-        if (prefix) {
-            // Ensure the prefix is always at the beginning
-            if (!newValue.startsWith(prefix)) {
-                newValue = prefix + newValue.trimStart();
-            }
-
-            // Prevent user from deleting the prefix
-            if (newValue.length < prefix.length) {
-                newValue = prefix;
-            }
-
-            // Extract user input (ensuring it's never undefined)
-            const userInput = newValue.slice(prefix.length) || ""; // Ensure empty string, not undefined
-
-            setStateValue(userInput);
-            event.target.value = prefix + userInput; // Update displayed value
-
-            // Ensure cursor stays in correct position
-            requestAnimationFrame(() => {
-                const cursorPosition = Math.max(
-                    prefix.length,
-                    event.target.selectionStart || 0
-                );
-                event.target.setSelectionRange(cursorPosition, cursorPosition);
-            });
-
-            // Pass only user input (without prefix) to parent `onChange`
-            if (onChange) {
-                const syntheticEvent = {
-                    ...event,
-                    target: { ...event.target, value: userInput },
-                };
-                onChange(
-                    syntheticEvent as React.ChangeEvent<HTMLTextAreaElement>
-                );
-            }
-        } else {
-            const transformedValue = transformValue
-                ? transformValue(newValue ?? "")
-                : newValue;
-
-            setStateValue(transformedValue);
-            event.target.value = transformedValue;
-            if (onChange) onChange(event);
-        }
+        const newValue = event.target.value;
+        setStateValue(newValue);
     };
 
     // =============================================================================

--- a/src/form/form-textarea.tsx
+++ b/src/form/form-textarea.tsx
@@ -30,6 +30,7 @@ const FormTextareaComponent = (
         tabletCols,
         desktopCols,
         transformValue,
+        prefix = "",
         ...otherProps
     } = props;
 
@@ -56,15 +57,53 @@ const FormTextareaComponent = (
     // EVENT HANDLER
     // =============================================================================
     const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-        const newValue = event.target.value;
+        let newValue = event.target.value;
 
-        const transformedValue = transformValue
-            ? transformValue(newValue ?? "")
-            : newValue;
+        if (prefix) {
+            // Ensure the prefix is always at the beginning
+            if (!newValue.startsWith(prefix)) {
+                newValue = prefix + newValue.trimStart();
+            }
 
-        setStateValue(transformedValue);
-        event.target.value = transformedValue;
-        if (onChange) onChange(event);
+            // Prevent user from deleting the prefix
+            if (newValue.length < prefix.length) {
+                newValue = prefix;
+            }
+
+            // Extract user input (ensuring it's never undefined)
+            const userInput = newValue.slice(prefix.length) || ""; // Ensure empty string, not undefined
+
+            setStateValue(userInput);
+            event.target.value = prefix + userInput; // Update displayed value
+
+            // Ensure cursor stays in correct position
+            requestAnimationFrame(() => {
+                const cursorPosition = Math.max(
+                    prefix.length,
+                    event.target.selectionStart || 0
+                );
+                event.target.setSelectionRange(cursorPosition, cursorPosition);
+            });
+
+            // Pass only user input (without prefix) to parent `onChange`
+            if (onChange) {
+                const syntheticEvent = {
+                    ...event,
+                    target: { ...event.target, value: userInput },
+                };
+                onChange(
+                    syntheticEvent as React.ChangeEvent<HTMLTextAreaElement>
+                );
+            }
+        } else {
+            const transformedValue = transformValue
+                ? transformValue(newValue ?? "")
+                : newValue;
+
+            setStateValue(transformedValue);
+            event.target.value = transformedValue;
+            if (onChange) onChange(event);
+        }
     };
 
     // =============================================================================
@@ -113,6 +152,7 @@ const FormTextareaComponent = (
                 error={!!errorMessage}
                 onChange={handleChange}
                 ref={ref}
+                prefix={prefix}
                 {...otherProps}
             />
             {renderBottomLabels()}

--- a/src/form/form-textarea.tsx
+++ b/src/form/form-textarea.tsx
@@ -108,6 +108,7 @@ const FormTextareaComponent = (
                 onChange={handleChange}
                 ref={ref}
                 prefix={prefix}
+                transformValue={transformValue}
                 {...otherProps}
             />
             {renderBottomLabels()}

--- a/src/input-textarea/textarea.style.tsx
+++ b/src/input-textarea/textarea.style.tsx
@@ -20,24 +20,6 @@ export const Wrapper = styled.div`
     flex-direction: column;
 `;
 
-export const PrefixWrapper = styled.span`
-    position: relative;
-    width: 100%;
-    display: flex;
-    align-items: center;
-`;
-
-export const PrefixSpan = styled.span`
-    position: absolute;
-    left: 16px;
-    top: 13px;
-    ${TextStyleHelper.getTextStyle("Body", "regular")}
-    color: ${Color.Neutral[1]};
-    background: ${Color.Neutral[8]};
-    whitespace: nowrap;
-    pointer-events: none;
-`;
-
 export const Element = styled.textarea<StyleProps>`
     border: 1px solid ${Color.Neutral[5]};
     border-radius: 4px;

--- a/src/input-textarea/textarea.style.tsx
+++ b/src/input-textarea/textarea.style.tsx
@@ -20,6 +20,24 @@ export const Wrapper = styled.div`
     flex-direction: column;
 `;
 
+export const PrefixWrapper = styled.span`
+    position: relative;
+    width: 100%;
+    display: flex;
+    align-items: center;
+`;
+
+export const PrefixSpan = styled.span`
+    position: absolute;
+    left: 16px;
+    top: 13px;
+    ${TextStyleHelper.getTextStyle("Body", "regular")}
+    color: ${Color.Neutral[1]};
+    background: ${Color.Neutral[8]};
+    whitespace: nowrap;
+    pointer-events: none;
+`;
+
 export const Element = styled.textarea<StyleProps>`
     border: 1px solid ${Color.Neutral[5]};
     border-radius: 4px;

--- a/src/input-textarea/textarea.tsx
+++ b/src/input-textarea/textarea.tsx
@@ -86,7 +86,7 @@ const TextareaBaseComponent = (
     const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
         if (!prefix) return;
 
-        const { selectionStart, selectionEnd } = event.currentTarget;
+        const { selectionStart } = event.currentTarget;
 
         // Prevent backspace in prefix
         if (event.key === "Backspace" && selectionStart <= prefix.length) {

--- a/src/input-textarea/textarea.tsx
+++ b/src/input-textarea/textarea.tsx
@@ -72,7 +72,7 @@ const TextareaBaseComponent = (
             // Adjust cursor position correctly
             requestAnimationFrame(() => {
                 let newCursorPosition = Math.max(
-                    selectionStart - (userInput.length === 0 ? 1 : 0),
+                    selectionStart - (transformedValue.length === 0 ? 1 : 0),
                     prefix.length
                 );
                 event.target.setSelectionRange(
@@ -103,7 +103,7 @@ const TextareaBaseComponent = (
     };
 
     const displayValue = () => {
-        return prefix + (stateValue ?? ""); // Ensures no "undefined"
+        return prefix ? prefix + (stateValue ?? "") : stateValue;
     };
 
     const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -139,7 +139,7 @@ const TextareaBaseComponent = (
         <Element
             ref={ref}
             disabled={disabled}
-            value={prefix ? displayValue() : stateValue}
+            value={displayValue()}
             onChange={handleChange}
             onKeyDown={handleKeyDown}
             error={error}

--- a/src/input-textarea/textarea.tsx
+++ b/src/input-textarea/textarea.tsx
@@ -15,6 +15,7 @@ const TextareaBaseComponent = (
         prefix,
         transformValue,
         onChange,
+        maxLength,
         ...otherProps
     }: TextareaProps,
     ref: TextareaRef
@@ -144,6 +145,7 @@ const TextareaBaseComponent = (
             onKeyDown={handleKeyDown}
             error={error}
             rows={rows}
+            maxLength={prefix ? prefix.length + maxLength : maxLength}
             {...otherProps}
         />
     );

--- a/src/input-textarea/textarea.tsx
+++ b/src/input-textarea/textarea.tsx
@@ -191,6 +191,7 @@ const TextareaComponent = (
     const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
         const newValue = event.target.value;
         setStateValue(newValue);
+        if (onChange) onChange(event);
     };
 
     // -------------------------------------------------------------------------

--- a/src/input-textarea/textarea.tsx
+++ b/src/input-textarea/textarea.tsx
@@ -27,30 +27,38 @@ const TextareaBaseComponent = (
 
     const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
         let newValue = event.target.value;
-
         if (prefix) {
-            // Ensure the prefix is always at the beginning
+            // Ensure prefix is always present
             if (!newValue.startsWith(prefix)) {
                 newValue = prefix + newValue.trimStart();
             }
 
-            // Prevent user from deleting the prefix
+            // Prevent deleting the prefix
             if (newValue.length < prefix.length) {
                 newValue = prefix;
+            }
+
+            const cursorPosition = event.target.selectionStart || 0;
+
+            // Ensure backspace does not delete the prefix
+            if (cursorPosition < prefix.length) {
+                event.preventDefault();
+                return;
             }
 
             // Extract user input
             const userInput = newValue.slice(prefix.length);
 
+            // Transform the input if needed
             const transformedValue = transformValue
-                ? transformValue(userInput ?? "")
+                ? transformValue(userInput)
                 : userInput;
 
+            // Update state and input field
             setStateValue(transformedValue);
+            event.target.value = prefix + transformedValue;
 
-            event.target.value = prefix + transformedValue; // Update displayed value
-
-            // Pass only user input (without prefix) to parent `onChange`
+            // Pass only the user input (without prefix) to `onChange`
             if (onChange) {
                 const syntheticEvent = {
                     ...event,

--- a/src/input-textarea/textarea.tsx
+++ b/src/input-textarea/textarea.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { TextareaCounter } from "./textarea-counter";
-import { Element, Wrapper } from "./textarea.style";
+import { Element, PrefixSpan, PrefixWrapper, Wrapper } from "./textarea.style";
 import { TextareaProps, TextareaRef } from "./types";
 
 // =============================================================================
@@ -20,91 +20,71 @@ const TextareaBaseComponent = (
     ref: TextareaRef
 ) => {
     const [stateValue, setStateValue] = useState(value);
+    const [prefixWidth, setPrefixWidth] = useState(0);
+    const prefixRef = useRef<HTMLSpanElement>(null);
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+    // Update prefix width on mount and when prefix changes
     useEffect(() => {
-        setStateValue(value);
-    }, [value]);
+        if (prefix && prefixRef.current) {
+            const { width } = prefixRef.current.getBoundingClientRect();
+            setPrefixWidth(width);
+        }
+    }, [prefix]);
 
     const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-        let newValue = event.target.value;
+        const newValue = event.target.value;
 
-        if (prefix) {
-            // Ensure the prefix is always at the beginning
-            if (!newValue.startsWith(prefix)) {
-                newValue = prefix + newValue.trimStart();
-            }
+        const transformedValue = transformValue
+            ? transformValue(newValue ?? "")
+            : newValue;
 
-            // Prevent user from deleting the prefix
-            if (newValue.length < prefix.length) {
-                newValue = prefix;
-            }
+        setStateValue(transformedValue);
+        event.target.value = transformedValue;
+        if (onChange) onChange(event);
+    };
 
-            // Extract user input (ensuring it's never undefined)
-            const userInput = newValue.slice(prefix.length) || ""; // Ensure empty string, not undefined
-
-            setStateValue(userInput);
-            event.target.value = prefix + userInput; // Update displayed value
-
-            // Ensure cursor stays in correct position
-            requestAnimationFrame(() => {
-                const cursorPosition = Math.max(
-                    prefix.length,
-                    event.target.selectionStart || 0
-                );
-                event.target.setSelectionRange(cursorPosition, cursorPosition);
-            });
-
-            // Pass only user input (without prefix) to parent `onChange`
-            if (onChange) {
-                const syntheticEvent = {
-                    ...event,
-                    target: { ...event.target, value: userInput },
-                };
-                onChange(
-                    syntheticEvent as React.ChangeEvent<HTMLTextAreaElement>
-                );
-            }
-        } else {
-            const transformedValue = transformValue
-                ? transformValue(newValue ?? "")
-                : newValue;
-
-            setStateValue(transformedValue);
-            event.target.value = transformedValue;
-            if (onChange) onChange(event);
+    useEffect(() => {
+        // Apply textIndent dynamically after prefix width is set
+        if (prefix && textareaRef.current) {
+            textareaRef.current.style.textIndent = `${prefixWidth}px`;
         }
-    };
-
-    const displayValue = () => {
-        return prefix + (stateValue ?? ""); // Ensures no "undefined"
-    };
-
-    const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-        // Prevent backspace when cursor is at the start (right after prefix)
-        if (prefix && event.key === "Backspace") {
-            const { selectionStart, selectionEnd } = event.currentTarget;
-
-            // If the cursor is at the start of the user input (right after prefix), prevent backspace
-            if (
-                selectionStart === selectionEnd &&
-                selectionStart <= prefix.length
-            ) {
-                event.preventDefault();
-            }
-        }
-    };
+    }, [prefixWidth]);
 
     return (
-        <Element
-            ref={ref}
-            disabled={disabled}
-            value={prefix ? displayValue() : stateValue}
-            onChange={handleChange}
-            onKeyDown={handleKeyDown} // Add this to prevent prefix deletion
-            error={error}
-            rows={rows}
-            {...otherProps}
-        />
+        <>
+            {prefix ? (
+                <PrefixWrapper>
+                    {prefix && (
+                        <PrefixSpan ref={prefixRef}>{prefix}</PrefixSpan>
+                    )}
+
+                    {/* Textarea (Uses textIndent) */}
+                    <Element
+                        ref={ref}
+                        disabled={disabled}
+                        value={stateValue}
+                        onChange={handleChange}
+                        error={error}
+                        rows={rows}
+                        style={{
+                            textIndent: `${prefixWidth}px`,
+                        }}
+                        {...otherProps}
+                    ></Element>
+                </PrefixWrapper>
+            ) : (
+                <Element
+                    ref={ref}
+                    disabled={disabled}
+                    value={stateValue}
+                    onChange={handleChange}
+                    error={error}
+                    rows={rows}
+                    {...otherProps}
+                ></Element>
+            )}
+        </>
     );
 };
 
@@ -116,7 +96,7 @@ export const TextareaBase = React.forwardRef(TextareaBaseComponent);
 
 const TextareaComponent = (
     {
-        value = "", // Ensure value is never undefined
+        value,
         disabled,
         rows = 5,
         onChange,
@@ -163,6 +143,7 @@ const TextareaComponent = (
                 onChange={handleChange}
                 prefix={prefix}
                 transformValue={transformValue}
+                maxLength={maxLength}
                 {...otherProps}
             />
             {maxLength && (

--- a/src/input-textarea/types.ts
+++ b/src/input-textarea/types.ts
@@ -5,6 +5,7 @@ export interface TextareaProps
     error?: boolean | undefined;
     "data-testid"?: string | undefined;
     transformValue?: ((value: string) => string) | undefined;
+    prefix?: string | undefined;
     renderCustomCounter?:
         | ((maxLength: number, currentValueLength: number) => JSX.Element)
         | undefined;

--- a/stories/form/form-textarea/form-textarea.mdx
+++ b/stories/form/form-textarea/form-textarea.mdx
@@ -38,6 +38,12 @@ You can specify the `transformValue` prop to format or sanitise input.
 
 <Canvas of={FormTextareaStories.TransformValue} />
 
+<Heading3>Prefix</Heading3>
+
+You can specify the prefix prop to add a prefix to the input.
+
+<Canvas of={FormTextareaStories.Prefix} />
+
 <Heading3>Rendering in grid layouts</Heading3>
 
 You can also specify [ColDiv's](/docs/getting-started-layout-column-divs--docs)

--- a/stories/form/form-textarea/form-textarea.mdx
+++ b/stories/form/form-textarea/form-textarea.mdx
@@ -40,7 +40,8 @@ You can specify the `transformValue` prop to format or sanitise input.
 
 <Heading3>Prefix</Heading3>
 
-You can specify the prefix prop to add a prefix to the input.
+You can specify the `prefix` prop to let the textarea begin with a fixed line of
+text. The prefix is not editable and does not count towards the character limit.
 
 <Canvas of={FormTextareaStories.Prefix} />
 

--- a/stories/form/form-textarea/form-textarea.stories.tsx
+++ b/stories/form/form-textarea/form-textarea.stories.tsx
@@ -79,10 +79,14 @@ export const Prefix: StoryObj<Component> = {
             <StoryContainer>
                 <Container>
                     <Form.Textarea
-                        label="This textarea has a prefix"
+                        label="This form textarea has a prefix"
                         maxLength={100}
                         prefix="ABC "
                     />
+                </Container>
+                <Container>
+                    <Form.Label>This textarea has a prefix</Form.Label>
+                    <Textarea maxLength={100} prefix="ABC " />
                 </Container>
             </StoryContainer>
         );

--- a/stories/form/form-textarea/form-textarea.stories.tsx
+++ b/stories/form/form-textarea/form-textarea.stories.tsx
@@ -81,12 +81,12 @@ export const Prefix: StoryObj<Component> = {
                     <Form.Textarea
                         label="This form textarea has a prefix"
                         maxLength={100}
-                        prefix="ABC "
+                        prefix={"ABC" + "\u00A0"}
                     />
                 </Container>
                 <Container>
                     <Form.Label>This textarea has a prefix</Form.Label>
-                    <Textarea maxLength={100} prefix="ABC " />
+                    <Textarea maxLength={100} prefix={"ABC" + "\u00A0"} />
                 </Container>
             </StoryContainer>
         );

--- a/stories/form/form-textarea/form-textarea.stories.tsx
+++ b/stories/form/form-textarea/form-textarea.stories.tsx
@@ -79,14 +79,10 @@ export const Prefix: StoryObj<Component> = {
             <StoryContainer>
                 <Container>
                     <Form.Textarea
-                        label="This form textarea has a prefix"
+                        label="This has a prefix"
+                        prefix="It is a truth universally acknowledged, "
                         maxLength={100}
-                        prefix="ABC "
                     />
-                </Container>
-                <Container>
-                    <Form.Label>This textarea has a prefix</Form.Label>
-                    <Textarea maxLength={100} prefix="ABC " />
                 </Container>
             </StoryContainer>
         );

--- a/stories/form/form-textarea/form-textarea.stories.tsx
+++ b/stories/form/form-textarea/form-textarea.stories.tsx
@@ -81,12 +81,12 @@ export const Prefix: StoryObj<Component> = {
                     <Form.Textarea
                         label="This form textarea has a prefix"
                         maxLength={100}
-                        prefix={"ABC" + "\u00A0"}
+                        prefix="ABC "
                     />
                 </Container>
                 <Container>
                     <Form.Label>This textarea has a prefix</Form.Label>
-                    <Textarea maxLength={100} prefix={"ABC" + "\u00A0"} />
+                    <Textarea maxLength={100} prefix="ABC " />
                 </Container>
             </StoryContainer>
         );

--- a/stories/form/form-textarea/form-textarea.stories.tsx
+++ b/stories/form/form-textarea/form-textarea.stories.tsx
@@ -73,6 +73,22 @@ export const TransformValue: StoryObj<Component> = {
     },
 };
 
+export const Prefix: StoryObj<Component> = {
+    render: () => {
+        return (
+            <StoryContainer>
+                <Container>
+                    <Form.Textarea
+                        label="This textarea has a prefix"
+                        maxLength={100}
+                        prefix="ABC "
+                    />
+                </Container>
+            </StoryContainer>
+        );
+    },
+};
+
 export const WithCustomCounter: StoryObj<Component> = {
     render: () => {
         return (

--- a/stories/form/form-textarea/props-table.tsx
+++ b/stories/form/form-textarea/props-table.tsx
@@ -50,6 +50,11 @@ const DATA: ApiTableSectionProps[] = [
                 description: "Function to transform value",
                 propTypes: ["(value: string) => string"],
             },
+            {
+                name: "prefix",
+                description: "The prefix to be displayed",
+                propTypes: ["string"],
+            },
         ],
     },
     ...SHARED_FORM_PROPS_DATA,


### PR DESCRIPTION
**Changes**

- Added support for a `prefix` prop for `textarea`
  - Ensures a predefined prefix is always present in the input field.
  - Prevents users from modifying or deleting the prefix.

- [delete] branch

**Additional information**

- You may refer to this [[ticket](https://sgtechstack.atlassian.net/browse/MOL-17553)]
