### PR TITLE
[BOOKINGSG-7232][JZ] Update color and allow 24 hour rows

### DIFF
--- a/src/timetable/internal-types.ts
+++ b/src/timetable/internal-types.ts
@@ -1,4 +1,10 @@
 import { RowBarAlternateColors, RowBarMainColors } from "./const";
+import { TimeTableRowCellData } from "./types";
+
+export type InternalTimeTableRowCellData = TimeTableRowCellData & {
+    roundedStartTime?: string;
+    roundedEndTime?: string;
+};
 
 export interface RowBarColors {
     mainColor: RowBarMainColors;

--- a/src/timetable/timetable-row/row-bar.tsx
+++ b/src/timetable/timetable-row/row-bar.tsx
@@ -17,8 +17,8 @@ export const RowBar = ({
     id,
     timetableMinTime,
     timetableMaxTime,
-    rowMinTime = timetableMinTime,
-    rowMaxTime = timetableMaxTime,
+    rowMinTime,
+    rowMaxTime,
     rowCells,
     rowBarColor,
     intervalWidth,
@@ -46,6 +46,7 @@ export const RowBar = ({
 
         // Handle non-op before hours
         if (
+            rowMinTime &&
             dayjs(timetableMinTime, "HH:mm").isBefore(
                 dayjs(rowMinTime, "HH:mm")
             )
@@ -102,6 +103,7 @@ export const RowBar = ({
 
         // Handle non-op after hours
         if (
+            rowMaxTime &&
             rowMaxTime !== "23:59" &&
             dayjs(timetableMaxTime, "HH:mm").isAfter(dayjs(rowMaxTime, "HH:mm"))
         ) {
@@ -114,8 +116,8 @@ export const RowBar = ({
             });
         }
 
-        // Handle empty row cells
-        if (sortedRowCells.length === 0) {
+        // Handle empty row cells and no min/max time to block from timetable min to max
+        if (sortedRowCells.length === 0 && !rowMinTime && !rowMaxTime) {
             rowCellArray.push({
                 id,
                 startTime: timetableMinTime,

--- a/src/timetable/timetable-row/row-bar.tsx
+++ b/src/timetable/timetable-row/row-bar.tsx
@@ -102,6 +102,7 @@ export const RowBar = ({
 
         // Handle non-op after hours
         if (
+            rowMaxTime !== "23:59" &&
             dayjs(timetableMaxTime, "HH:mm").isAfter(dayjs(rowMaxTime, "HH:mm"))
         ) {
             rowCellArray.push({

--- a/src/timetable/timetable-row/row-bar.tsx
+++ b/src/timetable/timetable-row/row-bar.tsx
@@ -114,6 +114,16 @@ export const RowBar = ({
             });
         }
 
+        // Handle empty row cells
+        if (sortedRowCells.length === 0) {
+            rowCellArray.push({
+                id,
+                startTime: timetableMinTime,
+                endTime: timetableMaxTime,
+                status: "blocked",
+                customPopover: outOfRangeCellPopover,
+            });
+        }
         return rowCellArray;
     }, [
         id,

--- a/src/timetable/timetable-row/row-cell.tsx
+++ b/src/timetable/timetable-row/row-cell.tsx
@@ -36,9 +36,11 @@ const Component = ({
     // =============================================================================
     // CONST, STATE, REF
     // =============================================================================
-    const isOnTheHour = dayjs(endTime, "HH:mm").get("minutes") === 0;
+    const roundedEndTime = endTime === "23:59" ? "24:00" : endTime; // Round 23:59 to 24:00 for appropriate width calculations
+    const isOnTheHour = dayjs(roundedEndTime, "HH:mm").get("minutes") === 0;
     const numberOfIntervals =
-        DateHelper.getTimeDiffInMinutes(startTime, endTime) / ROW_INTERVAL;
+        DateHelper.getTimeDiffInMinutes(startTime, roundedEndTime) /
+        ROW_INTERVAL;
     const totalCellWidth = numberOfIntervals * intervalWidth;
     const adjustedCellWidth = totalCellWidth - ROW_CELL_GAP;
     const isClickable =

--- a/src/timetable/timetable-row/row-cell.tsx
+++ b/src/timetable/timetable-row/row-cell.tsx
@@ -3,8 +3,7 @@ import React, { MutableRefObject } from "react";
 import { PopoverTrigger, PopoverV2TriggerProps } from "../../popover-v2";
 import { DateHelper } from "../../util";
 import { ROW_CELL_GAP, ROW_INTERVAL } from "../const";
-import { RowBarColors } from "../internal-types";
-import { TimeTableRowCellData } from "../types";
+import { InternalTimeTableRowCellData, RowBarColors } from "../internal-types";
 import {
     Block,
     BlockContainer,
@@ -14,7 +13,7 @@ import {
     Wrapper,
 } from "./row-cell.style";
 
-interface RowCellProps extends TimeTableRowCellData {
+interface RowCellProps extends InternalTimeTableRowCellData {
     containerRef: MutableRefObject<HTMLDivElement>;
     intervalWidth: number;
     rowBarColor: RowBarColors;
@@ -31,15 +30,16 @@ const Component = ({
     rowBarColor,
     containerRef,
     customPopover,
+    roundedStartTime = startTime,
+    roundedEndTime = endTime,
     onClick,
 }: RowCellProps) => {
     // =============================================================================
     // CONST, STATE, REF
     // =============================================================================
-    const roundedEndTime = endTime === "23:59" ? "24:00" : endTime; // Round 23:59 to 24:00 for appropriate width calculations
     const isOnTheHour = dayjs(roundedEndTime, "HH:mm").get("minutes") === 0;
     const numberOfIntervals =
-        DateHelper.getTimeDiffInMinutes(startTime, roundedEndTime) /
+        DateHelper.getTimeDiffInMinutes(roundedStartTime, roundedEndTime) /
         ROW_INTERVAL;
     const totalCellWidth = numberOfIntervals * intervalWidth;
     const adjustedCellWidth = totalCellWidth - ROW_CELL_GAP;

--- a/src/timetable/timetable.style.tsx
+++ b/src/timetable/timetable.style.tsx
@@ -162,7 +162,7 @@ export const RowHeader = styled.div<RowHeaderProps>`
     text-align: right;
     padding: 0 1rem 0 2rem;
     border-bottom: 1px solid ${Color.Neutral[5]};
-    border-left: 1px solid ${Color.Accent.Light[1]};
+    border-left: 1px solid ${Color.Neutral[5]};
     transition: all 0.5s ease-in-out;
     ${(props) => {
         if (props.$isScrolled) {

--- a/src/timetable/timetable.tsx
+++ b/src/timetable/timetable.tsx
@@ -57,8 +57,12 @@ export const TimeTable = ({
     // CONST, STATE, REF
     // =============================================================================
     const testId = otherProps["data-testid"] || "timetable";
-    const timetableMinTime = TimeHelper.roundToNearestHour(minTime);
-    const timetableMaxTime = TimeHelper.roundToNearestHour(maxTime, true);
+    const timetableMinTime = TimeHelper.roundToNearestInterval(minTime, 60);
+    const timetableMaxTime = TimeHelper.roundToNearestInterval(
+        maxTime,
+        60,
+        true
+    );
     const hourlyIntervals = TimeHelper.generateHourlyIntervals(
         timetableMinTime,
         timetableMaxTime

--- a/src/timetable/timetable.tsx
+++ b/src/timetable/timetable.tsx
@@ -66,7 +66,6 @@ export const TimeTable = ({
         timetableMinTime,
         timetableMaxTime
     );
-
     const isEmptyContent = totalRecords === 0 || isEmpty(rowData);
     const allRecordsLoaded = isEmptyContent || rowData.length === totalRecords;
     const tableContainerRef = useRef<HTMLDivElement>(null);

--- a/src/timetable/timetable.tsx
+++ b/src/timetable/timetable.tsx
@@ -58,10 +58,7 @@ export const TimeTable = ({
     // =============================================================================
     const testId = otherProps["data-testid"] || "timetable";
     const timetableMinTime = TimeHelper.roundToNearestHour(minTime);
-    const timetableMaxTime =
-        maxTime === "23:59"
-            ? "24:00"
-            : TimeHelper.roundToNearestHour(maxTime, true); // Interpret 23:59 as 24:00 for end of day
+    const timetableMaxTime = TimeHelper.roundToNearestHour(maxTime, true);
     const hourlyIntervals = TimeHelper.generateHourlyIntervals(
         timetableMinTime,
         timetableMaxTime

--- a/src/timetable/timetable.tsx
+++ b/src/timetable/timetable.tsx
@@ -58,11 +58,15 @@ export const TimeTable = ({
     // =============================================================================
     const testId = otherProps["data-testid"] || "timetable";
     const timetableMinTime = TimeHelper.roundToNearestHour(minTime);
-    const timetableMaxTime = TimeHelper.roundToNearestHour(maxTime, true);
+    const timetableMaxTime =
+        maxTime === "23:59"
+            ? "24:00"
+            : TimeHelper.roundToNearestHour(maxTime, true); // Interpret 23:59 as 24:00 for end of day
     const hourlyIntervals = TimeHelper.generateHourlyIntervals(
         timetableMinTime,
         timetableMaxTime
     );
+
     const isEmptyContent = totalRecords === 0 || isEmpty(rowData);
     const allRecordsLoaded = isEmptyContent || rowData.length === totalRecords;
     const tableContainerRef = useRef<HTMLDivElement>(null);

--- a/src/util/time-helper.ts
+++ b/src/util/time-helper.ts
@@ -31,12 +31,14 @@ export namespace TimeHelper {
     /**
      * Rounds time to the nearest interval, e.g 6:30 will be clamped to 6:00 when interval = 60
      * @param time the input time in HH:mm format
-     * @param toNextHour to clamp to next interval instead, e.g. 6:30 will be clamped to 7:00 when interval = 60
-     * @returns the time rounded to the nearest hour in HH:mm format
+     * @param interval the interval in minutes (e.g., 15 for 15 minutes, 60 for 1 hour)
+     * @param toNextInterval to clamp to next interval instead, e.g. 6:30 will be clamped to 7:00 when interval = 60.
+     * If the time is already a valid interval, it will not be rounded
+     * @returns the rounded time in HH:mm format,
      */
     export const roundToNearestInterval = (
         time: string,
-        interval: number, // Interval in minutes (e.g., 15 for 15 minutes, 60 for 1 hour)
+        interval: number,
         toNextInterval?: boolean
     ): string => {
         const [hoursStr, minutesStr] = time.split(":");

--- a/src/util/time-helper.ts
+++ b/src/util/time-helper.ts
@@ -32,7 +32,7 @@ export namespace TimeHelper {
      * Rounds time to the nearest hour, e.g 6:30 will be clamped to 6:00
      * @param time the input time in HH:mm format
      * @param toNextHour to clamp to next hour instead, e.g. 6:30 will be clamped to 7:00
-     * @returns
+     * @returns the time rounded to the nearest hour in HH:mm format
      */
     export const roundToNearestHour = (time: string, toNextHour?: boolean) => {
         const formattedTime = dayjs(time, "HH:mm");
@@ -42,7 +42,11 @@ export namespace TimeHelper {
                 : toNextHour
                 ? formattedTime.minute(0).add(1, "hour")
                 : formattedTime.minute(0);
-        return roundedTime.format("HH:mm");
+
+        // Get the difference in hours from 00:00 of today to rounded time
+        const today = dayjs("00:00", "HH:mm");
+        const hourDifference = roundedTime.diff(today, "hour");
+        return `${hourDifference}:00`;
     };
 
     export const generateHourlyIntervals = (

--- a/stories/timetable/props-table.tsx
+++ b/stories/timetable/props-table.tsx
@@ -205,7 +205,9 @@ const DATA: ApiTableSectionProps[] = [
                     <>
                         The array of row cells to be rendered in this row of
                         data. This component will sort the cells array by start
-                        time.
+                        time. If empty and <code>rowMinTime</code> and{" "}
+                        <code>rowMaxTime</code> are not provided, it will be
+                        blocked from start to end.
                     </>
                 ),
                 propTypes: ["TimeTableRowCellData[]"],
@@ -254,7 +256,8 @@ const DATA: ApiTableSectionProps[] = [
                         <code>TimeTableProps</code>.<br />
                         This component will automatically fill
                         <code>blocked</code>cells till<code>maxTime</code>from
-                        this time.
+                        this time. <code>23:59</code> will be interpreted as
+                        00:00 of the next day.
                     </>
                 ),
                 propTypes: ["string"],

--- a/stories/timetable/props-table.tsx
+++ b/stories/timetable/props-table.tsx
@@ -291,7 +291,11 @@ const DATA: ApiTableSectionProps[] = [
                 name: "startTime",
                 mandatory: true,
                 description: (
-                    <>The starting time of this cell. In {TIME_FORMAT}.</>
+                    <>
+                        The starting time of this cell. In {TIME_FORMAT}.
+                        <b>Note</b>: Duration between start-end should be
+                        multiples of 15
+                    </>
                 ),
                 propTypes: ["string"],
             },
@@ -299,7 +303,11 @@ const DATA: ApiTableSectionProps[] = [
                 name: "endTime",
                 mandatory: true,
                 description: (
-                    <>The ending time of this cell. In {TIME_FORMAT}.</>
+                    <>
+                        The ending time of this cell. In {TIME_FORMAT}.
+                        <b>Note</b>: Duration between start-end should be
+                        multiples of 15
+                    </>
                 ),
                 propTypes: ["string"],
             },

--- a/stories/timetable/props-table.tsx
+++ b/stories/timetable/props-table.tsx
@@ -206,8 +206,9 @@ const DATA: ApiTableSectionProps[] = [
                         The array of row cells to be rendered in this row of
                         data. This component will sort the cells array by start
                         time. If empty and <code>rowMinTime</code> and{" "}
-                        <code>rowMaxTime</code> are not provided, it will be
-                        blocked from start to end.
+                        <code>rowMaxTime</code> are not provided, the row will
+                        be blocked from <code>minTime</code> to{" "}
+                        <code>maxTime</code>.
                     </>
                 ),
                 propTypes: ["TimeTableRowCellData[]"],
@@ -237,11 +238,12 @@ const DATA: ApiTableSectionProps[] = [
                 name: "rowMinTime",
                 description: (
                     <>
-                        The starting time for this row in {TIME_FORMAT}. <br />
+                        The starting time for this row in {TIME_FORMAT}.
                         Defaults to <code>minTime</code>from
                         <code>TimeTableProps</code>.<br />
+                        <br />
                         This component will automatically fill
-                        <code>blocked</code>cells from<code>minTime</code>to
+                        <code>blocked</code>cells from <code>minTime</code> to
                         this time.
                     </>
                 ),
@@ -251,13 +253,13 @@ const DATA: ApiTableSectionProps[] = [
                 name: "rowMaxTime",
                 description: (
                     <>
-                        The ending time in for this row in {TIME_FORMAT}. <br />
+                        The ending time in for this row in {TIME_FORMAT}.
                         Defaults to <code>maxTime</code>from
                         <code>TimeTableProps</code>.<br />
+                        <br />
                         This component will automatically fill
-                        <code>blocked</code>cells till<code>maxTime</code>from
-                        this time. <code>23:59</code> will be interpreted as
-                        00:00 of the next day.
+                        <code>blocked</code>cells till <code>maxTime</code> from
+                        this time.
                     </>
                 ),
                 propTypes: ["string"],
@@ -292,7 +294,7 @@ const DATA: ApiTableSectionProps[] = [
                 mandatory: true,
                 description: (
                     <>
-                        The starting time of this cell. In {TIME_FORMAT}.
+                        The starting time of this cell. In {TIME_FORMAT}.<br />
                         <b>Note</b>: Duration between start-end should be
                         multiples of 15
                     </>
@@ -304,7 +306,7 @@ const DATA: ApiTableSectionProps[] = [
                 mandatory: true,
                 description: (
                     <>
-                        The ending time of this cell. In {TIME_FORMAT}.
+                        The ending time of this cell. In {TIME_FORMAT}.<br />
                         <b>Note</b>: Duration between start-end should be
                         multiples of 15
                     </>

--- a/stories/timetable/timetable-default-data.tsx
+++ b/stories/timetable/timetable-default-data.tsx
@@ -195,7 +195,7 @@ export const timetableDefaultData = [
         ],
     },
     {
-        name: "sit",
+        name: "No cells",
         rowCells: [],
     },
     {

--- a/stories/timetable/timetable-default-data.tsx
+++ b/stories/timetable/timetable-default-data.tsx
@@ -196,36 +196,7 @@ export const timetableDefaultData = [
     },
     {
         name: "sit",
-        rowMinTime: "08:30",
-        rowMaxTime: "21:00",
-        rowCells: [
-            {
-                title: "330 mins",
-                startTime: "08:30",
-                endTime: "14:00",
-                status: "filled" as TimeTableCellType,
-            },
-            {
-                startTime: "14:00",
-                endTime: "15:00",
-                status: "default" as TimeTableCellType,
-            },
-            {
-                startTime: "15:00",
-                endTime: "16:00",
-                status: "default" as TimeTableCellType,
-            },
-            {
-                startTime: "16:00",
-                endTime: "17:00",
-                status: "default" as TimeTableCellType,
-            },
-            {
-                startTime: "17:00",
-                endTime: "18:00",
-                status: "default" as TimeTableCellType,
-            },
-        ],
+        rowCells: [],
     },
     {
         name: "amet",

--- a/stories/timetable/timetable.mdx
+++ b/stories/timetable/timetable.mdx
@@ -10,7 +10,8 @@ import { PropsTable } from "./props-table";
 
 <Secondary>Overview</Secondary>
 
-A component that displays a timetable to view a schedule for a specific day
+A component that displays a timetable to view a schedule for a specific day.
+This supports slots in 15 minute intervals only.
 
 ```tsx
 import { TimeTable } from "@lifesg/react-design-system/timetable";

--- a/tests/timetable/timetable.spec.tsx
+++ b/tests/timetable/timetable.spec.tsx
@@ -280,4 +280,30 @@ describe("TimeTable", () => {
 
         expect(await screen.findByTestId("lazy-loader")).toBeInTheDocument();
     });
+
+    it("should render a full bar of blocked slot when row cells are empty and rowMinTime and rowMaxTime are omitted for that row", async () => {
+        render(
+            <TimeTable
+                date={timeTableMockData.date}
+                rowData={[
+                    {
+                        name: "blocked row",
+                        rowCells: [],
+                    },
+                ]}
+                minTime={"00:00"}
+                maxTime={"23:59"}
+                loading={false}
+                emptyContentMessage={timeTableMockData.emptyContentMessage}
+                onPreviousDayClick={timeTableMockData.onPreviousDayClick}
+                onNextDayClick={timeTableMockData.onNextDayClick}
+            />
+        );
+        const timetableRow = screen.findByTestId("timetable-row");
+        expect(
+            (await timetableRow).querySelectorAll(
+                '[data-testid="block-container"]'
+            ).length
+        ).toBe(1);
+    });
 });

--- a/tests/utils/time-helper.spec.ts
+++ b/tests/utils/time-helper.spec.ts
@@ -53,3 +53,143 @@ describe("parseInput tests", () => {
         expect(TimeHelper.parseInput("11111")).toBeUndefined();
     });
 });
+
+describe("roundToNearestInterval tests", () => {
+    it("should return the same time if already aligned with the interval", () => {
+        expect(TimeHelper.roundToNearestInterval("08:00", 15, false)).toBe(
+            "08:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:15", 15, false)).toBe(
+            "08:15"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:00", 15, true)).toBe(
+            "08:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:15", 15, true)).toBe(
+            "08:15"
+        );
+        expect(TimeHelper.roundToNearestInterval("00:45", 45, false)).toBe(
+            "00:45"
+        );
+        expect(TimeHelper.roundToNearestInterval("01:30", 45, false)).toBe(
+            "01:30"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:00", 60, false)).toBe(
+            "08:00"
+        );
+    });
+
+    it("should round down to the previous interval when toNextInterval is false", () => {
+        expect(TimeHelper.roundToNearestInterval("08:03", 15, false)).toBe(
+            "08:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:14", 15, false)).toBe(
+            "08:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:29", 15, false)).toBe(
+            "08:15"
+        );
+        expect(TimeHelper.roundToNearestInterval("00:44", 45, false)).toBe(
+            "00:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("00:55", 45, false)).toBe(
+            "00:45"
+        );
+        expect(TimeHelper.roundToNearestInterval("01:30", 45, false)).toBe(
+            "01:30"
+        );
+    });
+
+    it("should round up to the next interval when toNextInterval is true", () => {
+        expect(TimeHelper.roundToNearestInterval("08:03", 15, true)).toBe(
+            "08:15"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:14", 15, true)).toBe(
+            "08:15"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:29", 15, true)).toBe(
+            "08:30"
+        );
+    });
+
+    it("should handle edge cases like 00:00 and 24:00", () => {
+        expect(TimeHelper.roundToNearestInterval("00:00", 15, false)).toBe(
+            "00:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("00:14", 15, false)).toBe(
+            "00:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("00:14", 15, true)).toBe(
+            "00:15"
+        );
+        expect(TimeHelper.roundToNearestInterval("23:59", 15, true)).toBe(
+            "24:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("23:59", 15, false)).toBe(
+            "23:45"
+        );
+    });
+
+    it("should handle times exceeding 24:00", () => {
+        expect(TimeHelper.roundToNearestInterval("24:01", 15, false)).toBe(
+            "24:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("25:55", 15, true)).toBe(
+            "26:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("27:30", 30, true)).toBe(
+            "27:30"
+        );
+        expect(TimeHelper.roundToNearestInterval("27:45", 30, false)).toBe(
+            "27:30"
+        );
+    });
+
+    it("should handle 1-hour intervals", () => {
+        expect(TimeHelper.roundToNearestInterval("08:30", 60, false)).toBe(
+            "08:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:30", 60, true)).toBe(
+            "09:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("23:59", 60, true)).toBe(
+            "24:00"
+        );
+    });
+
+    it("should throw an error for invalid time formats", () => {
+        expect(() =>
+            TimeHelper.roundToNearestInterval("invalid", 15, true)
+        ).toThrow("Invalid time format");
+        expect(() =>
+            TimeHelper.roundToNearestInterval("25:99", 15, true)
+        ).toThrow("Invalid time format");
+        expect(() =>
+            TimeHelper.roundToNearestInterval("12:60", 15, true)
+        ).toThrow("Invalid time format");
+    });
+
+    it("should handle large intervals (e.g., 120 minutes)", () => {
+        expect(TimeHelper.roundToNearestInterval("08:30", 120, false)).toBe(
+            "08:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:30", 120, true)).toBe(
+            "10:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("23:59", 120, true)).toBe(
+            "24:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("00:15", 480, true)).toBe(
+            "08:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:00", 480, true)).toBe(
+            "08:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:15", 480, true)).toBe(
+            "16:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("00:15", 480, false)).toBe(
+            "00:00"
+        );
+    });
+});


### PR DESCRIPTION
**Changes**
- Interpret 23:59 as 24:00 or 00:00 of the next day for time comparisons, and also interpret as ending on the 0th minute
- Amend color of the left border for each row to use N5 color
- Auto block the entire row from start to end when row cell provided is an empty array and minTime/maxTime are not defined for that row

- [delete] branch

**Changelog entry**
- Update row left border color to N5
- Interpret 23:59 to be start of next day timing
- Auto block entire row if no rowcell provided and no minTime/maxTime provided for that row

**Additional information**

- You may refer to this [BOOKINGSG-7232](https://sgtechstack.atlassian.net/browse/BOOKINGSG-7232)

