### PR TITLE
Fix DropdownList search not working for capitalised substrings

### DIFF
--- a/src/shared/dropdown-list-v2/dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.tsx
@@ -134,8 +134,9 @@ export const DropdownList = <T, V>({
             const { title, secondaryLabel } = getOptionLabel(item);
             const updatedSearchValue = searchValue.trim().toLowerCase();
             return (
-                title.includes(updatedSearchValue) ||
-                (secondaryLabel && secondaryLabel.includes(updatedSearchValue))
+                title.toLowerCase().includes(updatedSearchValue) ||
+                (secondaryLabel &&
+                    secondaryLabel.toLowerCase().includes(updatedSearchValue))
             );
         });
     });


### PR DESCRIPTION
**Changes**
Filtering for components using `DropdownList` is returning no results when searching for capitalised substrings. The search string is converted to lowercase before comparison with the list items, but the item names are not.

- delete branch

**Changelog entry**
- Fix `DropdownList` search not working for capitalised substrings
