### PR TITLE
[MISC][JH] Fix missing background-color for timeline indicator (current variant)

### DIFF
--- a/src/timeline/timeline.style.tsx
+++ b/src/timeline/timeline.style.tsx
@@ -32,6 +32,9 @@ export const CircleIndicator = styled.div<VariantStyleProps>`
     ${(props) => {
         switch (props.$variant) {
             case "current":
+                return css`
+                    background-color: ${Colour["icon-primary-subtle"]};
+                `;
             case "upcoming-active":
                 return css`
                     border: 4px solid ${Colour["icon-primary-subtle"]};


### PR DESCRIPTION
**Changes**
Background-color was removed (by accident?) for the current variant timeline indicator. Adding this back

- delete branch

**Changelog entry**
- Fix missing background color for the `current` variant in the `Timeline` indicator
