### PR TITLE
V3 story cleanup

### DIFF
--- a/stories/form/form-custom-field/form-custom-field.stories.tsx
+++ b/stories/form/form-custom-field/form-custom-field.stories.tsx
@@ -2,8 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { Checkbox } from "src/checkbox";
 import { Form } from "src/form";
-import { StoryContainer } from "../../storybook-common";
-import { Container } from "../shared-doc-elements";
+import { StoryDecorator } from "stories/storybook-common";
 
 type Component = typeof Form.CustomField;
 
@@ -15,34 +14,30 @@ const meta: Meta<Component> = {
 export default meta;
 
 export const Default: StoryObj<Component> = {
-    render: () => {
+    render: (_args) => {
         const [cb1, setCb1] = useState(false);
         const [cb2, setCb2] = useState(false);
         const [cb3, setCb3] = useState(false);
         return (
-            <StoryContainer>
-                <Container>
-                    <Form.CustomField label="This is a custom field">
-                        <Checkbox checked={cb1} onClick={() => setCb1(!cb1)} />
-                    </Form.CustomField>
-                    <Form.CustomField
-                        label="This is the disabled state"
+            <>
+                <Form.CustomField label="This is a custom field">
+                    <Checkbox checked={cb1} onClick={() => setCb1(!cb1)} />
+                </Form.CustomField>
+                <Form.CustomField label="This is the disabled state" disabled>
+                    <Checkbox
+                        checked={cb2}
+                        onClick={() => setCb2(!cb2)}
                         disabled
-                    >
-                        <Checkbox
-                            checked={cb2}
-                            onClick={() => setCb2(!cb2)}
-                            disabled
-                        />
-                    </Form.CustomField>
-                    <Form.CustomField
-                        label="This is the error state"
-                        errorMessage="Date is required"
-                    >
-                        <Checkbox checked={cb3} onClick={() => setCb3(!cb3)} />
-                    </Form.CustomField>
-                </Container>
-            </StoryContainer>
+                    />
+                </Form.CustomField>
+                <Form.CustomField
+                    label="This is the error state"
+                    errorMessage="Date is required"
+                >
+                    <Checkbox checked={cb3} onClick={() => setCb3(!cb3)} />
+                </Form.CustomField>
+            </>
         );
     },
+    decorators: [StoryDecorator({ maxWidth: true })],
 };

--- a/stories/form/form-label/doc-elements.tsx
+++ b/stories/form/form-label/doc-elements.tsx
@@ -1,7 +1,0 @@
-import styled from "styled-components";
-
-export const Wrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-`;

--- a/stories/form/form-label/form-label.stories.tsx
+++ b/stories/form/form-label/form-label.stories.tsx
@@ -1,10 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { Checkbox } from "src/checkbox";
-import { Input } from "src/input";
 import { Form } from "src/form";
-import { Wrapper } from "./doc-elements";
-import { StoryContainer } from "../../storybook-common";
+import { Input } from "src/input";
+import { StackDecorator, StoryDecorator } from "stories/storybook-common";
 
 type Component = typeof Form.Label;
 
@@ -16,79 +15,73 @@ const meta: Meta<Component> = {
 export default meta;
 
 export const Default: StoryObj<Component> = {
-    render: () => {
+    render: (_args) => {
         return (
-            <StoryContainer>
-                <Wrapper>
-                    <Form.Label>The form label</Form.Label>
-                    <Form.Label
-                        addon={{
-                            content:
-                                "This is the form label's popover. And this will only be visible if you specify the addon prop",
-                            type: "popover",
-                        }}
-                    >
-                        The form label with an addon
-                    </Form.Label>
-                    <Form.Label subtitle="This is the subtitle">
-                        The form label with a subtitle
-                    </Form.Label>
-                </Wrapper>
-            </StoryContainer>
+            <>
+                <Form.Label>The form label</Form.Label>
+                <Form.Label
+                    addon={{
+                        content:
+                            "This is the form label's popover. And this will only be visible if you specify the addon prop",
+                        type: "popover",
+                    }}
+                >
+                    The form label with an addon
+                </Form.Label>
+                <Form.Label subtitle="This is the subtitle">
+                    The form label with a subtitle
+                </Form.Label>
+            </>
         );
     },
+    decorators: [StackDecorator(), StoryDecorator({ maxWidth: true })],
 };
 
 export const RealWorldUsage: StoryObj<Component> = {
-    render: () => {
+    render: (_args) => {
         const [checked, setChecked] = useState(false);
         return (
-            <StoryContainer>
-                <Wrapper>
-                    <div style={{ display: "flex", flexDirection: "column" }}>
-                        <Form.Label htmlFor="input">
-                            This is a descriptive label
-                        </Form.Label>
-                        <Input id="input" placeholder="Enter something" />
-                    </div>
-                    <div
-                        style={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: "0.5rem",
-                        }}
-                    >
-                        <Checkbox
-                            id="checkbox"
-                            checked={checked}
-                            onClick={() => setChecked(!checked)}
-                        />
-                        <Form.Label
-                            htmlFor="checkbox"
-                            style={{ marginBottom: 0 }}
-                        >
-                            Label for checkbox
-                        </Form.Label>
-                    </div>
-                </Wrapper>
-            </StoryContainer>
-        );
-    },
-};
-
-export const NestedChildren: StoryObj<Component> = {
-    render: () => {
-        return (
-            <StoryContainer>
+            <>
                 <div style={{ display: "flex", flexDirection: "column" }}>
                     <Form.Label htmlFor="input">
-                        <span>Label with a</span>&nbsp;<a href="">hyperlink</a>
-                        <br />
-                        <p>and some additional text on a new line</p>
+                        This is a descriptive label
                     </Form.Label>
                     <Input id="input" placeholder="Enter something" />
                 </div>
-            </StoryContainer>
+                <div
+                    style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "0.5rem",
+                    }}
+                >
+                    <Checkbox
+                        id="checkbox"
+                        checked={checked}
+                        onClick={() => setChecked(!checked)}
+                    />
+                    <Form.Label htmlFor="checkbox" style={{ marginBottom: 0 }}>
+                        Label for checkbox
+                    </Form.Label>
+                </div>
+            </>
         );
     },
+    decorators: [StackDecorator(), StoryDecorator({ maxWidth: true })],
+};
+
+export const NestedChildren: StoryObj<Component> = {
+    render: (_args) => {
+        return (
+            <div style={{ display: "flex", flexDirection: "column" }}>
+                <Form.Label htmlFor="input">
+                    Label with a&nbsp;<a href="">hyperlink</a>
+                    <br />
+                    and some additional text on a new line
+                </Form.Label>
+                <Input id="input" placeholder="Enter something" />
+            </div>
+        );
+    },
+    decorators: [StoryDecorator({ maxWidth: true })],
 };

--- a/stories/masonry/doc-elements.tsx
+++ b/stories/masonry/doc-elements.tsx
@@ -13,3 +13,7 @@ export const DemoContainer = styled.div`
     ${V2_TextStyleHelper.getTextStyle("Body", "semibold")}
     text-align: center;
 `;
+
+export const Container = styled.div`
+    width: 100vw;
+`;

--- a/stories/masonry/masonry.stories.tsx
+++ b/stories/masonry/masonry.stories.tsx
@@ -1,10 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Masonry } from "src/masonry";
-import { StoryContainer } from "../storybook-common";
+import { FullWidthStoryDecorator } from "../storybook-common";
 import { DemoContainer } from "./doc-elements";
 
 const meta: Meta = {
     title: "Deprecated/Masonry",
+    parameters: {
+        layout: "fullscreen",
+    },
+    decorators: [FullWidthStoryDecorator()],
 };
 
 export default meta;
@@ -12,25 +16,23 @@ export default meta;
 export const Default: StoryObj = {
     render: () => {
         return (
-            <StoryContainer>
-                <Masonry.Grid numOfCols={{ lg: 3 }}>
-                    <Masonry.Tile startLg={1} colsLg={1}>
-                        <DemoContainer>1</DemoContainer>
-                    </Masonry.Tile>
-                    <Masonry.Tile colsLg={2}>
-                        <DemoContainer>2</DemoContainer>
-                    </Masonry.Tile>
-                    <Masonry.Tile colsLg={3}>
-                        <DemoContainer>3</DemoContainer>
-                    </Masonry.Tile>
-                    <Masonry.Tile colsLg={2}>
-                        <DemoContainer>4</DemoContainer>
-                    </Masonry.Tile>
-                    <Masonry.Tile>
-                        <DemoContainer>5</DemoContainer>
-                    </Masonry.Tile>
-                </Masonry.Grid>
-            </StoryContainer>
+            <Masonry.Grid numOfCols={{ lg: 3 }}>
+                <Masonry.Tile startLg={1} colsLg={1}>
+                    <DemoContainer>1</DemoContainer>
+                </Masonry.Tile>
+                <Masonry.Tile colsLg={2}>
+                    <DemoContainer>2</DemoContainer>
+                </Masonry.Tile>
+                <Masonry.Tile colsLg={3}>
+                    <DemoContainer>3</DemoContainer>
+                </Masonry.Tile>
+                <Masonry.Tile colsLg={2}>
+                    <DemoContainer>4</DemoContainer>
+                </Masonry.Tile>
+                <Masonry.Tile>
+                    <DemoContainer>5</DemoContainer>
+                </Masonry.Tile>
+            </Masonry.Grid>
         );
     },
 };
@@ -38,25 +40,23 @@ export const Default: StoryObj = {
 export const DifferentMediaWidths: StoryObj = {
     render: () => {
         return (
-            <StoryContainer>
-                <Masonry.Grid numOfCols={{ lg: 4, md: 3, sm: 2 }}>
-                    <Masonry.Tile startLg={1} colsLg={1}>
-                        <DemoContainer>1</DemoContainer>
-                    </Masonry.Tile>
-                    <Masonry.Tile colsLg={1} colsMd={2}>
-                        <DemoContainer>2</DemoContainer>
-                    </Masonry.Tile>
-                    <Masonry.Tile colsLg={1} colsMd={3}>
-                        <DemoContainer>3</DemoContainer>
-                    </Masonry.Tile>
-                    <Masonry.Tile colsLg={1} colsMd={2}>
-                        <DemoContainer>4</DemoContainer>
-                    </Masonry.Tile>
-                    <Masonry.Tile colsSm={2} colsMd={1} colsLg={2}>
-                        <DemoContainer>5</DemoContainer>
-                    </Masonry.Tile>
-                </Masonry.Grid>
-            </StoryContainer>
+            <Masonry.Grid numOfCols={{ lg: 4, md: 3, sm: 2 }}>
+                <Masonry.Tile startLg={1} colsLg={1}>
+                    <DemoContainer>1</DemoContainer>
+                </Masonry.Tile>
+                <Masonry.Tile colsLg={1} colsMd={2}>
+                    <DemoContainer>2</DemoContainer>
+                </Masonry.Tile>
+                <Masonry.Tile colsLg={1} colsMd={3}>
+                    <DemoContainer>3</DemoContainer>
+                </Masonry.Tile>
+                <Masonry.Tile colsLg={1} colsMd={2}>
+                    <DemoContainer>4</DemoContainer>
+                </Masonry.Tile>
+                <Masonry.Tile colsSm={2} colsMd={1} colsLg={2}>
+                    <DemoContainer>5</DemoContainer>
+                </Masonry.Tile>
+            </Masonry.Grid>
         );
     },
 };

--- a/stories/storybook-common/story-container.tsx
+++ b/stories/storybook-common/story-container.tsx
@@ -1,64 +1,7 @@
 import { ReactRenderer } from "@storybook/react";
 import { DecoratorFunction } from "@storybook/types";
-import { MediaWidths } from "src/v2_spec/media-spec";
 import { Typography } from "src/typography";
-import { V2_MediaQuery } from "src/v2_media";
 import styled from "styled-components";
-
-const MINIMUM_SIDE_PADDING = 48;
-const SIDEBAR_WIDTH = 210;
-const SPACER = 600;
-
-/** @deprecated */
-export const StoryContainer = styled.div`
-    min-width: 500px;
-    margin: auto;
-    width: calc(
-        ${MediaWidths.desktopM}px -
-            ${MINIMUM_SIDE_PADDING + SIDEBAR_WIDTH + SPACER}px
-    );
-
-    ${V2_MediaQuery.MaxWidth.tablet} {
-        min-width: 400px;
-        width: calc(
-            ${MediaWidths.tablet}px -
-                ${MINIMUM_SIDE_PADDING + SIDEBAR_WIDTH + SPACER}px
-        );
-    }
-
-    ${V2_MediaQuery.MaxWidth.mobileL} {
-        min-width: 350px;
-        width: calc(
-            ${MediaWidths.mobileL}px - ${MINIMUM_SIDE_PADDING + SPACER}px
-        );
-    }
-
-    ${V2_MediaQuery.MaxWidth.mobileM} {
-        min-width: 0;
-        width: calc(${MediaWidths.mobileM}px - ${MINIMUM_SIDE_PADDING}px);
-    }
-
-    ${V2_MediaQuery.MaxWidth.mobileS} {
-        width: calc(${MediaWidths.mobileS}px - ${MINIMUM_SIDE_PADDING}px);
-    }
-`;
-
-/** @deprecated */
-export const FullWidthStoryContainer = styled.div`
-    margin: auto;
-    display: flex;
-    justify-content: center;
-`;
-
-/** @deprecated */
-export const FlexStoryContainer = styled.div`
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    flex-wrap: wrap;
-    padding: 2rem 1.25rem;
-    gap: 2rem;
-`;
 
 // =============================================================================
 // STYLE INTERFACES

--- a/stories/storybook-common/story-container.tsx
+++ b/stories/storybook-common/story-container.tsx
@@ -34,6 +34,7 @@ export const FullWidthStoryDecorator: (options?: {
         parameters.layout = "fullscreen";
         return (
             <FullWidthContainer
+                data-testid="full-width-story"
                 $fullHeight={options?.fullHeight}
                 $fullWidth={options?.fullWidth}
                 $fixedWidth={viewMode === "story"}
@@ -62,14 +63,20 @@ export const StoryDecorator: (options?: {
     function StoryWrapper(Story, { viewMode }) {
         if (viewMode === "docs") {
             return (
-                <DocsViewModeContainer $maxWidth={options?.maxWidth}>
+                <DocsViewModeContainer
+                    data-testid="story"
+                    $maxWidth={options?.maxWidth}
+                >
                     <Story />
                 </DocsViewModeContainer>
             );
         }
 
         return (
-            <StoryViewModeContainer $maxWidth={options?.maxWidth}>
+            <StoryViewModeContainer
+                data-testid="story"
+                $maxWidth={options?.maxWidth}
+            >
                 <Story />
             </StoryViewModeContainer>
         );
@@ -102,7 +109,7 @@ const DocsViewModeContainer = styled.div<StoryStyleProps>`
 export const RowDecorator: () => DecoratorFunction<ReactRenderer> = () =>
     function Row(Story) {
         return (
-            <RowStoryContainer>
+            <RowStoryContainer data-testid="row-story">
                 <Story />
             </RowStoryContainer>
         );
@@ -123,7 +130,7 @@ const RowStoryContainer = styled.div`
 export const StackDecorator: () => DecoratorFunction<ReactRenderer> = () =>
     function Stack(Story) {
         return (
-            <StackStoryContainer>
+            <StackStoryContainer data-testid="stack-story">
                 <Story />
             </StackStoryContainer>
         );
@@ -151,7 +158,11 @@ export const GridDecorator: (options: {
 }) =>
     function Grid(Story) {
         return (
-            <GridStoryContainer $grid={columns} $rowHeader={!!rowHeaders}>
+            <GridStoryContainer
+                data-testid="grid-story"
+                $grid={columns}
+                $rowHeader={!!rowHeaders}
+            >
                 {rowHeaders && columnHeaders ? <GridStoryRowHeader /> : null}
                 {columnHeaders
                     ? columnHeaders.map((header) => (

--- a/stories/storybook-common/story-container.tsx
+++ b/stories/storybook-common/story-container.tsx
@@ -169,6 +169,7 @@ const RowStoryContainer = styled.div`
     display: flex;
     gap: 1rem;
     flex-wrap: wrap;
+    align-items: center;
 `;
 
 // -----------------------------------------------------------------------------

--- a/stories/toggle/toggle-5-composite-section.stories.tsx
+++ b/stories/toggle/toggle-5-composite-section.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Form } from "src/form";
 import { Toggle } from "src/toggle";
-import { StoryContainer } from "../storybook-common";
 import { VariantDecorator } from "./doc-elements";
 
 type Component = typeof Toggle;
@@ -92,13 +91,6 @@ export const Collapsible: StoryObj<Component> = {
     render: (_args) => {
         return _Collapsible;
     },
-    decorators: [
-        (Story) => (
-            <StoryContainer>
-                <Story />
-            </StoryContainer>
-        ),
-    ],
 };
 
 const _Collapsible = (
@@ -119,13 +111,6 @@ export const CollapsedWithError: StoryObj<Component> = {
     render: (_args) => {
         return _CollapsedWithError;
     },
-    decorators: [
-        (Story) => (
-            <StoryContainer>
-                <Story />
-            </StoryContainer>
-        ),
-    ],
 };
 
 const _CollapsedWithError = (
@@ -149,13 +134,6 @@ export const CollapsedWithErrorAndDisabled: StoryObj<Component> = {
     render: (_args) => {
         return _CollapsedWithErrorAndDisabled;
     },
-    decorators: [
-        (Story) => (
-            <StoryContainer>
-                <Story />
-            </StoryContainer>
-        ),
-    ],
 };
 
 const _CollapsedWithErrorAndDisabled = (


### PR DESCRIPTION
**Changes**

- Prevent RowDecorator from auto-stretching the height of elements, this was affecting the [Tag component story](https://designsystem.life.gov.sg/react/index.html?path=/story/feedback-indicators-tag--interactive&globals=viewport:iphonex)
- Remove deprecated story containers
- Add `data-testid` to the decorators - makes it easier to identify the actual component when inspecting the html
- [delete] branch