### PR TITLE
Add workaround for button label in Chrome/Voiceover

### DIFF
--- a/src/shared/accessibility/index.ts
+++ b/src/shared/accessibility/index.ts
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+export const VisuallyHidden = styled.div`
+    clip-path: inset(50%);
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+`;

--- a/tests/otp-input.spec.tsx/otp-input.spec.tsx
+++ b/tests/otp-input.spec.tsx/otp-input.spec.tsx
@@ -75,20 +75,29 @@ describe("OtpInput", () => {
         );
 
         expect(
-            screen.getByRole("button", { name: "Resend OTP in 10 seconds" })
+            screen.getByRole("button", {
+                name: "Resend OTP in 10 seconds",
+                description: "10 seconds remaining",
+            })
         ).toBeDisabled();
         expect(onCooldownStart).toHaveBeenCalled();
+
+        act(() => jest.advanceTimersByTime(9000));
+
+        expect(
+            screen.getByRole("button", {
+                name: "Resend OTP in 10 seconds",
+                description: "1 second remaining",
+            })
+        ).toBeDisabled();
 
         act(() => jest.advanceTimersByTime(1000));
 
         expect(
-            screen.getByRole("button", { name: "Resend OTP in 9 seconds" })
-        ).toBeDisabled();
-
-        act(() => jest.advanceTimersByTime(10000));
-
-        expect(
-            screen.getByRole("button", { name: "Resend OTP" })
+            screen.getByRole("button", {
+                name: "Resend OTP",
+                description: "0 seconds remaining",
+            })
         ).toBeEnabled();
         expect(onCooldownEnd).toHaveBeenCalled();
     });


### PR DESCRIPTION
**Changes**

- Chrome/Voiceover gets stuck rereading the button contents as the countdown is changing too fast
- This implements an alternative way of exposing the countdown using `aria-describedby`
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Fix reading of countdown in Chrome/Voiceover