### PR TITLE
Enhancements to Tab

### DIFF
--- a/src/tab/tab-link-chain.style.tsx
+++ b/src/tab/tab-link-chain.style.tsx
@@ -45,6 +45,7 @@ export const Chain = styled.ul<ChainStyleProps>`
 
 export const ChainItem = styled.li<ChainItemStyleProps>`
     display: flex;
+    justify-content: center;
     flex-shrink: 0;
     border-bottom: ${Border["width-040"]} ${Border.solid} ${Colour.border};
 
@@ -52,7 +53,6 @@ export const ChainItem = styled.li<ChainItemStyleProps>`
         if (props.$width) {
             return css`
                 width: ${props.$width};
-                justify-content: center;
             `;
         }
     }}

--- a/src/tab/tab-link-chain.style.tsx
+++ b/src/tab/tab-link-chain.style.tsx
@@ -16,6 +16,7 @@ interface ChainStyleProps {
 
 interface ChainItemStyleProps {
     $active?: boolean;
+    $width?: string;
 }
 
 // =============================================================================
@@ -46,6 +47,15 @@ export const ChainItem = styled.li<ChainItemStyleProps>`
     display: flex;
     flex-shrink: 0;
     border-bottom: ${Border["width-040"]} ${Border.solid} ${Colour.border};
