### PR TITLE
Add codemod for `V2_TextStyleHelper.getTextStyle()`

### DIFF
--- a/codemods/codemod-utils.ts
+++ b/codemods/codemod-utils.ts
@@ -1,0 +1,141 @@
+import { API, Collection, JSCodeshift } from "jscodeshift";
+
+export namespace CodemodUtils {
+    export function hasImport(
+        source: Collection,
+        api: API,
+        importPath: string | string[],
+        importSpecifier: string
+    ) {
+        const j: JSCodeshift = api.jscodeshift;
+
+        let imported = false;
+        source.find(j.ImportDeclaration).forEach((path) => {
+            const currentImportPath = path.node.source.value as string;
+
+            if (Array.isArray(importPath)) {
+                if (!importPath.includes(currentImportPath)) {
+                    return;
+                }
+            } else {
+                if (currentImportPath !== importPath) {
+                    return;
+                }
+            }
+
+            path.node.specifiers?.forEach((specifier) => {
+                if (
+                    j.ImportSpecifier.check(specifier) &&
+                    specifier.imported.name === importSpecifier
+                ) {
+                    imported = true;
+                }
+            });
+        });
+
+        return imported;
+    }
+
+    export function addImport(
+        source: Collection,
+        api: API,
+        importPath: string,
+        importSpecifier: string
+    ) {
+        const j: JSCodeshift = api.jscodeshift;
+
+        const hasExistingImport =
+            source.find(j.ImportDeclaration, {
+                source: { value: importPath },
+            }).length > 0;
+
+        if (hasExistingImport) {
+            // Append the import
+            source.find(j.ImportDeclaration).forEach((path) => {
+                const currentImportPath = path.node.source.value;
+
+                if (currentImportPath === importPath) {
+                    const hasSpecifier =
+                        j(path).find(j.ImportSpecifier, {
+                            imported: { name: importSpecifier },
+                        }).length > 0;
+
+                    if (!hasSpecifier) {
+                        // Add to existing import
+                        path.node.specifiers?.push(
+                            j.importSpecifier(j.identifier(importSpecifier))
+                        );
+                    }
+                }
+            });
+        } else {
+            // Add the import
+            const newImportDeclaration = j.importDeclaration(
+                [j.importSpecifier(j.identifier(importSpecifier))],
+                j.literal(importPath)
+            );
+
+            source.get().node.program.body.unshift(newImportDeclaration);
+        }
+    }
+
+    export function removeImport(
+        source: Collection,
+        api: API,
+        importPath: string | string[],
+        importSpecifier: string
+    ) {
+        const j: JSCodeshift = api.jscodeshift;
+
+        source.find(j.ImportDeclaration).forEach((path) => {
+            const currentImportPath = path.node.source.value as string;
+
+            if (Array.isArray(importPath)) {
+                if (!importPath.includes(currentImportPath)) {
+                    return;
+                }
+            } else {
+                if (currentImportPath !== importPath) {
+                    return;
+                }
+            }
+
+            const specifiers = j(path).find(j.ImportSpecifier, {
+                imported: { name: importSpecifier },
+            });
+
+            if (specifiers.length) {
+                specifiers.remove();
+
+                // Remove entire import if no longer used
+                const unused = j(path).find(j.ImportSpecifier).length === 0;
+                if (unused) {
+                    j(path).remove();
+                }
+            }
+        });
+    }
+
+    export function hasReferences(
+        source: Collection,
+        api: API,
+        importPath: string | string[],
+        importSpecifier: string
+    ) {
+        const j: JSCodeshift = api.jscodeshift;
+
+        const imported = hasImport(source, api, importPath, importSpecifier);
+        if (imported) {
+            return (
+                source
+                    .find(j.Identifier, { name: importSpecifier })
+                    .filter((id) => {
+                        // found in the import statement, does not count as usage
+                        return !j(id).closest(j.ImportDeclaration).length;
+                    }).length > 0
+            );
+        }
+
+        return false;
+    }
+}

