### PR TITLE
Enhance documentation for component tokens

### DIFF
--- a/src/theme/colour-semantic/theme-helper.ts
+++ b/src/theme/colour-semantic/theme-helper.ts
@@ -5,7 +5,7 @@ import { LifeSGColourSet } from "./specs/lifesg-semantic-tokens";
 import { PAColourSet } from "./specs/pa-semantic-tokens";
 import { SemanticColourCollectionMap } from "./types";
 
-const ColourSpec: ThemeCollectionSpec<
+export const ColourSpec: ThemeCollectionSpec<
     SemanticColourCollectionMap,
     ColourScheme
 > = {

--- a/stories/button/button.mdx
+++ b/stories/button/button.mdx
@@ -34,24 +34,6 @@ apply a red scheme over the buttons.
 
 ## Component tokens
 
-### Overriding
-
-```tsx
-import { LifeSGTheme } from "@lifesg/react-design-system/theme";
-
-const customTheme: ThemeSpec = {
-    ...LifeSGTheme,
-    componentOverrides: {
-        Button: {
-            "button-radius": 15, // specify a custom pixel-based value or Radius token
-            "button-default-colour-bg": Colour["bg-primary"], // specify a Colour token or a custom colour value
-        },
-    },
-};
-```
-
-### Default preset
-
 <Story of={ButtonStories.TokenCustomisation} />
 
 ## Component API

--- a/stories/button/button.stories.tsx
+++ b/stories/button/button.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "src/button";
 import { Container } from "./doc-elements";
-import { TokenTable } from "./tokens-table";
+import { TokensTable } from "./tokens-table";
 
 type Component = typeof Button.Default;
 
@@ -196,5 +196,5 @@ export const DangerLoadingState: StoryObj<Component> = {
 
 export const TokenCustomisation: StoryObj = {
     tags: ["!dev"],
-    render: () => <TokenTable />,
+    render: () => <TokensTable />,
 };

--- a/stories/button/tokens-table.tsx
+++ b/stories/button/tokens-table.tsx
@@ -1,167 +1,70 @@
-import styled, { useTheme } from "styled-components";
-import {
-    ThemeButton,
-    getTokenValue,
-} from "../../src/theme/components/theme-helper";
-import { ButtonTokens } from "../../src/theme/components/types";
-import { ApiTable, ApiTableSectionProps } from "../storybook-common";
+import { ThemeButton } from "src/theme/components/theme-helper";
+import { TokenTable, TokenTableSectionProps } from "../storybook-common";
 
-const ButtonToken = ({ token }: { token: keyof ButtonTokens }) => {
-    const theme = useTheme();
-    switch (token) {
-        case "button-radius":
-            return (
-                <SwatchItem key={token}>
-                    <Reference>{ThemeButton[token]({ theme })}</Reference>
-                    <div>
-                        <RadiusExample
-                            $radius={getTokenValue(ThemeButton[token], {
-                                theme,
-                            })}
-                        />
-                    </div>
-                </SwatchItem>
-            );
-        default:
-            return (
-                <Swatch>
-                    <SwatchItem key={token}>
-                        <Reference>{ThemeButton[token]({ theme })}</Reference>
-                        <SwatchColour
-                            $colour={getTokenValue(ThemeButton[token], {
-                                theme,
-                            })}
-                        />
-                    </SwatchItem>
-                </Swatch>
-            );
-    }
-};
-
-const DATA: ApiTableSectionProps[] = [
+const DATA: TokenTableSectionProps[] = [
     {
         attributes: [
             {
                 name: "button-radius",
                 description: "The radius of the button",
-                propTypes: [],
-                defaultValue: <ButtonToken token={"button-radius"} />,
+                defaultValue: {
+                    type: "default",
+                    token: ThemeButton["button-radius"],
+                },
             },
             {
                 name: "button-default-colour-bg",
-                description:
-                    "The background color of the button in its default style",
-                propTypes: [],
-                defaultValue: (
-                    <ButtonToken token={"button-default-colour-bg"} />
-                ),
-            },
-            {
-                name: "button-default-colour-text",
-                description:
-                    "The text color of the button in its default style",
-                propTypes: [],
-                defaultValue: (
-                    <ButtonToken token={"button-default-colour-text"} />
-                ),
+                description: "The background colour of the default button",
+                defaultValue: {
+                    type: "colour-token",
+                    token: ThemeButton["button-default-colour-bg"],
+                },
             },
             {
                 name: "button-default-colour-bg-hover",
-                description: "The background color of the button when hovered",
-                propTypes: [],
-                defaultValue: (
-                    <ButtonToken token={"button-default-colour-bg-hover"} />
-                ),
-            },
-            {
-                name: "button-secondary-colour-text",
                 description:
-                    "The text color of the button in its secondary style",
-                propTypes: [],
-                defaultValue: (
-                    <ButtonToken token={"button-secondary-colour-text"} />
-                ),
+                    "The background colour of the default button when hovered",
+                defaultValue: {
+                    type: "colour-token",
+                    token: ThemeButton["button-default-colour-bg-hover"],
+                },
             },
             {
-                name: "button-light-colour-text",
-                description: "The text color of the button in its light style",
-                propTypes: [],
-                defaultValue: (
-                    <ButtonToken token={"button-light-colour-text"} />
-                ),
+                name: "button-default-colour-text",
+                description: "The text colour of the default button",
+                defaultValue: {
+                    type: "colour-token",
+                    token: ThemeButton["button-default-colour-text"],
+                },
             },
             {
                 name: "button-secondary-colour-border",
-                description:
-                    "The border color of the button in its secondary style",
-                propTypes: [],
-                defaultValue: (
-                    <ButtonToken token={"button-secondary-colour-border"} />
-                ),
+                description: "The border colour of the secondary button",
+                defaultValue: {
+                    type: "colour-token",
+                    token: ThemeButton["button-secondary-colour-border"],
+                },
+            },
+            {
+                name: "button-secondary-colour-text",
+                description: "The text colour of the secondary button",
+                defaultValue: {
+                    type: "colour-token",
+                    token: ThemeButton["button-secondary-colour-text"],
+                },
+            },
+            {
+                name: "button-light-colour-text",
+                description: "The text colour of the light button",
+                defaultValue: {
+                    type: "colour-token",
+                    token: ThemeButton["button-light-colour-text"],
+                },
             },
         ],
     },
 ];
 
-export const TokenTable = () => {
-    return <ApiTable sections={DATA} />;
+export const TokensTable = () => {
+    return <TokenTable sections={DATA} />;
 };
-
-// =============================================================================
-// STYLE INTERFACE
-// =============================================================================
-interface SwatchColourProps {
-    $colour: string;
-}
-
-interface RadiusStyleProps {
-    $radius: string;
-}
-
-const Swatch = styled.ul`
-    display: flex;
-    flex-direction: column;
-    margin: 0;
-    padding: 0;
-    gap: 0.25rem;
-`;
-
-const SwatchItem = styled.li`
-    display: flex;
-    justify-items: "";
-    align-items: center;
-    gap: 0.5rem;
-`;
-
-const SwatchColour = styled.div<SwatchColourProps>`
-    flex-shrink: 0;
-    height: 1.5rem;
-    width: 1.5rem;
-    box-shadow: rgba(0, 0, 0, 0.1) 0 1px 3px 0;
-    border: 1px solid rgba(0, 0, 0, 0.1);
-    border-radius: 4px;
-    background: repeating-linear-gradient(
-        135deg,
-        #edefef 0px,
-        #edefef 10px,
-        #dde1e2 10px,
-        #dde1e2 20px
-    );
-    background: ${(props) => props.$colour};
-`;
-
-const Reference = styled.div`
-    font-family: monospace;
-    font-size: 0.875rem;
-    border-radius: 4px;
-    padding: 0 0.5rem;
-    color: #787878;
-    width: 6rem;
-`;
-
-const RadiusExample = styled.div<RadiusStyleProps>`
-    height: 48px;
-    width: 128px;
-    background: ${ThemeButton["button-default-colour-bg"]};
-    border-radius: ${(props) => props.$radius};
-`;

--- a/stories/storybook-common/api-table/api-table-components.tsx
+++ b/stories/storybook-common/api-table/api-table-components.tsx
@@ -1,6 +1,5 @@
-import React from "react";
 import styled, { css } from "styled-components";
-import { V2_Color } from "../../../src/v2_color";
+import { DocTable } from "../doc-table";
 import { DefaultColProps, DescriptionColProps } from "./types";
 
 // =============================================================================
@@ -25,45 +24,7 @@ export const Table = ({ children }: TableProps) => {
     );
 };
 
-const StyledTable = styled.table`
-    width: 100%;
-    position: relative;
-    border-collapse: collapse;
-    border-spacing: 0;
-    line-height: 1.5;
-
-    a {
-        color: ${V2_Color.Primary};
-        cursor: pointer;
-        text-decoration: none;
-    }
-
-    code {
-        background-color: #f5f5f5;
-        color: #d0021b;
-        font-family: monospace;
-        font-size: 0.725rem;
-        font-weight: 400;
-        padding: 0.25rem 0.5rem;
-        white-space: pre-wrap;
-    }
-
-    td,
-    th {
-        font-family: "Nunito Sans", -apple-system, ".SFNSText-Regular",
-            "San Francisco", BlinkMacSystemFont, "Segoe UI", "Helvetica Neue",
-            Helvetica, Arial, sans-serif;
-        padding: 0.5rem;
-        font-size: 0.875rem;
-        text-align: left;
-        vertical-align: top;
-    }
-
-    thead,
-    th {
-        font-weight: bold;
-    }
-
+const StyledTable = styled(DocTable)`
     td {
         :first-child {
             width: 20%;
@@ -71,26 +32,6 @@ const StyledTable = styled.table`
 
         :last-child {
             width: 20%;
-        }
-    }
-
-    tbody {
-        tr {
-            border: none;
-            border-bottom: 1px solid ${V2_Color.Neutral[6]};
-            :nth-child(even) {
-                background: ${V2_Color.Neutral[7]};
-            }
-        }
-    }
-
-    thead {
-        tr {
-            border-bottom: 2px solid ${V2_Color.Primary};
-        }
-
-        th {
-            color: ${V2_Color.Primary};
         }
     }
 `;
@@ -110,7 +51,7 @@ export const Section = ({ children }: SectionProps) => (
 );
 
 const SectionRow = styled.tr`
-    background: ${V2_Color.Neutral[3]} !important;
+    background: #686868 !important;
     color: white;
     font-weight: bold;
 `;
@@ -143,7 +84,7 @@ const Label = styled.td<NameColStyleProps>`
     ${(props) => {
         if (props.$isFunction) {
             return css`
-                color: ${V2_Color.PrimaryDark};
+                color: #1768be;
             `;
         }
     }}
@@ -153,13 +94,13 @@ const Mandatory = styled.td<NameColStyleProps>`
     font-weight: bold;
     :after {
         content: " *";
-        color: ${V2_Color.Validation.Red.Text};
+        color: #9e130f;
     }
 
     ${(props) => {
         if (props.$isFunction) {
             return css`
-                color: ${V2_Color.PrimaryDark};
+                color: #1768be;
             `;
         }
     }}

--- a/stories/storybook-common/doc-table.tsx
+++ b/stories/storybook-common/doc-table.tsx
@@ -1,11 +1,11 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
-export const DocTable = styled.table`
-    width: 100%;
-    position: relative;
-    border-collapse: collapse;
-    border-spacing: 0;
-    line-height: 1.5;
+export const DocTextStyle = css`
+    font-family: "Nunito Sans", -apple-system, ".SFNSText-Regular",
+        "San Francisco", BlinkMacSystemFont, "Segoe UI", "Helvetica Neue",
+        Helvetica, Arial, sans-serif;
+    font-size: 0.875rem;
+    color: #2e3438;
 
     a {
         color: #1768be;
@@ -22,14 +22,20 @@ export const DocTable = styled.table`
         padding: 0.25rem 0.5rem;
         white-space: pre-wrap;
     }
+`;
+
+export const DocTable = styled.table`
+    width: 100%;
+    position: relative;
+    border-collapse: collapse;
+    border-spacing: 0;
+    line-height: 1.5;
+
+    ${DocTextStyle}
 
     td,
     th {
-        font-family: "Nunito Sans", -apple-system, ".SFNSText-Regular",
-            "San Francisco", BlinkMacSystemFont, "Segoe UI", "Helvetica Neue",
-            Helvetica, Arial, sans-serif;
         padding: 0.5rem;
-        font-size: 0.875rem;
         text-align: left;
         vertical-align: top;
     }

--- a/stories/storybook-common/doc-table.tsx
+++ b/stories/storybook-common/doc-table.tsx
@@ -1,0 +1,61 @@
+import styled from "styled-components";
+
+export const DocTable = styled.table`
+    width: 100%;
+    position: relative;
+    border-collapse: collapse;
+    border-spacing: 0;
+    line-height: 1.5;
+
+    a {
+        color: #1768be;
+        cursor: pointer;
+        text-decoration: none;
+    }
+
+    code {
+        background-color: #f5f5f5;
+        color: #d0021b;
+        font-family: monospace;
+        font-size: 0.725rem;
+        font-weight: 400;
+        padding: 0.25rem 0.5rem;
+        white-space: pre-wrap;
+    }
+
+    td,
+    th {
+        font-family: "Nunito Sans", -apple-system, ".SFNSText-Regular",
+            "San Francisco", BlinkMacSystemFont, "Segoe UI", "Helvetica Neue",
+            Helvetica, Arial, sans-serif;
+        padding: 0.5rem;
+        font-size: 0.875rem;
+        text-align: left;
+        vertical-align: top;
+    }
+
+    thead,
+    th {
+        font-weight: bold;
+    }
+
+    tbody {
+        tr {
+            border: none;
+            border-bottom: 1px solid #dde1e2;
+            :nth-child(even) {
+                background: #f9f9f9;
+            }
+        }
+    }
+
+    thead {
+        tr {
+            border-bottom: 2px solid #1768be;
+        }
+
+        th {
+            color: #1768be;
+        }
+    }
+`;

--- a/stories/storybook-common/index.ts
+++ b/stories/storybook-common/index.ts
@@ -5,3 +5,4 @@ export * from "./story-container";
 export * from "./storybook-link";
 export * from "./tabs";
 export * from "./token-inspector";
+export * from "./token-table";

--- a/stories/storybook-common/index.ts
+++ b/stories/storybook-common/index.ts
@@ -4,3 +4,4 @@ export * from "./preview-box";
 export * from "./story-container";
 export * from "./storybook-link";
 export * from "./tabs";
+export * from "./token-inspector";

--- a/stories/storybook-common/token-inspector.tsx
+++ b/stories/storybook-common/token-inspector.tsx
@@ -1,0 +1,78 @@
+import { PrimitiveColourSet, SemanticColourSet } from "src/theme";
+import { ColourSpec as PrimitiveColourSpec } from "src/theme/colour-primitive/theme-helper";
+import { ColourSpec as SematicColourSpec } from "src/theme/colour-semantic/theme-helper";
+import { DefaultTheme } from "styled-components";
+
+/**
+ * Inspect the name of the colour token that was accessed
+ *
+ * Usage:
+ * ```
+ * ColourTokenInspector.from(theme).inspect(callback)
+ * ```
+ */
+export class ColourTokenInspector {
+    private primitiveOriginal!: PrimitiveColourSet;
+    private primitiveColourToken!: string | undefined;
+    private semanticOriginal!: SemanticColourSet;
+    private semanticColourToken!: string | undefined;
+
+    private constructor(private theme: DefaultTheme) {}
+
+    public static from(theme: DefaultTheme) {
+        return new ColourTokenInspector(theme);
+    }
+
+    public inspect<T>(fn: () => T) {
+        this.setup();
+        const result = fn();
+        const { primitive, semantic } = this.get();
+        this.cleanup();
+
+        return { primitive, semantic, result };
+    }
+
+    public setup() {
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
+        const self = this;
+
+        const scheme = this.theme.colourScheme;
+
+        this.primitiveOriginal = PrimitiveColourSpec.collections[scheme];
+        const primitiveProxy = {
+            get(target: PrimitiveColourSet, prop: keyof PrimitiveColourSet) {
+                self.primitiveColourToken = prop;
+                return target[prop];
+            },
+        };
+        PrimitiveColourSpec.collections[scheme] = new Proxy(
+            this.primitiveOriginal,
+            primitiveProxy
+        );
+
+        this.semanticOriginal = SematicColourSpec.collections[scheme];
+        const semanticProxy = {
+            get(target: SemanticColourSet, prop: keyof SemanticColourSet) {
+                self.semanticColourToken = prop;
+                return target[prop];
+            },
+        };
+        SematicColourSpec.collections[scheme] = new Proxy(
+            this.semanticOriginal,
+            semanticProxy
+        );
+    }
+
+    public get() {
+        return {
+            primitive: this.primitiveColourToken,
+            semantic: this.semanticColourToken,
+        };
+    }
+
+    public cleanup() {
+        const scheme = this.theme.colourScheme;
+        PrimitiveColourSpec.collections[scheme] = this.primitiveOriginal;
+        SematicColourSpec.collections[scheme] = this.semanticOriginal;
+    }
+}

--- a/stories/storybook-common/token-table/index.ts
+++ b/stories/storybook-common/token-table/index.ts
@@ -1,0 +1,2 @@
+export * from "./token-table";
+export * from "./types";

--- a/stories/storybook-common/token-table/token-table-components.tsx
+++ b/stories/storybook-common/token-table/token-table-components.tsx
@@ -1,12 +1,23 @@
 import React from "react";
 import { StyledComponentProps } from "src/theme/helpers";
 import styled, { DefaultTheme, useTheme } from "styled-components";
-import { DocTable } from "../doc-table";
+import { DocTable, DocTextStyle } from "../doc-table";
 import { ColourTokenInspector } from "../token-inspector";
 import {
     TokenTableDefaultValueColourTokenProps,
     TokenTableDefaultValueDefaultProps,
 } from "./types";
+
+export const Usage = styled.div`
+    margin: 16px 0;
+    ${DocTextStyle}
+
+    svg {
+        width: 0.75lh;
+        height: 0.75lh;
+        vertical-align: middle;
+    }
+`;
 
 // =============================================================================
 // TABLE

--- a/stories/storybook-common/token-table/token-table-components.tsx
+++ b/stories/storybook-common/token-table/token-table-components.tsx
@@ -1,0 +1,207 @@
+import React from "react";
+import { StyledComponentProps } from "src/theme/helpers";
+import styled, { DefaultTheme, useTheme } from "styled-components";
+import { DocTable } from "../doc-table";
+import { ColourTokenInspector } from "../token-inspector";
+import {
+    TokenTableDefaultValueColourTokenProps,
+    TokenTableDefaultValueDefaultProps,
+} from "./types";
+
+// =============================================================================
+// TABLE
+// =============================================================================
+interface TableProps {
+    children: JSX.Element | JSX.Element[];
+}
+
+export const Table = ({ children }: TableProps) => {
+    return (
+        <StyledTable>
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Description</th>
+                    <th>Default value</th>
+                </tr>
+            </thead>
+            <tbody>{children}</tbody>
+        </StyledTable>
+    );
+};
+
+const StyledTable = styled(DocTable)`
+    td {
+        :first-child {
+            width: 20%;
+        }
+
+        :last-child {
+            width: 25%;
+        }
+    }
+`;
+
+// =============================================================================
+// SECTION
+// =============================================================================
+
+interface SectionProps {
+    children: string;
+}
+
+export const Section = ({ children }: SectionProps) => (
+    <SectionRow>
+        <td colSpan={3}>{children}</td>
+    </SectionRow>
+);
+
+const SectionRow = styled.tr`
+    background: #686868 !important;
+    color: white;
+    font-weight: bold;
+`;
+
+// =============================================================================
+// NAME COLUMN
+// =============================================================================
+interface NameColProps {
+    children: string;
+}
+
+export const NameCol = ({ children }: NameColProps) => {
+    return (
+        <td>
+            <Label>{children}</Label>
+        </td>
+    );
+};
+
+const Label = styled.div`
+    font-weight: bold;
+    color: #333333;
+`;
+
+// =============================================================================
+// DESCRIPTION COLUMN
+// =============================================================================
+interface DescriptionColProps {
+    children: React.ReactNode;
+}
+
+export const DescriptionCol = ({ children }: DescriptionColProps) => {
+    return (
+        <td>
+            <Description>{children}</Description>
+        </td>
+    );
+};
+
+const Description = styled.div`
+    color: #333333;
+
+    code {
+        :not(:last-child) {
+            margin-right: 0.25rem;
+        }
+    }
+`;
+
+// =============================================================================
+// DEFAULT VALUE COLUMN
+// =============================================================================
+interface DefaultColProps {
+    attributes?:
+        | TokenTableDefaultValueColourTokenProps
+        | TokenTableDefaultValueDefaultProps
+        | undefined;
+}
+
+interface SwatchColourProps {
+    $colour: string;
+}
+
+export const DefaultCol = ({ attributes }: DefaultColProps) => {
+    const theme = useTheme();
+
+    if (!attributes) {
+        return (
+            <td>
+                <Default>
+                    <code>-</code>
+                </Default>
+            </td>
+        );
+    }
+
+    if (attributes.type === "colour-token") {
+        const {
+            primitive,
+            semantic,
+            result: value,
+        } = ColourTokenInspector.from(theme).inspect(
+            () => getTokenValue(attributes.token, theme) as string
+        );
+
+        const display = semantic
+            ? `Colour["${semantic}"]`
+            : primitive
+            ? `Colour.Primitive["${primitive}"]`
+            : value;
+
+        return (
+            <td>
+                <Default>
+                    <SwatchColour $colour={value} />
+                    <code>{display}</code>
+                </Default>
+            </td>
+        );
+    } else {
+        const value = getTokenValue(attributes.token, theme);
+
+        return (
+            <td>
+                <Default>
+                    <code>{value}</code>
+                </Default>
+            </td>
+        );
+    }
+};
+
+const getTokenValue = (
+    token: string | number | ((props: StyledComponentProps) => string | number),
+    theme: DefaultTheme
+): string | number => {
+    if (typeof token === "function") {
+        return getTokenValue(token({ theme }), theme);
+    }
+
+    return token;
+};
+
+const Default = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    color: #333333;
+`;
+
+const SwatchColour = styled.div<SwatchColourProps>`
+    flex-shrink: 0;
+    height: 1.5rem;
+    width: 1.5rem;
+    box-shadow: rgba(0, 0, 0, 0.1) 0 1px 3px 0;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    border-radius: 4px;
+    background: repeating-linear-gradient(
+        135deg,
+        #edefef 0px,
+        #edefef 10px,
+        #dde1e2 10px,
+        #dde1e2 20px
+    );
+    background: ${(props) => props.$colour};
+
+    margin-right: 4px;
+`;

--- a/stories/storybook-common/token-table/token-table.tsx
+++ b/stories/storybook-common/token-table/token-table.tsx
@@ -1,11 +1,14 @@
+import { DocIcon } from "@lifesg/react-icons/doc";
 import { Unstyled } from "@storybook/blocks";
 import { Fragment } from "react";
+import { StorybookLink } from "../storybook-link";
 import {
     DefaultCol,
     DescriptionCol,
     NameCol,
     Section,
     Table,
+    Usage,
 } from "./token-table-components";
 import { TokenTableAttributeRowProps, TokenTableProps } from "./types";
 
@@ -41,8 +44,17 @@ export const TokenTable = (props: TokenTableProps): JSX.Element => {
     };
 
     return (
-        <Unstyled style={{ width: "100%" }}>
-            <Table>{renderContents()}</Table>
-        </Unstyled>
+        <>
+            <Usage>
+                For more information on usage, refer to the{" "}
+                <StorybookLink path="/docs/foundations-component-tokens-introduction--docs">
+                    <DocIcon /> documentation
+                </StorybookLink>
+                .
+            </Usage>
+            <Unstyled style={{ width: "100%" }}>
+                <Table>{renderContents()}</Table>
+            </Unstyled>
+        </>
     );
 };

--- a/stories/storybook-common/token-table/token-table.tsx
+++ b/stories/storybook-common/token-table/token-table.tsx
@@ -1,0 +1,48 @@
+import { Unstyled } from "@storybook/blocks";
+import { Fragment } from "react";
+import {
+    DefaultCol,
+    DescriptionCol,
+    NameCol,
+    Section,
+    Table,
+} from "./token-table-components";
+import { TokenTableAttributeRowProps, TokenTableProps } from "./types";
+
+export const TokenTable = (props: TokenTableProps): JSX.Element => {
+    const renderSection = (
+        attributes: TokenTableAttributeRowProps[],
+        sectionIndex: number
+    ) => {
+        return attributes.map((attribute, index) => {
+            return (
+                <tr key={`${sectionIndex}-${index}`}>
+                    <NameCol>{attribute.name}</NameCol>
+                    <DescriptionCol>{attribute.description}</DescriptionCol>
+                    <DefaultCol attributes={attribute.defaultValue} />
+                </tr>
+            );
+        });
+    };
+
+    const renderContents = () => {
+        return props.sections.map((section, index) => {
+            return (
+                <Fragment key={index}>
+                    {section.name && (
+                        <Section key={`section-${index + 1}`}>
+                            {section.name}
+                        </Section>
+                    )}
+                    {renderSection(section.attributes, index)}
+                </Fragment>
+            );
+        });
+    };
+
+    return (
+        <Unstyled style={{ width: "100%" }}>
+            <Table>{renderContents()}</Table>
+        </Unstyled>
+    );
+};

--- a/stories/storybook-common/token-table/types.ts
+++ b/stories/storybook-common/token-table/types.ts
@@ -1,0 +1,29 @@
+import { ThemeStyleProps } from "src/theme";
+
+export interface TokenTableAttributeRowProps {
+    name: string;
+    description: React.ReactNode;
+    defaultValue?:
+        | TokenTableDefaultValueColourTokenProps
+        | TokenTableDefaultValueDefaultProps
+        | undefined;
+}
+
+export interface TokenTableDefaultValueColourTokenProps {
+    type: "colour-token";
+    token: (props: ThemeStyleProps) => string;
+}
+
+export interface TokenTableDefaultValueDefaultProps {
+    type: "default";
+    token: (props: ThemeStyleProps) => string;
+}
+
+export interface TokenTableSectionProps {
+    name?: string | undefined;
+    attributes: TokenTableAttributeRowProps[];
+}
+
+export interface TokenTableProps {
+    sections: TokenTableSectionProps[];
+}

--- a/stories/theme/component/a-component-token-introduction.mdx
+++ b/stories/theme/component/a-component-token-introduction.mdx
@@ -5,8 +5,8 @@ import { DocInfo, DocNote } from "stories/storybook-common";
 
 # Component tokens
 
-Some components offer limited style customisation on the theme level. For more
-information, refer to their respective docs.
+Some components offer limited style customisation on the theme level. For
+details on what can be overridden, refer to their respective docs.
 
 Supported components:
 

--- a/stories/theme/component/a-component-token-introduction.mdx
+++ b/stories/theme/component/a-component-token-introduction.mdx
@@ -1,0 +1,64 @@
+import { Meta } from "@storybook/blocks";
+import { DocInfo, DocNote } from "stories/storybook-common";
+
+<Meta title="Foundations/Component tokens/Introduction" />
+
+# Component tokens
+
+Some components offer limited style customisation on the theme level. For more
+information, refer to their respective docs.
+
+Supported components:
+
+-   [Button](/docs/selection-and-input-button-base--docs#component-tokens)
+
+## Usage
+
+Component tokens can be selectively customised by setting `componentOverrides`.
+
+```tsx
+import { LifeSGTheme } from "@lifesg/react-design-system/theme";
+
+const customTheme: ThemeSpec = {
+    ...LifeSGTheme,
+    componentOverrides: {
+        Button: {
+            "button-radius": 15,
+            "button-default-colour-bg": Colour["bg-primary"],
+        },
+    },
+};
+
+<ThemeProvider theme={customTheme}>
+    <App />
+</ThemeProvider>;
+```
+
+You can nest `ThemeProvider`s; a component will pick up the theme from the
+nearest `ThemeProvider` ancestor. This is useful if you need to customise
+component tokens only in a specific context.
+
+In this example, the first button follows the default colours, while the second
+button has the custom styling.
+
+```tsx
+import { LifeSGTheme } from "@lifesg/react-design-system/theme";
+
+const customTheme: ThemeSpec = {
+    ...LifeSGTheme,
+    componentOverrides: {
+        Button: {
+            "button-default-colour-bg": "#fab",
+        },
+    },
+};
+
+const App = (
+    <ThemeProvider theme={LifeSGTheme}>
+        <Button />
+        <ThemeProvider theme={customTheme}>
+            <Button />
+        </ThemeProvider>
+    </ThemeProvider>
+);
+```


### PR DESCRIPTION
**Changes**

- Add common table in preparation for future component tokens
  - supports automatic swatching of colour tokens
  - extract a util to detect the semantic/primitive token that is used
- Add introductory section on usage of component tokens on the theme level
- [delete] branch