### PR TITLE
Add prop fullWidthBottomBorder to Tab

### DIFF
--- a/src/tab/tab-link-chain.style.tsx
+++ b/src/tab/tab-link-chain.style.tsx
@@ -12,19 +12,37 @@ interface LabelStyleProps {
 }
 
 interface ChainStyleProps {
+    $fullWidthIndicatorLine?: boolean;
+}
+
+interface ChainItemStyleProps {
     $active?: boolean;
 }
 
 // =============================================================================
 // STYLING
 // =============================================================================
-export const Chain = styled.ul`
+export const Chain = styled.ul<ChainStyleProps>`
     display: inline-flex;
     width: 100%;
     list-style-type: none;
+
+    ${(props) => {
+        if (props.$fullWidthIndicatorLine) {
+            return css`
+                ::after {
+                    content: "";
+                    height: inherit;
+                    flex-grow: 1;
+                    /* follows the border in ChainItem */
+                    border-bottom: 4px solid ${Color.Neutral[5]};
+                }
+            `;
+        }
+    }}
 `;
 
-export const ChainItem = styled.li<ChainStyleProps>`
+export const ChainItem = styled.li<ChainItemStyleProps>`
     display: flex;
     flex-shrink: 0;
     border-bottom: 4px solid ${Color.Neutral[5]};

--- a/src/tab/tab-link-chain.tsx
+++ b/src/tab/tab-link-chain.tsx
@@ -16,12 +16,14 @@ interface Props {
     controlledMode?: boolean | undefined;
     "data-testid"?: string | undefined;
     onTabClick?: ((title: string, order: number) => void) | undefined;
+    fullWidthIndicatorLine?: boolean | undefined;
 }
 
 export const TabLinkChain = ({
     controlledMode,
     "data-testid": testId,
     onTabClick,
+    fullWidthIndicatorLine,
 }: Props) => {
     // =========================================================================
     // CONST, STATE, REFS
@@ -77,7 +79,10 @@ export const TabLinkChain = ({
     // =========================================================================
     return (
         <CustomFadeWrapper onResize={handleResize} data-testid={testId}>
-            <Chain role="tablist">
+            <Chain
+                role="tablist"
+                $fullWidthIndicatorLine={fullWidthIndicatorLine}
+            >
                 {tabLinks.map((linkChain, index) => {
                     const isActive = currentActiveIndex === index;
 

--- a/src/tab/tab.tsx
+++ b/src/tab/tab.tsx
@@ -20,6 +20,7 @@ const TabBase = ({
     initialActive = 0,
     onTabClick,
     "data-testid": testId,
+    fullWidthIndicatorLine,
     ...otherProps
 }: TabProps) => {
     // =========================================================================
@@ -84,6 +85,7 @@ const TabBase = ({
                     controlledMode={typeof currentActiveIndex === "number"}
                     onTabClick={onTabClick}
                     data-testid={`${testId}-tabs`}
+                    fullWidthIndicatorLine={fullWidthIndicatorLine}
                 />
                 {renderChildren()}
             </TabContext.Provider>

--- a/src/tab/types.ts
+++ b/src/tab/types.ts
@@ -11,6 +11,7 @@ export interface TabProps {
     id?: string | undefined;
     "data-testid"?: string | undefined;
     onTabClick?: ((title: string, index: number) => void) | undefined;
+    fullWidthIndicatorLine?: boolean | undefined;
 }
 
 export interface TabItemProps {

--- a/stories/tab/props-table.tsx
+++ b/stories/tab/props-table.tsx
@@ -46,6 +46,12 @@ const TAB_DATA: ApiTableSectionProps[] = [
                 description: "Called when a tab item selector is clicked",
                 propTypes: ["(title: string, index: number) => void"],
             },
+            {
+                name: "fullWidthIndicatorLine",
+                description:
+                    "Extends the bottom border to the full width of the container",
+                propTypes: ["boolean"],
+            },
         ],
     },
 ];

--- a/stories/tab/tab.mdx
+++ b/stories/tab/tab.mdx
@@ -43,6 +43,12 @@ state on our own.
 
 <Canvas of={TabStories.ControlledMode} />
 
+<Secondary>Full width bottom border</Secondary>
+
+If you want the bottom border to extend to the full container, use the `fullWidthIndicatorLine` prop
+
+<Canvas of={TabStories.FullWidthIndicatorLine} />
+
 <Secondary>Component API</Secondary>
 
 <PropsTable />

--- a/stories/tab/tab.stories.tsx
+++ b/stories/tab/tab.stories.tsx
@@ -182,3 +182,52 @@ export const ControlledMode: StoryObj<Component> = {
         );
     },
 };
+
+export const FullWidthIndicatorLine: StoryObj<Component> = {
+    render: () => {
+        return (
+            <Tab fullWidthIndicatorLine>
+                <Tab.Item title="Section A">
+                    <Content>
+                        <Text.H1>Section A</Text.H1>
+                        <br />
+                        <Text.Body>
+                            Lorem ipsum dolor sit amet, consectetur adipiscing
+                            elit. Nullam commodo eget turpis sit amet luctus.
+                            Duis fringilla, libero ac eleifend vehicula, sem
+                            arcu mattis diam, eget pellentesque urna libero
+                            feugiat sem.
+                        </Text.Body>
+                    </Content>
+                </Tab.Item>
+                <Tab.Item title="Section B">
+                    <Content>
+                        <Text.H1>Section B</Text.H1>
+                        <br />
+                        <Text.Body>
+                            Donec metus augue, vulputate ut laoreet pretium,
+                            cursus sed odio. Aenean imperdiet sapien nec lectus
+                            gravida, vitae tincidunt sem feugiat. Nullam sit
+                            amet tortor purus. Sed eget nulla sapien. Proin a
+                            lacus pellentesque, facilisis augue quis, vestibulum
+                            sem.
+                        </Text.Body>
+                    </Content>
+                </Tab.Item>
+                <Tab.Item title="Section C">
+                    <Content>
+                        <Text.H1>Section C</Text.H1>
+                        <br />
+                        <Text.Body>
+                            Maecenas tempor dolor sit amet turpis interdum
+                            convallis. Nunc ut elit vitae justo placerat
+                            vulputate. Mauris varius sem in lectus vestibulum,
+                            sed porttitor nisi ultricies. Morbi quis commodo
+                            ipsum.
+                        </Text.Body>
+                    </Content>
+                </Tab.Item>
+            </Tab>
+        );
+    },
+};


### PR DESCRIPTION
**Changes**
Add prop `fullWidthBottomBorder` to `Tab`, which extends the bottom border to the full width of `Tab`

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Add prop `fullWidthBottomBorder` to `Tab`