--- a/codemods/migrate-text/data.ts
+++ b/codemods/migrate-text/data.ts
@@ -16,3 +16,33 @@ export const textComponentMap = {
     "Hyperlink.Default": "LinkBL",
     "Hyperlink.Small": "LinkSM",
 };
+
+export const textStyleFontMap = {
+    D1: "heading-xxl",
+    D2: "heading-xl",
+    D3: "heading-md",
+    D4: "heading-sm",
+    H1: "heading-lg",
+    H2: "heading-md",
+    H3: "heading-sm",
+    H4: "heading-xs",
+    H5: "body-md",
+    H6: "body-sm",
+    DBody: "heading-sm",
+    Body: "body-baseline",
+    BodySmall: "body-md",
+    XSmall: "body-xs",
+};
+
+export const weightMap = {
+    regular: "regular",
+    semibold: "semibold",
+    bold: "bold",
+    light: "light",
+    black: "bold",
+    400: "regular",
+    600: "semibold",
+    700: "bold",
+    300: "light",
+    900: "bold",
+};

--- a/codemods/run-codemod.ts
+++ b/codemods/run-codemod.ts
@@ -31,7 +31,8 @@ const CodemodDescriptions: { [key in Codemod]: string } = {
     [Codemod.MigrateLayout]: "Replace V2_Layout with new Layout components",
     [Codemod.MigrateMediaQuery]:
         "Replace V2 media queries with new Breakpoint tokens",
-    [Codemod.MigrateText]: "Replace V2_Text with new Typography components",
+    [Codemod.MigrateText]:
+        "Replace V2_Text with new Typography components and V2_TextStyleHelper.getTextStyle() with Font",
     [Codemod.MigrateTextList]:
         "Replace V2_TextList with new Textlist components",
 };

