### PR TITLE
[BOOKINGSG-7064][MW] add loading state to button-with-icon

### DIFF
--- a/src/button-with-icon/button-with-icon.tsx
+++ b/src/button-with-icon/button-with-icon.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Spinner } from "../button/button.style";
 import {
     MainButtonWithIcon,
     MainStylePropsWithIcon,
@@ -22,6 +23,7 @@ const DefaultComponent = (
         danger = false,
         icon,
         iconPosition = "left",
+        loading = false,
         ...otherProps
     } = props;
 
@@ -40,7 +42,7 @@ const DefaultComponent = (
             {...mainStyle}
             {...otherProps}
         >
-            {icon}
+            {loading ? <Spinner {...mainStyle} size={16} /> : icon}
             <span>{children}</span>
         </MainButtonWithIcon>
     );
@@ -54,6 +56,7 @@ const SmallComponent = (props: ButtonWithIconProps, ref: ButtonWithIconRef) => {
         danger = false,
         icon,
         iconPosition = "left",
+        loading = false,
         ...otherProps
     } = props;
 
@@ -72,7 +75,7 @@ const SmallComponent = (props: ButtonWithIconProps, ref: ButtonWithIconRef) => {
             {...mainStyle}
             {...otherProps}
         >
-            {icon}
+            {loading ? <Spinner {...mainStyle} size={16} /> : icon}
             <span>{children}</span>
         </MainButtonWithIcon>
     );

--- a/src/button-with-icon/button-with-icon.tsx
+++ b/src/button-with-icon/button-with-icon.tsx
@@ -32,6 +32,7 @@ const DefaultComponent = (
         $buttonStyle: disabled ? "disabled" : styleType,
         $buttonSizeStyle: "default",
         $buttonIsDanger: danger,
+        $buttonWithIcon: true,
     };
 
     return (
@@ -42,7 +43,7 @@ const DefaultComponent = (
             {...mainStyle}
             {...otherProps}
         >
-            {loading ? <Spinner {...mainStyle} size={16} /> : icon}
+            {loading ? <Spinner {...mainStyle} /> : icon}
             <span>{children}</span>
         </MainButtonWithIcon>
     );
@@ -65,6 +66,7 @@ const SmallComponent = (props: ButtonWithIconProps, ref: ButtonWithIconRef) => {
         $buttonStyle: disabled ? "disabled" : styleType,
         $buttonSizeStyle: "small",
         $buttonIsDanger: danger,
+        $buttonWithIcon: true,
     };
 
     return (

--- a/src/button-with-icon/types.ts
+++ b/src/button-with-icon/types.ts
@@ -1,6 +1,6 @@
-import { ButtonBaseProps, ButtonRef } from "../button/types";
+import { ButtonProps, ButtonRef } from "../button/types";
 
-export interface ButtonWithIconProps extends ButtonBaseProps {
+export interface ButtonWithIconProps extends ButtonProps {
     /** The icon to be rendered in the button */
     icon: JSX.Element;
     /** Specifies where the icon will be positioned */

--- a/src/button/button.style.tsx
+++ b/src/button/button.style.tsx
@@ -1,10 +1,10 @@
 import styled, { css } from "styled-components";
 import { Color } from "../color/color";
+import { DesignToken } from "../design-token";
 import { MediaQuery } from "../media/media";
 import { ComponentLoadingSpinner } from "../shared/component-loading-spinner/component-loading-spinner";
 import { TextStyleHelper } from "../text";
 import { MainStyleProps } from "./types";
-import { DesignToken } from "../design-token";
 
 export const Main = styled.button<MainStyleProps>`
     padding: 0.5rem 1rem;
@@ -125,7 +125,6 @@ export const Main = styled.button<MainStyleProps>`
 `;
 
 export const Spinner = styled(ComponentLoadingSpinner)<MainStyleProps>`
-    margin-right: 0.5rem;
     ${(props) => {
         let color = props.$buttonIsDanger
             ? DesignToken.Button.Danger.Primary
@@ -144,6 +143,8 @@ export const Spinner = styled(ComponentLoadingSpinner)<MainStyleProps>`
         }
 
         return css`
+            margin-right: ${props.$buttonWithIcon ? 0 : "0.5rem"};
+
             #inner1,
             #inner2,
             #inner3,

--- a/src/button/types.ts
+++ b/src/button/types.ts
@@ -29,4 +29,5 @@ export interface MainStyleProps extends ComponentLoadingSpinnerProps {
     $buttonStyle: MainButtonStyle;
     $buttonSizeStyle?: MainButtonSize | undefined;
     $buttonIsDanger?: boolean;
+    $buttonWithIcon?: boolean;
 }

--- a/src/shared/component-loading-spinner/component-loading-spinner.tsx
+++ b/src/shared/component-loading-spinner/component-loading-spinner.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
     InnerRing1,
     InnerRing2,
@@ -26,7 +25,12 @@ export const ComponentLoadingSpinner = ({
     const borderWidth = 2;
 
     return (
-        <OuterRing className={className} $size={size} $color={color}>
+        <OuterRing
+            className={className}
+            $size={size}
+            $color={color}
+            data-testid={"component-loading-spinner"}
+        >
             <InnerRing1
                 id="inner1"
                 $size={size - borderWidth}

--- a/stories/button-with-icon/button-with-icon.mdx
+++ b/stories/button-with-icon/button-with-icon.mdx
@@ -32,6 +32,10 @@ apply a red scheme over the buttons.
 
 <Canvas of={ButtonWithIconStories.Danger} />
 
+<Heading3>Loading</Heading3>
+
+<Canvas of={ButtonWithIconStories.LoadingState} />
+
 <Secondary>Component API</Secondary>
 
 <PropsTable />

--- a/stories/button-with-icon/button-with-icon.stories.tsx
+++ b/stories/button-with-icon/button-with-icon.stories.tsx
@@ -117,8 +117,6 @@ export const RightPositioned: StoryObj<Component> = {
                     <ButtonWithIcon.Small
                         icon={<PlaceholderIcon />}
                         iconPosition="right"
-                        loading={true}
-                        disabled={true}
                     >
                         Small
                     </ButtonWithIcon.Small>

--- a/stories/button-with-icon/button-with-icon.stories.tsx
+++ b/stories/button-with-icon/button-with-icon.stories.tsx
@@ -1,7 +1,7 @@
+import { PlaceholderIcon } from "@lifesg/react-icons/placeholder";
 import type { Meta, StoryObj } from "@storybook/react";
 import { ButtonWithIcon } from "../../src/button-with-icon";
 import { Container } from "../button/doc-elements";
-import { PlaceholderIcon } from "@lifesg/react-icons/placeholder";
 
 type Component = typeof ButtonWithIcon.Default;
 
@@ -117,6 +117,8 @@ export const RightPositioned: StoryObj<Component> = {
                     <ButtonWithIcon.Small
                         icon={<PlaceholderIcon />}
                         iconPosition="right"
+                        loading={true}
+                        disabled={true}
                     >
                         Small
                     </ButtonWithIcon.Small>
@@ -208,6 +210,81 @@ export const Danger: StoryObj<Component> = {
                         danger
                     >
                         Link
+                    </ButtonWithIcon.Small>
+                </Container>
+            </>
+        );
+    },
+};
+
+export const LoadingState: StoryObj<Component> = {
+    render: () => {
+        return (
+            <>
+                <Container>
+                    <ButtonWithIcon.Default icon={<PlaceholderIcon />} loading>
+                        Loading
+                    </ButtonWithIcon.Default>
+                    <ButtonWithIcon.Default
+                        icon={<PlaceholderIcon />}
+                        styleType="secondary"
+                        loading
+                    >
+                        Loading
+                    </ButtonWithIcon.Default>
+                    <ButtonWithIcon.Default
+                        icon={<PlaceholderIcon />}
+                        styleType="light"
+                        loading
+                    >
+                        Loading
+                    </ButtonWithIcon.Default>
+                    <ButtonWithIcon.Default
+                        icon={<PlaceholderIcon />}
+                        styleType="link"
+                        loading
+                    >
+                        Loading
+                    </ButtonWithIcon.Default>
+                    <ButtonWithIcon.Default
+                        icon={<PlaceholderIcon />}
+                        disabled
+                        loading
+                    >
+                        Loading
+                    </ButtonWithIcon.Default>
+                </Container>
+                <Container>
+                    <ButtonWithIcon.Small icon={<PlaceholderIcon />} loading>
+                        Small
+                    </ButtonWithIcon.Small>
+                    <ButtonWithIcon.Small
+                        icon={<PlaceholderIcon />}
+                        styleType="secondary"
+                        loading
+                    >
+                        Loading
+                    </ButtonWithIcon.Small>
+                    <ButtonWithIcon.Small
+                        icon={<PlaceholderIcon />}
+                        styleType="light"
+                        loading
+                    >
+                        Loading
+                    </ButtonWithIcon.Small>
+                    <ButtonWithIcon.Small
+                        icon={<PlaceholderIcon />}
+                        styleType="link"
+                        loading
+                    >
+                        Loading
+                    </ButtonWithIcon.Small>
+                    <ButtonWithIcon.Small
+                        icon={<PlaceholderIcon />}
+                        disabled
+                        loading
+                    >
+                        Loading
                     </ButtonWithIcon.Small>
                 </Container>
             </>

--- a/stories/button-with-icon/props-table.tsx
+++ b/stories/button-with-icon/props-table.tsx
@@ -49,6 +49,12 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["boolean"],
                 defaultValue: "false",
             },
+            {
+                name: "loading",
+                description: "The icon will become a loading spinner",
+                propTypes: ["boolean"],
+                defaultValue: "false",
+            },
         ],
     },
 ];

--- a/tests/button-with-icon/button-with-icon.spec.tsx
+++ b/tests/button-with-icon/button-with-icon.spec.tsx
@@ -1,5 +1,5 @@
 import { PlaceholderIcon } from "@lifesg/react-icons/placeholder";
-import { fireEvent, getByText, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { ButtonWithIcon } from "../../src/button-with-icon";
 
 // =============================================================================
@@ -53,6 +53,46 @@ describe("ButtonWithIcon", () => {
         fireEvent.click(button);
 
         expect(onClickMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("should render the loading spinner - Default", () => {
+        render(
+            <ButtonWithIcon.Default
+                icon={<PlaceholderIcon />}
+                iconPosition="left"
+                data-testid="test-button"
+                loading
+            >
+                {BUTTON_TEXT}
+            </ButtonWithIcon.Default>
+        );
+
+        const button = screen.getByTestId("test-button");
+        const icon = button.querySelector("svg");
+        const spinner = screen.getByTestId("component-loading-spinner");
+
+        expect(icon).not.toBeInTheDocument();
+        expect(spinner).toBeInTheDocument();
+    });
+
+    it("should render the loading spinner - Small", () => {
+        render(
+            <ButtonWithIcon.Small
+                icon={<PlaceholderIcon />}
+                iconPosition="left"
+                data-testid="test-button"
+                loading
+            >
+                {BUTTON_TEXT}
+            </ButtonWithIcon.Small>
+        );
+
+        const button = screen.getByTestId("test-button");
+        const icon = button.querySelector("svg");
+        const spinner = screen.getByTestId("component-loading-spinner");
+
+        expect(icon).not.toBeInTheDocument();
+        expect(spinner).toBeInTheDocument();
     });
 });
 


### PR DESCRIPTION
**Changes**
Added loading state to `ButtonWithIcon`. On loading state, the icon will become a loading spinner.
Ticket: [BOOKINGSG-7064](https://sgtechstack.atlassian.net/browse/BOOKINGSG-7064)

<img width="1352" alt="image" src="https://github.com/user-attachments/assets/f9afc4b6-caa0-4582-a243-f6da53ac59d1" />


- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Added loading state to `ButtonWithIcon`

**Additional information**

- Enhancement required by [BOOKINGSG-6798](https://sgtechstack.atlassian.net/browse/BOOKINGSG-6798)
