### PR TITLE
Resolve React 18+ spread key warning in unit tests

### DIFF
--- a/src/shared/dropdown-list-v2/dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.tsx
@@ -471,6 +471,8 @@ export const DropdownList = <T, V>({
     };
 
     const renderVirtualisedList = () => {
+        const isTestEnv = process.env.NODE_ENV === "test";
+
         return (
             <Listbox role="listbox" id={listboxId}>
                 <Virtuoso
@@ -481,10 +483,12 @@ export const DropdownList = <T, V>({
                     itemContent={(index, item) => renderItem(item, index)}
                     // disable virtualisation in tests
                     // https://github.com/petyosi/react-virtuoso/issues/26#issuecomment-1040316576
-                    {...(process.env.NODE_ENV === "test"
+                    // explicitly set the `key` prop to avoid React warning
+                    key={isTestEnv ? displayListItems.length : undefined}
+                    // omit the `initialItemCount` prop to resolve NaN error
+                    {...(isTestEnv
                         ? {
                               initialItemCount: displayListItems.length,
-                              key: displayListItems.length,
                           }
                         : {})}
                 />

--- a/src/shared/dropdown-list-v2/nested-dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/nested-dropdown-list.tsx
@@ -582,6 +582,8 @@ export const NestedDropdownList = <T,>({
     };
 
     const renderVirtualisedList = () => {
+        const isTestEnv = process.env.NODE_ENV === "test";
+
         return (
             <div
                 aria-multiselectable={multiSelect}
@@ -596,10 +598,12 @@ export const NestedDropdownList = <T,>({
                     itemContent={(vIndex, item) => renderItem(item, vIndex)}
                     // disable virtualisation in tests
                     // https://github.com/petyosi/react-virtuoso/issues/26#issuecomment-1040316576
-                    {...(process.env.NODE_ENV === "test"
+                    // explicitly set the `key` prop to avoid React warning
+                    key={isTestEnv ? visibleItems.length : undefined}
+                    // omit the `initialItemCount` prop to resolve NaN error
+                    {...(isTestEnv
                         ? {
                               initialItemCount: visibleItems.length,
-                              key: visibleItems.length,
                           }
                         : {})}
                 />


### PR DESCRIPTION
**Changes**

Resolves this warning when unit tests rendering the select/nested select components are run in a React 18 environment

```
 Warning: A props object containing a "key" prop is being spread into JSX:
```

- [delete] branch