+
+    ${(props) => {
+        if (props.$width) {
+            return css`
+                width: ${props.$width};
+                justify-content: center;
+            `;
+        }
+    }}
 
     ${(props) => {
         if (props.$active) {

--- a/src/tab/tab-link-chain.tsx
+++ b/src/tab/tab-link-chain.tsx
@@ -1,5 +1,8 @@
 import { useContext, useRef } from "react";
 import { useMediaQuery } from "react-responsive";
+import { useTheme } from "styled-components";
+import { ResizeCallbackParams } from "../shared/fade-wrapper";
+import { Breakpoint } from "../theme";
 import { TabContext } from "./tab-context";
 import {
     BoldLabel,
@@ -9,11 +12,8 @@ import {
     CustomFadeWrapper,
     Label,
 } from "./tab-link-chain.style";
-import { ResizeCallbackParams } from "../shared/fade-wrapper";
-import { Breakpoint } from "../theme";
-import { useTheme } from "styled-components";
 
-interface Props {
+export interface TabLinkChainProps {
     controlledMode?: boolean | undefined;
     "data-testid"?: string | undefined;
     onTabClick?: ((title: string, order: number) => void) | undefined;
@@ -25,7 +25,7 @@ export const TabLinkChain = ({
     "data-testid": testId,
     onTabClick,
     fullWidthIndicatorLine,
-}: Props) => {
+}: TabLinkChainProps) => {
     // =========================================================================
     // CONST, STATE, REFS
     // =========================================================================
@@ -99,6 +99,7 @@ export const TabLinkChain = ({
                             role="none"
                             $active={isActive}
                             ref={isActive ? activeLinkRef : null}
+                            $width={linkChain.width}
                         >
                             <ChainLink
                                 role="tab"

--- a/src/tab/tab-link-chain.tsx
+++ b/src/tab/tab-link-chain.tsx
@@ -12,12 +12,14 @@ import {
     CustomFadeWrapper,
     Label,
 } from "./tab-link-chain.style";
+import { TabProps } from "./types";
 
-export interface TabLinkChainProps {
+interface Props
+    extends Pick<
+        TabProps,
+        "fullWidthIndicatorLine" | "onTabClick" | "data-testid"
+    > {
     controlledMode?: boolean | undefined;
-    "data-testid"?: string | undefined;
-    onTabClick?: ((title: string, order: number) => void) | undefined;
-    fullWidthIndicatorLine?: boolean | undefined;
 }
 
 export const TabLinkChain = ({
@@ -25,7 +27,7 @@ export const TabLinkChain = ({
     "data-testid": testId,
     onTabClick,
     fullWidthIndicatorLine,
-}: TabLinkChainProps) => {
+}: Props) => {
     // =========================================================================
     // CONST, STATE, REFS
     // =========================================================================

--- a/src/tab/tab.tsx
+++ b/src/tab/tab.tsx
@@ -10,7 +10,7 @@ import { TabContext } from "./tab-context";
 import { TabItem } from "./tab-item";
 import { TabLinkChain } from "./tab-link-chain";
 import { Wrapper } from "./tab.style";
-import { TabItemProps, TabProps } from "./types";
+import { TabItemProps, TabLinkProps, TabProps } from "./types";
 
 // =============================================================================
 // COMPONENT
@@ -37,8 +37,8 @@ const TabBase = ({
         ) as ReactElement<TabItemProps>[];
 
         return validChildren.map((child) => {
-            return { title: child.props.title };
-        });
+            return { title: child.props.title, width: child.props.width };
+        }) as TabLinkProps[];
     }, [children]);
 
     // =========================================================================

--- a/src/tab/tab.tsx
+++ b/src/tab/tab.tsx
@@ -3,13 +3,14 @@ import {
     ReactElement,
     cloneElement,
     useEffect,
+    useMemo,
     useState,
 } from "react";
 import { TabContext } from "./tab-context";
 import { TabItem } from "./tab-item";
 import { TabLinkChain } from "./tab-link-chain";
 import { Wrapper } from "./tab.style";
-import { TabItemProps, TabLinkProps, TabProps } from "./types";
+import { TabItemProps, TabProps } from "./types";
 
 // =============================================================================
 // COMPONENT
@@ -29,34 +30,25 @@ const TabBase = ({
     const [currentActive, setCurrentActive] = useState<number>(
         currentActiveIndex || initialActive
     );
-    const [tabLinks, setTabLinks] = useState<TabLinkProps[]>([]);
 
-    // =========================================================================
-    // EFFECTS
-    // =========================================================================
-    useEffect(() => {
+    const tabLinks = useMemo(() => {
         const validChildren = Children.toArray(children).filter(
             Boolean
         ) as ReactElement<TabItemProps>[];
-        updateTabLinks(validChildren);
+
+        return validChildren.map((child) => {
+            return { title: child.props.title };
+        });
     }, [children]);
 
+    // =========================================================================
+    // Effects
+    // =========================================================================
     useEffect(() => {
         if (typeof currentActiveIndex === "number") {
             setCurrentActive(currentActiveIndex);
         }
     }, [currentActiveIndex]);
-
-    // =========================================================================
-    // HELPER FUNCTIONS
-    // =========================================================================
-    const updateTabLinks = (children: ReactElement<TabItemProps>[]) => {
-        const tabLinks: TabLinkProps[] = children.map((child) => {
-            return { title: child.props.title };
-        });
-
-        setTabLinks(tabLinks);
-    };
 
     // =========================================================================
     // RENDER FUNCTIONS
@@ -65,6 +57,7 @@ const TabBase = ({
         const validChildren = Children.toArray(children).filter(Boolean);
 
         return validChildren.map((child, index) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             return cloneElement(child as ReactElement<any>, {
                 key: index,
                 index,

--- a/src/tab/types.ts
+++ b/src/tab/types.ts
@@ -1,10 +1,4 @@
-import { TabLinkChainProps } from "./tab-link-chain";
-
-export interface TabProps
-    extends Pick<
-        TabLinkChainProps,
-        "fullWidthIndicatorLine" | "onTabClick" | "data-testid"
-    > {
+export interface TabProps {
     children: JSX.Element | JSX.Element[];
     /** Specify the initial tab index that is to be displayed */
     initialActive?: number | undefined;
@@ -15,6 +9,9 @@ export interface TabProps
     currentActive?: number;
     className?: string | undefined;
     id?: string | undefined;
+    "data-testid"?: string | undefined;
+    onTabClick?: ((title: string, index: number) => void) | undefined;
+    fullWidthIndicatorLine?: boolean | undefined;
 }
 
 export interface TabItemProps {

--- a/src/tab/types.ts
+++ b/src/tab/types.ts
@@ -1,4 +1,10 @@
-export interface TabProps {
+import { TabLinkChainProps } from "./tab-link-chain";
+
+export interface TabProps
+    extends Pick<
+        TabLinkChainProps,
+        "fullWidthIndicatorLine" | "onTabClick" | "data-testid"
+    > {
     children: JSX.Element | JSX.Element[];
     /** Specify the initial tab index that is to be displayed */
     initialActive?: number | undefined;
@@ -9,9 +15,6 @@ export interface TabProps {
     currentActive?: number;
     className?: string | undefined;
     id?: string | undefined;
-    "data-testid"?: string | undefined;
-    onTabClick?: ((title: string, index: number) => void) | undefined;
-    fullWidthIndicatorLine?: boolean | undefined;
 }
 
 export interface TabItemProps {
@@ -20,9 +23,11 @@ export interface TabItemProps {
     className?: string | undefined;
     id?: string | undefined;
     "data-testid"?: string | undefined;
+    width?: string | undefined;
 }
 
 export interface TabLinkProps {
     title: string;
     counter?: number | undefined;
+    width?: string | undefined;
 }

--- a/stories/tab/props-table.tsx
+++ b/stories/tab/props-table.tsx
@@ -89,6 +89,11 @@ const TAB_ITEM_DATA: ApiTableSectionProps[] = [
                 description: "The test identifier for the component",
                 propTypes: ["string"],
             },
+            {
+                name: "width",
+                description: "The tab selector width",
+                propTypes: ["string"],
+            },
         ],
     },
 ];

--- a/stories/tab/tab.mdx
+++ b/stories/tab/tab.mdx
@@ -46,6 +46,13 @@ If you want the bottom border to extend to the full container, use the `fullWidt
 
 <Canvas of={TabStories.FullWidthIndicatorLine} />
 
+## Override tab width and Center tab label
+
+If you want to specify the width of a tab, use the `overrideTabWidth` prop (eg: "50%", "100px").
+If you want to center the label of a tab within the specified width, use the `centerTabLabel` prop.
+
+<Canvas of={TabStories.OverrideTabWidthAndCenterTabLabel} />
+
 ## Component API
 
 <PropsTable />

--- a/stories/tab/tab.mdx
+++ b/stories/tab/tab.mdx
@@ -46,12 +46,11 @@ If you want the bottom border to extend to the full container, use the `fullWidt
 
 <Canvas of={TabStories.FullWidthIndicatorLine} />
 
-## Override tab width and Center tab label
+## Custom tab width
 
-If you want to specify the width of a tab, use the `overrideTabWidth` prop (eg: "50%", "100px").
-If you want to center the label of a tab within the specified width, use the `centerTabLabel` prop.
+To specify the width of a tab item, set the `width` prop.
 
-<Canvas of={TabStories.OverrideTabWidthAndCenterTabLabel} />
+<Canvas of={TabStories.CustomTabWidth} />
 
 ## Component API
 

--- a/stories/tab/tab.stories.tsx
+++ b/stories/tab/tab.stories.tsx
@@ -96,7 +96,7 @@ export const FullWidthIndicatorLine: StoryObj<Component> = {
     },
 };
 
-export const OverrideTabWidthAndCenterTabLabel: StoryObj<Component> = {
+export const CustomTabWidth: StoryObj<Component> = {
     render: (_args) => {
         return (
             <Tab>

--- a/stories/tab/tab.stories.tsx
+++ b/stories/tab/tab.stories.tsx
@@ -95,3 +95,18 @@ export const FullWidthIndicatorLine: StoryObj<Component> = {
         );
     },
 };
+
+export const OverrideTabWidthAndCenterTabLabel: StoryObj<Component> = {
+    render: (_args) => {
+        return (
+            <Tab>
+                <Tab.Item title="Section A" width="50%">
+                    <ContentA />
+                </Tab.Item>
+                <Tab.Item title="Section B" width="50%">
+                    <ContentB />
+                </Tab.Item>
+            </Tab>
+        );
+    },
+};


### PR DESCRIPTION
**Changes**
added new props
- overrideTabWidth
- centerTabLabel

- delete branch

<!-- Remove if not required -->
**Changelog entry**

- Added new props for  `Tab`
  - overrideTabWidth - set a custom width for Tab ChainItem (eg "50%", "100px")
  - centerTabLabel - centers the label in the ChainItem