--- a/tests/codemods/migrate-text/test-data.ts
+++ b/tests/codemods/migrate-text/test-data.ts
@@ -1,7 +1,6 @@
-export const inputCode = `
-
-
-import { V2_Text } from "@lifesg/react-design-system/v2_text";
+export const TypicalUsage = {
+    input: `
+import { V2_Text, V2_TextStyleHelper } from "@lifesg/react-design-system/v2_text";
 import { V2_Layout } from "@lifesg/react-design-system/v2_layout";
 
 const ExampleComponent = () => (
@@ -28,11 +27,14 @@ const ExampleComponent = () => (
 
 export default ExampleComponent;
 
-const Text = styled(V2_Text.Body)\`\`;
-`;
-
-export const expectedOutputCode = `
-
+const Text = styled(V2_Text.Body)\`
+    \${V2_TextStyleHelper.getTextStyle("D1", "semibold")}
+    \${V2_TextStyleHelper.getTextStyle("H1", 400)}
+    \${V2_TextStyleHelper.getTextStyle("BodySmall")}
+\`;
+`,
+    expectedOutput: `
+import { Font } from "@lifesg/react-design-system/theme";
 import { Typography } from "@lifesg/react-design-system/typography";
 import { V2_Layout } from "@lifesg/react-design-system/v2_layout";
 
@@ -60,5 +62,76 @@ const ExampleComponent = () => (
 
 export default ExampleComponent;
 
-const Text = styled(Typography.BodyBL)\`\`;
-`;
+const Text = styled(Typography.BodyBL)\`
+    \${Font["heading-xxl-semibold"]}
+    \${Font["heading-lg-regular"]}
+    \${Font["body-md-regular"]}
+\`;
+`,
+};
+
+export const RootImport = {
+    input: `
+import { V2_Text, V2_TextStyleHelper } from "@lifesg/react-design-system";
+
+const ExampleComponent = () => (
+    <V2_Text.Body weight="bold">This is body text</V2_Text.Body>
+);
+
+export default ExampleComponent;
+
+const Text = styled(V2_Text.Body)\`
+    \${V2_TextStyleHelper.getTextStyle("Body", "regular")}
+    \${V2_TextStyleHelper.getDisplayStyle()}
+\`;
+`,
+    expectedOutput: `
+import { Font } from "@lifesg/react-design-system/theme";
+import { Typography } from "@lifesg/react-design-system/typography";
+import { V2_TextStyleHelper } from "@lifesg/react-design-system";
+
+const ExampleComponent = () => (
+    <Typography.BodyBL weight="bold">This is body text</Typography.BodyBL>
+);
+
+export default ExampleComponent;
+
+const Text = styled(Typography.BodyBL)\`
+    \${Font["body-baseline-regular"]}
+    \${V2_TextStyleHelper.getDisplayStyle()}
+\`;
+`,
+};
+
+export const TextStyleHelperReferences = {
+    input: `
+import { V2_Text, V2_TextStyleHelper } from "@lifesg/react-design-system/v2_text";
+
+const ExampleComponent = () => (
+    <V2_Text.Body weight="bold">This is body text</V2_Text.Body>
+);
+
+export default ExampleComponent;
+
+const Text = styled(V2_Text.Body)\`
+    \${V2_TextStyleHelper.getTextStyle("Body", "regular")}
+    \${V2_TextStyleHelper.getDisplayStyle()}
+\`;
+`,
+    expectedOutput: `
+import { Font } from "@lifesg/react-design-system/theme";
+import { Typography } from "@lifesg/react-design-system/typography";
+import { V2_TextStyleHelper } from "@lifesg/react-design-system/v2_text";
+
+const ExampleComponent = () => (
+    <Typography.BodyBL weight="bold">This is body text</Typography.BodyBL>
+);
+
+export default ExampleComponent;
+
+const Text = styled(Typography.BodyBL)\`
+    \${Font["body-baseline-regular"]}
+    \${V2_TextStyleHelper.getDisplayStyle()}
+\`;
+`,
+};

--- a/tests/codemods/migrate-text/transformer.spec.tsx
+++ b/tests/codemods/migrate-text/transformer.spec.tsx
@@ -1,25 +1,30 @@
 import { execSync } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
-import { expectedOutputCode, inputCode } from "./test-data";
+import {
+    RootImport,
+    TextStyleHelperReferences,
+    TypicalUsage,
+} from "./test-data";
 
 describe("Codemod Transformer for V2_Text to Typography", () => {
     const inputPath = path.join(__dirname, "input.tsx");
     const outputPath = path.join(__dirname, "output.tsx");
 
-    beforeAll(() => {
-        // create sample input file for testing
-        jest.resetAllMocks();
-        fs.writeFileSync(inputPath, inputCode);
-    });
-
-    afterAll(() => {
+    afterEach(() => {
         // delete the files created for testing (comment this out to view files)
         fs.unlinkSync(inputPath);
         fs.unlinkSync(outputPath);
     });
 
-    it("should transform V2_Text components to Typography components", () => {
+    it.each`
+        scenario                                                         | inputCode                          | expectedOutputCode
+        ${"should transform to V3 modules correctly"}                    | ${TypicalUsage.input}              | ${TypicalUsage.expectedOutput}
+        ${"should transform imports from the library root correctly"}    | ${RootImport.input}                | ${RootImport.expectedOutput}
+        ${"should not transform remaining usages of V2_TextStyleHelper"} | ${TextStyleHelperReferences.input} | ${TextStyleHelperReferences.expectedOutput}
+    `("$scenario", ({ inputCode, expectedOutputCode }) => {
+        // create sample input file for testing
+        fs.writeFileSync(inputPath, inputCode);
         fs.copyFileSync(inputPath, outputPath);
 
         // Execute the jscodeshift command for the codemod


### PR DESCRIPTION
**Changes**

- enhanced `migrate-text` codemod to also transform `V2_TextStyleHelper.getTextStyle()` to font tokens. the remaining helpers still have to be manually migrated
- added utils for common jscodeshift actions, will refactor the remaining scripts in the future
- [delete] branch