### PR TITLE
[BOOKINGSG-7232-v3][JZ] Update color and allow 24 hour rows

### DIFF
--- a/src/timetable/internal-types.ts
+++ b/src/timetable/internal-types.ts
@@ -1,4 +1,10 @@
 import { RowBarAlternateColors, RowBarMainColors } from "./const";
+import { TimeTableRowCellData } from "./types";
+
+export type InternalTimeTableRowCellData = TimeTableRowCellData & {
+    roundedStartTime?: string;
+    roundedEndTime?: string;
+};
 
 export interface RowBarColors {
     mainColor: RowBarMainColors;

--- a/src/timetable/timetable-row/row-bar.tsx
+++ b/src/timetable/timetable-row/row-bar.tsx
@@ -96,6 +96,7 @@ export const RowBar = ({
 
         // Handle non-op after hours
         if (
+            rowMaxTime !== "23:59" &&
             dayjs(timetableMaxTime, "HH:mm").isAfter(dayjs(rowMaxTime, "HH:mm"))
         ) {
             rowCellArray.push({
@@ -107,6 +108,16 @@ export const RowBar = ({
             });
         }
 
+        // Handle empty row cells
+        if (sortedRowCells.length === 0) {
+            rowCellArray.push({
+                id,
+                startTime: timetableMinTime,
+                endTime: timetableMaxTime,
+                status: "blocked",
+                customPopover: outOfRangeCellPopover,
+            });
+        }
         return rowCellArray;
     }, [
         id,

--- a/src/timetable/timetable-row/row-bar.tsx
+++ b/src/timetable/timetable-row/row-bar.tsx
@@ -17,8 +17,8 @@ export const RowBar = ({
     id,
     timetableMinTime,
     timetableMaxTime,
-    rowMinTime = timetableMinTime,
-    rowMaxTime = timetableMaxTime,
+    rowMinTime,
+    rowMaxTime,
     rowCells,
     rowBarColor,
     intervalWidth,
@@ -40,6 +40,7 @@ export const RowBar = ({
 
         // Handle non-op before hours
         if (
+            rowMinTime &&
             dayjs(timetableMinTime, "HH:mm").isBefore(
                 dayjs(rowMinTime, "HH:mm")
             )
@@ -96,6 +97,7 @@ export const RowBar = ({
 
         // Handle non-op after hours
         if (
+            rowMaxTime &&
             rowMaxTime !== "23:59" &&
             dayjs(timetableMaxTime, "HH:mm").isAfter(dayjs(rowMaxTime, "HH:mm"))
         ) {
@@ -108,8 +110,8 @@ export const RowBar = ({
             });
         }
 
-        // Handle empty row cells
-        if (sortedRowCells.length === 0) {
+        // Handle empty row cells and no min/max time to block from timetable min to max
+        if (sortedRowCells.length === 0 && !rowMinTime && !rowMaxTime) {
             rowCellArray.push({
                 id,
                 startTime: timetableMinTime,

--- a/src/timetable/timetable-row/row-bar.tsx
+++ b/src/timetable/timetable-row/row-bar.tsx
@@ -1,7 +1,9 @@
 import dayjs from "dayjs";
 import { RefObject, useMemo } from "react";
-import { RowBarColors } from "../internal-types";
-import { TimeTableRowCellData, TimeTableRowData } from "../types";
+import { TimeHelper } from "../../util/time-helper";
+import { ROW_INTERVAL } from "../const";
+import { InternalTimeTableRowCellData, RowBarColors } from "../internal-types";
+import { TimeTableRowData } from "../types";
 import { RowCellContainer } from "./row-bar.style";
 import { RowCell } from "./row-cell";
 
@@ -25,6 +27,13 @@ export const RowBar = ({
     containerRef,
     outOfRangeCellPopover,
 }: RowBarProps) => {
+    const roundedMinTime = rowMinTime
+        ? TimeHelper.roundToNearestInterval(rowMinTime, ROW_INTERVAL)
+        : timetableMinTime;
+    const roundedMaxTime = rowMaxTime
+        ? TimeHelper.roundToNearestInterval(rowMaxTime, ROW_INTERVAL, true)
+        : timetableMaxTime;
+
     // ===========================================================================
     // HELPER FUNCTIONS
     // ===========================================================================
@@ -36,19 +45,19 @@ export const RowBar = ({
     };
 
     const rowCellArray = useMemo(() => {
-        const rowCellArray: TimeTableRowCellData[] = [];
+        const rowCellArray: InternalTimeTableRowCellData[] = [];
 
         // Handle non-op before hours
         if (
-            rowMinTime &&
+            roundedMinTime &&
             dayjs(timetableMinTime, "HH:mm").isBefore(
-                dayjs(rowMinTime, "HH:mm")
+                dayjs(roundedMinTime, "HH:mm")
             )
         ) {
             rowCellArray.push({
                 id,
                 startTime: timetableMinTime,
-                endTime: rowMinTime,
+                endTime: roundedMinTime,
                 status: "blocked",
                 customPopover: outOfRangeCellPopover,
             });
@@ -63,18 +72,36 @@ export const RowBar = ({
         });
 
         sortedRowCells.forEach((cell, index) => {
-            const { endTime } = cell;
-            rowCellArray.push(cell);
+            const { startTime, endTime } = cell;
+            const roundedStartTime = TimeHelper.roundToNearestInterval(
+                startTime,
+                ROW_INTERVAL,
+                index !== 0
+            );
+            const roundedEndTime = TimeHelper.roundToNearestInterval(
+                endTime,
+                ROW_INTERVAL,
+                true
+            );
+            rowCellArray.push({ ...cell, roundedStartTime, roundedEndTime });
 
-            const nextSlotStartTime = dayjs(
-                rowCells[index + 1]?.startTime || rowMaxTime, // Get next cell start time, if next cell don't exist, use current row max time
+            const nextSlotStartTime =
+                rowCells[index + 1]?.startTime || roundedMaxTime; // Get next cell start time, if next cell don't exist, use current row max time
+            const roundedNextSlotStartTime = dayjs(
+                TimeHelper.roundToNearestInterval(
+                    nextSlotStartTime,
+                    ROW_INTERVAL,
+                    true
+                ),
                 "HH:mm"
             );
-            const parsedEndTime = dayjs(endTime, "HH:mm");
+            const parsedEndTime = dayjs(roundedEndTime, "HH:mm");
 
             let curr = parsedEndTime;
-            while (curr.isBefore(nextSlotStartTime)) {
-                if (!isOnTheSameHour(curr, nextSlotStartTime)) {
+
+            // Auto block slots between cell time gaps
+            while (curr.isBefore(roundedNextSlotStartTime)) {
+                if (!isOnTheSameHour(curr, roundedNextSlotStartTime)) {
                     const nextHour = curr.add(1, "hour").startOf("hour"); // Round to the next hour
                     rowCellArray.push({
                         id,
@@ -87,23 +114,26 @@ export const RowBar = ({
                     rowCellArray.push({
                         id,
                         startTime: curr.format("HH:mm").toString(),
-                        endTime: nextSlotStartTime.format("HH:mm").toString(),
+                        endTime: roundedNextSlotStartTime
+                            .format("HH:mm")
+                            .toString(),
                         status: "disabled",
                     });
-                    curr = nextSlotStartTime;
+                    curr = roundedNextSlotStartTime;
                 }
             }
         });
 
         // Handle non-op after hours
         if (
-            rowMaxTime &&
-            rowMaxTime !== "23:59" &&
-            dayjs(timetableMaxTime, "HH:mm").isAfter(dayjs(rowMaxTime, "HH:mm"))
+            roundedMaxTime &&
+            dayjs(timetableMaxTime, "HH:mm").isAfter(
+                dayjs(roundedMaxTime, "HH:mm")
+            )
         ) {
             rowCellArray.push({
                 id,
-                startTime: rowMaxTime,
+                startTime: roundedMaxTime,
                 endTime: timetableMaxTime,
                 status: "blocked",
                 customPopover: outOfRangeCellPopover,
@@ -122,12 +152,14 @@ export const RowBar = ({
         }
         return rowCellArray;
     }, [
-        id,
+        roundedMinTime,
         timetableMinTime,
+        rowCells,
+        roundedMaxTime,
         timetableMaxTime,
         rowMinTime,
         rowMaxTime,
-        rowCells,
+        id,
         outOfRangeCellPopover,
     ]);
 

--- a/src/timetable/timetable-row/row-bar.tsx
+++ b/src/timetable/timetable-row/row-bar.tsx
@@ -70,14 +70,29 @@ export const RowBar = ({
             if (timeA.isAfter(timeB)) return 1;
             return 0;
         });
+        let lastRoundedEndTime: string | undefined;
 
         sortedRowCells.forEach((cell, index) => {
             const { startTime, endTime } = cell;
-            const roundedStartTime = TimeHelper.roundToNearestInterval(
+            let roundedStartTime = TimeHelper.roundToNearestInterval(
                 startTime,
-                ROW_INTERVAL,
-                index !== 0
+                ROW_INTERVAL
             );
+
+            // NOTE - Prevent overlapping rounded start time and end time cells
+            const isStartTimeBeforePreviousEndTime =
+                lastRoundedEndTime &&
+                dayjs(roundedStartTime, "HH:mm").isBefore(
+                    dayjs(lastRoundedEndTime, "HH:mm")
+                );
+            if (isStartTimeBeforePreviousEndTime) {
+                roundedStartTime = TimeHelper.roundToNearestInterval(
+                    startTime,
+                    ROW_INTERVAL,
+                    true
+                );
+            }
+
             const roundedEndTime = TimeHelper.roundToNearestInterval(
                 endTime,
                 ROW_INTERVAL,
@@ -90,8 +105,7 @@ export const RowBar = ({
             const roundedNextSlotStartTime = dayjs(
                 TimeHelper.roundToNearestInterval(
                     nextSlotStartTime,
-                    ROW_INTERVAL,
-                    true
+                    ROW_INTERVAL
                 ),
                 "HH:mm"
             );
@@ -122,6 +136,7 @@ export const RowBar = ({
                     curr = roundedNextSlotStartTime;
                 }
             }
+            lastRoundedEndTime = curr.format("HH:mm").toString();
         });
 
         // Handle non-op after hours

--- a/src/timetable/timetable-row/row-cell.tsx
+++ b/src/timetable/timetable-row/row-cell.tsx
@@ -2,8 +2,7 @@ import dayjs from "dayjs";
 import React, { RefObject } from "react";
 import { DateHelper } from "../../util";
 import { ROW_CELL_GAP, ROW_INTERVAL } from "../const";
-import { RowBarColors } from "../internal-types";
-import { TimeTableRowCellData } from "../types";
+import { InternalTimeTableRowCellData, RowBarColors } from "../internal-types";
 import {
     Block,
     BlockContainer,
@@ -14,7 +13,7 @@ import {
 } from "./row-cell.style";
 import { WithOptionalPopover } from "./with-optional-popover";
 
-interface RowCellProps extends TimeTableRowCellData {
+interface RowCellProps extends InternalTimeTableRowCellData {
     containerRef: RefObject<HTMLDivElement>;
     intervalWidth: number;
     rowBarColor: RowBarColors;
@@ -31,15 +30,16 @@ const Component = ({
     rowBarColor,
     containerRef,
     customPopover,
+    roundedStartTime = startTime,
+    roundedEndTime = endTime,
     onClick,
 }: RowCellProps) => {
     // =============================================================================
     // CONST, STATE, REF
     // =============================================================================
-    const roundedEndTime = endTime === "23:59" ? "24:00" : endTime; // Round 23:59 to 24:00 for appropriate width calculations
     const isOnTheHour = dayjs(roundedEndTime, "HH:mm").get("minutes") === 0;
     const numberOfIntervals =
-        DateHelper.getTimeDiffInMinutes(startTime, roundedEndTime) /
+        DateHelper.getTimeDiffInMinutes(roundedStartTime, roundedEndTime) /
         ROW_INTERVAL;
     const totalCellWidth = numberOfIntervals * intervalWidth;
     const adjustedCellWidth = totalCellWidth - ROW_CELL_GAP;

--- a/src/timetable/timetable-row/row-cell.tsx
+++ b/src/timetable/timetable-row/row-cell.tsx
@@ -36,9 +36,11 @@ const Component = ({
     // =============================================================================
     // CONST, STATE, REF
     // =============================================================================
-    const isOnTheHour = dayjs(endTime, "HH:mm").get("minutes") === 0;
+    const roundedEndTime = endTime === "23:59" ? "24:00" : endTime; // Round 23:59 to 24:00 for appropriate width calculations
+    const isOnTheHour = dayjs(roundedEndTime, "HH:mm").get("minutes") === 0;
     const numberOfIntervals =
-        DateHelper.getTimeDiffInMinutes(startTime, endTime) / ROW_INTERVAL;
+        DateHelper.getTimeDiffInMinutes(startTime, roundedEndTime) /
+        ROW_INTERVAL;
     const totalCellWidth = numberOfIntervals * intervalWidth;
     const adjustedCellWidth = totalCellWidth - ROW_CELL_GAP;
     const isClickable =

--- a/src/timetable/timetable.style.tsx
+++ b/src/timetable/timetable.style.tsx
@@ -172,8 +172,7 @@ export const RowHeader = styled.div<RowHeaderProps>`
     text-align: right;
     padding: 0 ${Spacing["spacing-16"]} 0 ${Spacing["spacing-32"]};
     border-bottom: ${Border["width-010"]} ${Border["solid"]} ${Colour["border"]};
-    border-left: ${Border["width-010"]} ${Border["solid"]}
-        ${Colour["border-primary"]};
+    border-left: ${Border["width-010"]} ${Border["solid"]} ${Colour["border"]};
     transition: all 0.5s ease-in-out;
     ${(props) => {
         if (props.$isScrolled) {

--- a/src/timetable/timetable.tsx
+++ b/src/timetable/timetable.tsx
@@ -58,7 +58,10 @@ export const TimeTable = ({
     // =============================================================================
     const testId = otherProps["data-testid"] || "timetable";
     const timetableMinTime = TimeHelper.roundToNearestHour(minTime);
-    const timetableMaxTime = TimeHelper.roundToNearestHour(maxTime, true);
+    const timetableMaxTime =
+        maxTime === "23:59"
+            ? "24:00"
+            : TimeHelper.roundToNearestHour(maxTime, true); // Interpret 23:59 as 24:00 for end of day
     const hourlyIntervals = TimeHelper.generateHourlyIntervals(
         timetableMinTime,
         timetableMaxTime

--- a/src/timetable/timetable.tsx
+++ b/src/timetable/timetable.tsx
@@ -57,15 +57,17 @@ export const TimeTable = ({
     // CONST, STATE, REF
     // =============================================================================
     const testId = otherProps["data-testid"] || "timetable";
-    const timetableMinTime = TimeHelper.roundToNearestHour(minTime);
-    const timetableMaxTime =
-        maxTime === "23:59"
-            ? "24:00"
-            : TimeHelper.roundToNearestHour(maxTime, true); // Interpret 23:59 as 24:00 for end of day
+    const timetableMinTime = TimeHelper.roundToNearestInterval(minTime, 60);
+    const timetableMaxTime = TimeHelper.roundToNearestInterval(
+        maxTime,
+        60,
+        true
+    );
     const hourlyIntervals = TimeHelper.generateHourlyIntervals(
         timetableMinTime,
         timetableMaxTime
     );
+
     const isEmptyContent = totalRecords === 0 || isEmpty(rowData);
     const allRecordsLoaded = isEmptyContent || rowData.length === totalRecords;
     const tableContainerRef = useRef<HTMLDivElement>(null);

--- a/src/util/time-helper.ts
+++ b/src/util/time-helper.ts
@@ -29,20 +29,48 @@ interface TimeValuesPlain {
 // =============================================================================
 export namespace TimeHelper {
     /**
-     * Rounds time to the nearest hour, e.g 6:30 will be clamped to 6:00
+     * Rounds time to the nearest interval, e.g 6:30 will be clamped to 6:00 when interval = 60
      * @param time the input time in HH:mm format
-     * @param toNextHour to clamp to next hour instead, e.g. 6:30 will be clamped to 7:00
-     * @returns
+     * @param toNextHour to clamp to next interval instead, e.g. 6:30 will be clamped to 7:00 when interval = 60
+     * @returns the time rounded to the nearest hour in HH:mm format
      */
-    export const roundToNearestHour = (time: string, toNextHour?: boolean) => {
-        const formattedTime = dayjs(time, "HH:mm");
-        const roundedTime =
-            formattedTime.minute() === 0
-                ? formattedTime
-                : toNextHour
-                ? formattedTime.minute(0).add(1, "hour")
-                : formattedTime.minute(0);
-        return roundedTime.format("HH:mm");
+    export const roundToNearestInterval = (
+        time: string,
+        interval: number, // Interval in minutes (e.g., 15 for 15 minutes, 60 for 1 hour)
+        toNextInterval?: boolean
+    ): string => {
+        const [hoursStr, minutesStr] = time.split(":");
+        const hours = parseInt(hoursStr, 10);
+        const minutes = parseInt(minutesStr, 10);
+
+        // Handle invalid inputs
+        if (isNaN(hours) || isNaN(minutes) || minutes < 0 || minutes >= 60) {
+            throw new Error("Invalid time format");
+        }
+
+        // Convert the time to total minutes
+        const totalMinutes = hours * 60 + minutes;
+        const remainder = totalMinutes % interval;
+
+        // Calculate the rounded total minutes
+        const roundedMinutes =
+            remainder === 0
+                ? totalMinutes
+                : toNextInterval
+                ? totalMinutes + (interval - remainder)
+                : totalMinutes - remainder;
+
+        // Convert the rounded total minutes back to hours and minutes
+        const roundedHours = Math.floor(roundedMinutes / 60);
+        const roundedMinutesWithinHour = roundedMinutes % 60;
+
+        // Format the result as HH:mm, allowing for hours >= 24
+        const formattedHours = roundedHours.toString().padStart(2, "0");
+        const formattedMinutes = roundedMinutesWithinHour
+            .toString()
+            .padStart(2, "0");
+
+        return `${formattedHours}:${formattedMinutes}`;
     };
 
     export const generateHourlyIntervals = (

--- a/src/util/time-helper.ts
+++ b/src/util/time-helper.ts
@@ -31,12 +31,14 @@ export namespace TimeHelper {
     /**
      * Rounds time to the nearest interval, e.g 6:30 will be clamped to 6:00 when interval = 60
      * @param time the input time in HH:mm format
-     * @param toNextHour to clamp to next interval instead, e.g. 6:30 will be clamped to 7:00 when interval = 60
-     * @returns the time rounded to the nearest hour in HH:mm format
+     * @param interval the interval in minutes (e.g., 15 for 15 minutes, 60 for 1 hour)
+     * @param toNextInterval to clamp to next interval instead, e.g. 6:30 will be clamped to 7:00 when interval = 60.
+     * If the time is already a valid interval, it will not be rounded
+     * @returns the rounded time in HH:mm format,
      */
     export const roundToNearestInterval = (
         time: string,
-        interval: number, // Interval in minutes (e.g., 15 for 15 minutes, 60 for 1 hour)
+        interval: number,
         toNextInterval?: boolean
     ): string => {
         const [hoursStr, minutesStr] = time.split(":");

--- a/stories/timetable/props-table.tsx
+++ b/stories/timetable/props-table.tsx
@@ -204,7 +204,9 @@ const DATA: ApiTableSectionProps[] = [
                     <>
                         The array of row cells to be rendered in this row of
                         data. This component will sort the cells array by start
-                        time.
+                        time. If empty and <code>rowMinTime</code> and{" "}
+                        <code>rowMaxTime</code> are not provided, it will be
+                        blocked from start to end.
                     </>
                 ),
                 propTypes: ["TimeTableRowCellData[]"],
@@ -253,7 +255,8 @@ const DATA: ApiTableSectionProps[] = [
                         <code>TimeTableProps</code>.<br />
                         This component will automatically fill
                         <code>blocked</code>cells till<code>maxTime</code>from
-                        this time.
+                        this time. <code>23:59</code> will be interpreted as
+                        00:00 of the next day.
                     </>
                 ),
                 propTypes: ["string"],

--- a/stories/timetable/props-table.tsx
+++ b/stories/timetable/props-table.tsx
@@ -290,7 +290,11 @@ const DATA: ApiTableSectionProps[] = [
                 name: "startTime",
                 mandatory: true,
                 description: (
-                    <>The starting time of this cell. In {TIME_FORMAT}.</>
+                    <>
+                        The starting time of this cell. In {TIME_FORMAT}.
+                        <b>Note</b>: Duration between start-end should be
+                        multiples of 15
+                    </>
                 ),
                 propTypes: ["string"],
             },
@@ -298,7 +302,11 @@ const DATA: ApiTableSectionProps[] = [
                 name: "endTime",
                 mandatory: true,
                 description: (
-                    <>The ending time of this cell. In {TIME_FORMAT}.</>
+                    <>
+                        The ending time of this cell. In {TIME_FORMAT}.
+                        <b>Note</b>: Duration between start-end should be
+                        multiples of 15
+                    </>
                 ),
                 propTypes: ["string"],
             },

--- a/stories/timetable/props-table.tsx
+++ b/stories/timetable/props-table.tsx
@@ -205,8 +205,9 @@ const DATA: ApiTableSectionProps[] = [
                         The array of row cells to be rendered in this row of
                         data. This component will sort the cells array by start
                         time. If empty and <code>rowMinTime</code> and{" "}
-                        <code>rowMaxTime</code> are not provided, it will be
-                        blocked from start to end.
+                        <code>rowMaxTime</code> are not provided, the row will
+                        be blocked from <code>minTime</code> to{" "}
+                        <code>maxTime</code>.
                     </>
                 ),
                 propTypes: ["TimeTableRowCellData[]"],
@@ -236,11 +237,12 @@ const DATA: ApiTableSectionProps[] = [
                 name: "rowMinTime",
                 description: (
                     <>
-                        The starting time for this row in {TIME_FORMAT}. <br />
+                        The starting time for this row in {TIME_FORMAT}.
                         Defaults to <code>minTime</code>from
                         <code>TimeTableProps</code>.<br />
+                        <br />
                         This component will automatically fill
-                        <code>blocked</code>cells from<code>minTime</code>to
+                        <code>blocked</code>cells from <code>minTime</code> to
                         this time.
                     </>
                 ),
@@ -250,13 +252,13 @@ const DATA: ApiTableSectionProps[] = [
                 name: "rowMaxTime",
                 description: (
                     <>
-                        The ending time in for this row in {TIME_FORMAT}. <br />
+                        The ending time in for this row in {TIME_FORMAT}.
                         Defaults to <code>maxTime</code>from
                         <code>TimeTableProps</code>.<br />
+                        <br />
                         This component will automatically fill
-                        <code>blocked</code>cells till<code>maxTime</code>from
-                        this time. <code>23:59</code> will be interpreted as
-                        00:00 of the next day.
+                        <code>blocked</code>cells till <code>maxTime</code> from
+                        this time.
                     </>
                 ),
                 propTypes: ["string"],
@@ -291,7 +293,7 @@ const DATA: ApiTableSectionProps[] = [
                 mandatory: true,
                 description: (
                     <>
-                        The starting time of this cell. In {TIME_FORMAT}.
+                        The starting time of this cell. In {TIME_FORMAT}.<br />
                         <b>Note</b>: Duration between start-end should be
                         multiples of 15
                     </>
@@ -303,7 +305,7 @@ const DATA: ApiTableSectionProps[] = [
                 mandatory: true,
                 description: (
                     <>
-                        The ending time of this cell. In {TIME_FORMAT}.
+                        The ending time of this cell. In {TIME_FORMAT}.<br />
                         <b>Note</b>: Duration between start-end should be
                         multiples of 15
                     </>

--- a/stories/timetable/timetable-default-data.tsx
+++ b/stories/timetable/timetable-default-data.tsx
@@ -265,7 +265,7 @@ export const timetableDefaultData: TimeTableRowData[] = [
         },
     },
     {
-        name: "sit",
+        name: "No cells",
         rowCells: [],
     },
 ];

--- a/stories/timetable/timetable-default-data.tsx
+++ b/stories/timetable/timetable-default-data.tsx
@@ -264,4 +264,8 @@ export const timetableDefaultData: TimeTableRowData[] = [
             alert(`Clicked on row header for ${rowData.name}`);
         },
     },
+    {
+        name: "sit",
+        rowCells: [],
+    },
 ];

--- a/stories/timetable/timetable-default-data.tsx
+++ b/stories/timetable/timetable-default-data.tsx
@@ -42,7 +42,7 @@ export const timetableDefaultData: TimeTableRowData[] = [
     {
         name: "1 hour intervals",
         rowMinTime: "08:00",
-        rowMaxTime: "21:00",
+        rowMaxTime: "23:59",
         rowCells: [
             {
                 title: "60 mins",
@@ -79,7 +79,7 @@ export const timetableDefaultData: TimeTableRowData[] = [
             },
             {
                 startTime: "18:00",
-                endTime: "20:00",
+                endTime: "23:59",
                 status: "default",
             },
         ],

--- a/stories/timetable/timetable.mdx
+++ b/stories/timetable/timetable.mdx
@@ -8,7 +8,8 @@ import { PropsTable } from "./props-table";
 
 ## Overview
 
-A component that displays a timetable to view a schedule for a specific day
+A component that displays a timetable to view a schedule for a specific day.
+This supports slots in 15 minute intervals only.
 
 ```tsx
 import { TimeTable } from "@lifesg/react-design-system/timetable";

--- a/stories/timetable/timetable.stories.tsx
+++ b/stories/timetable/timetable.stories.tsx
@@ -79,7 +79,7 @@ export const Default: StoryObj<Component> = {
             <StyledTimeTable
                 date={date}
                 minTime={"06:00"}
-                maxTime={"23:00"}
+                maxTime={"23:59"}
                 rowData={results}
                 loading={loading}
                 onNextDayClick={onNextDayClick}

--- a/tests/timetable/timetable.spec.tsx
+++ b/tests/timetable/timetable.spec.tsx
@@ -255,6 +255,32 @@ describe("TimeTable", () => {
 
         expect(await screen.findByTestId("lazy-loader")).toBeInTheDocument();
     });
+
+    it("should render a full bar of blocked slot when row cells are empty and rowMinTime and rowMaxTime are omitted for that row", async () => {
+        render(
+            <TimeTable
+                date={timeTableMockProps.date}
+                rowData={[
+                    {
+                        name: "blocked row",
+                        rowCells: [],
+                    },
+                ]}
+                minTime={"00:00"}
+                maxTime={"23:59"}
+                loading={false}
+                emptyContentMessage={timeTableMockProps.emptyContentMessage}
+                onPreviousDayClick={timeTableMockProps.onPreviousDayClick}
+                onNextDayClick={timeTableMockProps.onNextDayClick}
+            />
+        );
+        const timetableRow = screen.findByTestId("timetable-row");
+        expect(
+            (await timetableRow).querySelectorAll(
+                '[data-testid="block-container"]'
+            ).length
+        ).toBe(1);
+    });
 });
 
 // =============================================================================

--- a/tests/utils/time-helper.spec.ts
+++ b/tests/utils/time-helper.spec.ts
@@ -53,3 +53,143 @@ describe("parseInput tests", () => {
         expect(TimeHelper.parseInput("11111")).toBeUndefined();
     });
 });
+
+describe("roundToNearestInterval tests", () => {
+    it("should return the same time if already aligned with the interval", () => {
+        expect(TimeHelper.roundToNearestInterval("08:00", 15, false)).toBe(
+            "08:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:15", 15, false)).toBe(
+            "08:15"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:00", 15, true)).toBe(
+            "08:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:15", 15, true)).toBe(
+            "08:15"
+        );
+        expect(TimeHelper.roundToNearestInterval("00:45", 45, false)).toBe(
+            "00:45"
+        );
+        expect(TimeHelper.roundToNearestInterval("01:30", 45, false)).toBe(
+            "01:30"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:00", 60, false)).toBe(
+            "08:00"
+        );
+    });
+
+    it("should round down to the previous interval when toNextInterval is false", () => {
+        expect(TimeHelper.roundToNearestInterval("08:03", 15, false)).toBe(
+            "08:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:14", 15, false)).toBe(
+            "08:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:29", 15, false)).toBe(
+            "08:15"
+        );
+        expect(TimeHelper.roundToNearestInterval("00:44", 45, false)).toBe(
+            "00:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("00:55", 45, false)).toBe(
+            "00:45"
+        );
+        expect(TimeHelper.roundToNearestInterval("01:30", 45, false)).toBe(
+            "01:30"
+        );
+    });
+
+    it("should round up to the next interval when toNextInterval is true", () => {
+        expect(TimeHelper.roundToNearestInterval("08:03", 15, true)).toBe(
+            "08:15"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:14", 15, true)).toBe(
+            "08:15"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:29", 15, true)).toBe(
+            "08:30"
+        );
+    });
+
+    it("should handle edge cases like 00:00 and 24:00", () => {
+        expect(TimeHelper.roundToNearestInterval("00:00", 15, false)).toBe(
+            "00:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("00:14", 15, false)).toBe(
+            "00:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("00:14", 15, true)).toBe(
+            "00:15"
+        );
+        expect(TimeHelper.roundToNearestInterval("23:59", 15, true)).toBe(
+            "24:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("23:59", 15, false)).toBe(
+            "23:45"
+        );
+    });
+
+    it("should handle times exceeding 24:00", () => {
+        expect(TimeHelper.roundToNearestInterval("24:01", 15, false)).toBe(
+            "24:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("25:55", 15, true)).toBe(
+            "26:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("27:30", 30, true)).toBe(
+            "27:30"
+        );
+        expect(TimeHelper.roundToNearestInterval("27:45", 30, false)).toBe(
+            "27:30"
+        );
+    });
+
+    it("should handle 1-hour intervals", () => {
+        expect(TimeHelper.roundToNearestInterval("08:30", 60, false)).toBe(
+            "08:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:30", 60, true)).toBe(
+            "09:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("23:59", 60, true)).toBe(
+            "24:00"
+        );
+    });
+
+    it("should throw an error for invalid time formats", () => {
+        expect(() =>
+            TimeHelper.roundToNearestInterval("invalid", 15, true)
+        ).toThrow("Invalid time format");
+        expect(() =>
+            TimeHelper.roundToNearestInterval("25:99", 15, true)
+        ).toThrow("Invalid time format");
+        expect(() =>
+            TimeHelper.roundToNearestInterval("12:60", 15, true)
+        ).toThrow("Invalid time format");
+    });
+
+    it("should handle large intervals (e.g., 120 minutes)", () => {
+        expect(TimeHelper.roundToNearestInterval("08:30", 120, false)).toBe(
+            "08:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:30", 120, true)).toBe(
+            "10:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("23:59", 120, true)).toBe(
+            "24:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("00:15", 480, true)).toBe(
+            "08:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:00", 480, true)).toBe(
+            "08:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("08:15", 480, true)).toBe(
+            "16:00"
+        );
+        expect(TimeHelper.roundToNearestInterval("00:15", 480, false)).toBe(
+            "00:00"
+        );
+    });
+});


### PR DESCRIPTION
Changes

Interpret 23:59 as 24:00 or 00:00 of the next day for time comparisons, and also interpret as ending on the 0th minute

Amend color of the left border for each row to use N5 color

Auto block the entire row from start to end when row cell provided is an empty array and minTime/maxTime are not defined for that row

[delete] branch

Changelog entry

Update row left border color to N5
Interpret 23:59 to be start of next day timing
Auto block entire row if no rowcell provided and no minTime/maxTime provided for that row
Additional information

You may refer to this [BOOKINGSG-7232](https://sgtechstack.atlassian.net/browse/BOOKINGSG-7232)