### PR TITLE
Improve `OtpInput` accessibility

### DIFF
--- a/src/otp-input/otp-input.tsx
+++ b/src/otp-input/otp-input.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useRef, useState } from "react";
-import { OtpInputProps } from "./types";
+import { FormErrorMessage } from "src/form/form-label";
+import { SimpleIdGenerator, StringHelper } from "../util";
 import {
     CTAButton,
     InputContainer,
     InputField,
     Wrapper,
 } from "./otp-input.styles";
-
-import { FormErrorMessage } from "src/form/form-label";
+import { OtpInputProps } from "./types";
 
 export const OtpInput = ({
     id,
@@ -40,6 +40,9 @@ export const OtpInput = ({
     );
     const [countDown, setCountDown] = useState<number>(cooldownDuration);
     const [lastCtaTimestamp, setLastCtaTimestamp] = useState<Date>(new Date());
+    const [internalId] = useState(() => SimpleIdGenerator.generate());
+
+    const hasError = !!errorMessage;
 
     // =============================================================================
     // EFFECTS
@@ -198,7 +201,10 @@ export const OtpInput = ({
 
     return (
         <Wrapper id={id} data-testid={dataTestId} className={className}>
-            <InputContainer>
+            <InputContainer
+                role="group"
+                aria-label={`${numOfInput}-digit OTP input field`}
+            >
                 {otpValues.map((data, index) => {
                     return (
                         <InputField
@@ -208,13 +214,17 @@ export const OtpInput = ({
                                 "otp-input",
                                 dataTestId
                             )}
-                            aria-label={`Enter OTP character ${index + 1}`}
+                            aria-label={`${StringHelper.formatOrdinal(
+                                index + 1
+                            )} digit`}
+                            aria-invalid={hasError}
+                            aria-describedby={hasError ? internalId : undefined}
                             key={index}
                             ref={(el) => (inputRefs.current[index] = el)}
                             type="text"
                             inputMode="numeric"
                             value={data}
-                            error={!!errorMessage}
+                            error={hasError}
                             onChange={handleChange(index)}
                             onKeyDown={handleKeyDown(index)}
                             autoComplete="off"
@@ -224,7 +234,9 @@ export const OtpInput = ({
                 })}
             </InputContainer>
             {errorMessage && (
-                <FormErrorMessage>{errorMessage}</FormErrorMessage>
+                <FormErrorMessage id={internalId}>
+                    {errorMessage}
+                </FormErrorMessage>
             )}
             <CTAButton
                 styleType={styleType}

--- a/src/otp-input/otp-input.tsx
+++ b/src/otp-input/otp-input.tsx
@@ -111,6 +111,10 @@ export const OtpInput = ({
                 if (onChange) {
                     onChange(newOtpValues);
                 }
+            } else if (event.code === "ArrowRight") {
+                inputRefs.current[index + 1]?.focus();
+            } else if (event.code === "ArrowLeft") {
+                inputRefs.current[index - 1]?.focus();
             }
         };
 

--- a/src/util/string-helper.ts
+++ b/src/util/string-helper.ts
@@ -205,4 +205,21 @@ export namespace StringHelper {
             ? { startIndex: index0, endIndex: index1 }
             : { startIndex: index1, endIndex: index0 };
     };
+
+    const ordinalPluralRules = new Intl.PluralRules("en", {
+        type: "ordinal",
+    });
+
+    const suffixes = new Map([
+        ["one", "st"],
+        ["two", "nd"],
+        ["few", "rd"],
+        ["other", "th"],
+    ]);
+
+    export const formatOrdinal = (n: number) => {
+        const rule = ordinalPluralRules.select(n);
+        const suffix = suffixes.get(rule);
+        return `${n}${suffix}`;
+    };
 }

--- a/tests/otp-input.spec.tsx/otp-input.spec.tsx
+++ b/tests/otp-input.spec.tsx/otp-input.spec.tsx
@@ -1,0 +1,94 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { OtpInput } from "src/otp-input";
+
+// =============================================================================
+// UNIT TESTS
+// =============================================================================
+describe("OtpInput", () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.clearAllMocks();
+    });
+
+    it("should render default component", () => {
+        render(<OtpInput numOfInput={3} cooldownDuration={10} />);
+
+        expect(screen.queryAllByRole("textbox")).toHaveLength(3);
+        expect(screen.queryByLabelText("1st digit")).toHaveValue("");
+        expect(screen.queryByLabelText("2nd digit")).toHaveValue("");
+        expect(screen.queryByLabelText("3rd digit")).toHaveValue("");
+
+        expect(
+            screen.getByRole("button", { name: "Resend OTP in 10 seconds" })
+        ).toBeInTheDocument();
+    });
+
+    it("should render component with value", () => {
+        render(
+            <OtpInput
+                numOfInput={3}
+                cooldownDuration={10}
+                value={["1", "2", "3"]}
+            />
+        );
+
+        expect(screen.queryAllByRole("textbox")).toHaveLength(3);
+        expect(screen.queryByLabelText("1st digit")).toHaveValue("1");
+        expect(screen.queryByLabelText("2nd digit")).toHaveValue("2");
+        expect(screen.queryByLabelText("3rd digit")).toHaveValue("3");
+    });
+
+    it("should invoke onChange with the correct value", () => {
+        const onChange = jest.fn();
+        render(
+            <OtpInput
+                numOfInput={3}
+                cooldownDuration={10}
+                onChange={onChange}
+            />
+        );
+
+        fireEvent.change(screen.getByLabelText("1st digit"), {
+            target: { value: "8" },
+        });
+
+        expect(onChange).toHaveBeenCalledWith(["8", "", ""]);
+
+        fireEvent.change(screen.getByLabelText("2nd digit"), {
+            target: { value: "1" },
+        });
+
+        expect(onChange).toHaveBeenCalledWith(["8", "1", ""]);
+    });
+
+    it("should handle countdown behaviour", () => {
+        const onCooldownStart = jest.fn();
+        const onCooldownEnd = jest.fn();
+        render(
+            <OtpInput
+                numOfInput={3}
+                cooldownDuration={10}
+                onCooldownStart={onCooldownStart}
+                onCooldownEnd={onCooldownEnd}
+            />
+        );
+
+        expect(
+            screen.getByRole("button", { name: "Resend OTP in 10 seconds" })
+        ).toBeDisabled();
+        expect(onCooldownStart).toHaveBeenCalled();
+
+        act(() => jest.advanceTimersByTime(1000));
+
+        expect(
+            screen.getByRole("button", { name: "Resend OTP in 9 seconds" })
+        ).toBeDisabled();
+
+        act(() => jest.advanceTimersByTime(10000));
+
+        expect(
+            screen.getByRole("button", { name: "Resend OTP" })
+        ).toBeEnabled();
+        expect(onCooldownEnd).toHaveBeenCalled();
+    });
+});

--- a/tests/otp-input.spec.tsx/otp-input.spec.tsx
+++ b/tests/otp-input.spec.tsx/otp-input.spec.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { OtpInput } from "src/otp-input";
 
 // =============================================================================
@@ -90,5 +91,31 @@ describe("OtpInput", () => {
             screen.getByRole("button", { name: "Resend OTP" })
         ).toBeEnabled();
         expect(onCooldownEnd).toHaveBeenCalled();
+    });
+
+    it("should support keyboard navigation", async () => {
+        const user = userEvent.setup({ delay: null });
+
+        render(<OtpInput numOfInput={3} cooldownDuration={10} />);
+
+        await user.click(screen.getByLabelText("1st digit"));
+
+        expect(screen.getByLabelText("1st digit")).toHaveFocus();
+
+        await user.keyboard("{ArrowRight}{ArrowRight}");
+
+        expect(screen.getByLabelText("3rd digit")).toHaveFocus();
+
+        await user.keyboard("{ArrowRight}");
+
+        expect(screen.getByLabelText("3rd digit")).toHaveFocus();
+
+        await user.keyboard("{ArrowLeft}{ArrowLeft}");
+
+        expect(screen.getByLabelText("1st digit")).toHaveFocus();
+
+        await user.keyboard("{ArrowLeft}");
+
+        expect(screen.getByLabelText("1st digit")).toHaveFocus();
     });
 });

--- a/tests/utils/string-helper.spec.ts
+++ b/tests/utils/string-helper.spec.ts
@@ -206,4 +206,23 @@ describe("StringHelper", () => {
             );
         });
     });
+
+    describe("formatOrdinal", () => {
+        it.each`
+            input | output
+            ${0}  | ${"0th"}
+            ${1}  | ${"1st"}
+            ${2}  | ${"2nd"}
+            ${3}  | ${"3rd"}
+            ${4}  | ${"4th"}
+            ${11} | ${"11th"}
+            ${12} | ${"12th"}
+            ${13} | ${"13th"}
+            ${21} | ${"21st"}
+            ${22} | ${"22nd"}
+            ${23} | ${"23rd"}
+        `("should return $output", ({ input, output }) => {
+            expect(StringHelper.formatOrdinal(input)).toEqual(output);
+        });
+    });
 });


### PR DESCRIPTION
**Changes**

- Update a11y labels
- Support navigation with arrow keys
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Improve `OtpInput` accessibility and enhance keyboard navigation

**Additional information**

- You may refer to this [Figma](https://www.figma.com/design/wDAxbRmlq4xOn4UJ8zPuEF/%F0%9F%A7%91%F0%9F%8F%BB%E2%80%8D%F0%9F%A6%AF-Flagship-A11y-Annotations?node-id=758-922&p=f&m=dev)