### PR TITLE
Expose rootnode

### DIFF
--- a/src/date-input/date-input.tsx
+++ b/src/date-input/date-input.tsx
@@ -29,7 +29,7 @@ export const DateInput = ({
     id,
     allowDisabledSelection,
     zIndex,
-    dropdownRootNode: rootNode,
+    dropdownRootNode,
     ...otherProps
 }: DateInputProps) => {
     // =============================================================================
@@ -244,7 +244,7 @@ export const DateInput = ({
             onDismiss={handleDismiss}
             customZIndex={zIndex}
             offset={16}
-            rootNode={rootNode}
+            rootNode={dropdownRootNode}
         />
     );
 };

--- a/src/date-input/date-input.tsx
+++ b/src/date-input/date-input.tsx
@@ -29,7 +29,7 @@ export const DateInput = ({
     id,
     allowDisabledSelection,
     zIndex,
-    rootNode,
+    dropdownRootNode: rootNode,
     ...otherProps
 }: DateInputProps) => {
     // =============================================================================

--- a/src/date-input/date-input.tsx
+++ b/src/date-input/date-input.tsx
@@ -29,6 +29,7 @@ export const DateInput = ({
     id,
     allowDisabledSelection,
     zIndex,
+    rootNode,
     ...otherProps
 }: DateInputProps) => {
     // =============================================================================
@@ -243,6 +244,7 @@ export const DateInput = ({
             onDismiss={handleDismiss}
             customZIndex={zIndex}
             offset={16}
+            rootNode={rootNode}
         />
     );
 };

--- a/src/date-input/types.ts
+++ b/src/date-input/types.ts
@@ -9,12 +9,12 @@ export interface DateInputProps extends CommonCalendarProps {
     className?: string | undefined;
     id?: string | undefined;
     /**
-     * The root element that contains the popover element. Defaults to the document body.
+     * The root element that contains the dropdown element. Defaults to the document body.
      *
      * If the parent that contains the trigger element has a higher z-index than the popover,
      * the popover may not be visible. Specify the parent element here instead
      */
-    rootNode?: RefObject<HTMLElement> | undefined;
+    dropdownRootNode?: RefObject<HTMLElement> | undefined;
 
     // Input-specific Attributes
     "data-testid"?: string | undefined;

--- a/src/date-input/types.ts
+++ b/src/date-input/types.ts
@@ -11,8 +11,8 @@ export interface DateInputProps extends CommonCalendarProps {
     /**
      * The root element that contains the dropdown element. Defaults to the document body.
      *
-     * If the parent that contains the trigger element has a higher z-index than the popover,
-     * the popover may not be visible. Specify the parent element here instead
+     * If the parent that contains the trigger element has a higher z-index than the dropdown,
+     * the dropdown may not be visible. Specify the parent element here instead
      */
     dropdownRootNode?: RefObject<HTMLElement> | undefined;
 

--- a/src/date-input/types.ts
+++ b/src/date-input/types.ts
@@ -1,3 +1,4 @@
+import { RefObject } from "react";
 import {
     CommonCalendarProps,
     YearMonthDisplay,
@@ -7,6 +8,13 @@ export interface DateInputProps extends CommonCalendarProps {
     // Standard HTML Attributes
     className?: string | undefined;
     id?: string | undefined;
+    /**
+     * The root element that contains the popover element. Defaults to the document body.
+     *
+     * If the parent that contains the trigger element has a higher z-index than the popover,
+     * the popover may not be visible. Specify the parent element here instead
+     */
+    rootNode?: RefObject<HTMLElement> | undefined;
 
     // Input-specific Attributes
     "data-testid"?: string | undefined;

--- a/src/date-navigator/date-navigator.tsx
+++ b/src/date-navigator/date-navigator.tsx
@@ -27,7 +27,7 @@ export const DateNavigator = ({
     onLeftArrowClick,
     onRightArrowClick,
     onCalendarDateSelect,
-    rootNode,
+    dropdownRootNode,
     ...otherProps
 }: DateNavigatorProps) => {
     // =============================================================================
@@ -152,7 +152,7 @@ export const DateNavigator = ({
             onDismiss={() => setIsCalendarOpen(false)}
             onClose={() => setIsCalendarOpen(false)}
             offset={8}
-            rootNode={rootNode}
+            rootNode={dropdownRootNode}
         />
     );
 };

--- a/src/date-navigator/date-navigator.tsx
+++ b/src/date-navigator/date-navigator.tsx
@@ -27,6 +27,7 @@ export const DateNavigator = ({
     onLeftArrowClick,
     onRightArrowClick,
     onCalendarDateSelect,
+    rootNode,
     ...otherProps
 }: DateNavigatorProps) => {
     // =============================================================================
@@ -151,6 +152,7 @@ export const DateNavigator = ({
             onDismiss={() => setIsCalendarOpen(false)}
             onClose={() => setIsCalendarOpen(false)}
             offset={8}
+            rootNode={rootNode}
         />
     );
 };

--- a/src/date-navigator/types.ts
+++ b/src/date-navigator/types.ts
@@ -17,10 +17,10 @@ export interface DateNavigatorProps {
     onRightArrowClick: (currentDate: string) => void;
     onCalendarDateSelect?: ((currentDate: string) => void) | undefined;
     /**
-     * The root element that contains the popover element. Defaults to the document body.
+     * The root element that contains the dropdown element. Defaults to the document body.
      *
-     * If the parent that contains the trigger element has a higher z-index than the popover,
-     * the popover may not be visible. Specify the parent element here instead
+     * If the parent that contains the trigger element has a higher z-index than the dropdown,
+     * the dropdown may not be visible. Specify the parent element here instead
      */
-    rootNode?: RefObject<HTMLElement> | undefined;
+    dropdownRootNode?: RefObject<HTMLElement> | undefined;
 }

--- a/src/date-navigator/types.ts
+++ b/src/date-navigator/types.ts
@@ -1,3 +1,5 @@
+import { RefObject } from "react";
+
 export interface DateNavigatorProps {
     id?: string | undefined;
     className?: string | undefined;
@@ -14,4 +16,11 @@ export interface DateNavigatorProps {
     onLeftArrowClick: (currentDate: string) => void;
     onRightArrowClick: (currentDate: string) => void;
     onCalendarDateSelect?: ((currentDate: string) => void) | undefined;
+    /**
+     * The root element that contains the popover element. Defaults to the document body.
+     *
+     * If the parent that contains the trigger element has a higher z-index than the popover,
+     * the popover may not be visible. Specify the parent element here instead
+     */
+    rootNode?: RefObject<HTMLElement> | undefined;
 }

--- a/src/date-range-input/date-range-input.tsx
+++ b/src/date-range-input/date-range-input.tsx
@@ -68,6 +68,7 @@ export const DateRangeInput = ({
     id,
     allowDisabledSelection,
     zIndex,
+    rootNode,
     ...otherProps
 }: DateRangeInputProps) => {
     // =============================================================================
@@ -661,6 +662,7 @@ export const DateRangeInput = ({
             renderDropdown={renderCalendar}
             customZIndex={zIndex}
             offset={16}
+            rootNode={rootNode}
         />
     );
 };

--- a/src/date-range-input/date-range-input.tsx
+++ b/src/date-range-input/date-range-input.tsx
@@ -68,7 +68,7 @@ export const DateRangeInput = ({
     id,
     allowDisabledSelection,
     zIndex,
-    rootNode,
+    dropdownRootNode: rootNode,
     ...otherProps
 }: DateRangeInputProps) => {
     // =============================================================================

--- a/src/date-range-input/types.ts
+++ b/src/date-range-input/types.ts
@@ -36,10 +36,10 @@ export interface DateRangeInputProps extends CommonCalendarProps {
     /** The z-index of the calendar dropdown */
     zIndex?: number | undefined;
     /**
-     * The root element that contains the popover element. Defaults to the document body.
+     * The root element that contains the dropdown element. Defaults to the document body.
      *
-     * If the parent that contains the trigger element has a higher z-index than the popover,
-     * the popover may not be visible. Specify the parent element here instead
+     * If the parent that contains the trigger element has a higher z-index than the dropdown,
+     * the dropdown may not be visible. Specify the parent element here instead
      */
     dropdownRootNode?: RefObject<HTMLElement> | undefined;
     /**

--- a/src/date-range-input/types.ts
+++ b/src/date-range-input/types.ts
@@ -1,3 +1,4 @@
+import { RefObject } from "react";
 import {
     CommonCalendarProps,
     Variant,
@@ -34,6 +35,13 @@ export interface DateRangeInputProps extends CommonCalendarProps {
     withButton?: boolean | undefined;
     /** The z-index of the calendar dropdown */
     zIndex?: number | undefined;
+    /**
+     * The root element that contains the popover element. Defaults to the document body.
+     *
+     * If the parent that contains the trigger element has a higher z-index than the popover,
+     * the popover may not be visible. Specify the parent element here instead
+     */
+    rootNode?: RefObject<HTMLElement> | undefined;
     /**
      * Function that returns when a valid selection is made. Returns the start and
      * end date in "YYYY-MM-DD" string format.

--- a/src/date-range-input/types.ts
+++ b/src/date-range-input/types.ts
@@ -41,7 +41,7 @@ export interface DateRangeInputProps extends CommonCalendarProps {
      * If the parent that contains the trigger element has a higher z-index than the popover,
      * the popover may not be visible. Specify the parent element here instead
      */
-    rootNode?: RefObject<HTMLElement> | undefined;
+    dropdownRootNode?: RefObject<HTMLElement> | undefined;
     /**
      * Function that returns when a valid selection is made. Returns the start and
      * end date in "YYYY-MM-DD" string format.

--- a/src/input-multi-select/input-multi-select.tsx
+++ b/src/input-multi-select/input-multi-select.tsx
@@ -49,7 +49,7 @@ export const InputMultiSelect = <T, V>({
     alignment,
     dropdownZIndex,
     maxSelectable,
-    rootNode,
+    dropdownRootNode,
 }: InputMultiSelectProps<T, V>): JSX.Element => {
     // =============================================================================
     // CONST, STATE
@@ -276,7 +276,7 @@ export const InputMultiSelect = <T, V>({
                 alignment={alignment}
                 fitAvailableHeight
                 customZIndex={dropdownZIndex}
-                rootNode={rootNode}
+                rootNode={dropdownRootNode}
             />
         </DropdownListState>
     );

--- a/src/input-multi-select/input-multi-select.tsx
+++ b/src/input-multi-select/input-multi-select.tsx
@@ -49,6 +49,7 @@ export const InputMultiSelect = <T, V>({
     alignment,
     dropdownZIndex,
     maxSelectable,
+    rootNode,
 }: InputMultiSelectProps<T, V>): JSX.Element => {
     // =============================================================================
     // CONST, STATE
@@ -275,6 +276,7 @@ export const InputMultiSelect = <T, V>({
                 alignment={alignment}
                 fitAvailableHeight
                 customZIndex={dropdownZIndex}
+                rootNode={rootNode}
             />
         </DropdownListState>
     );

--- a/src/input-multi-select/types.ts
+++ b/src/input-multi-select/types.ts
@@ -32,7 +32,7 @@ export interface InputMultiSelectProps<T, V>
      * If the parent that contains the trigger element has a higher z-index than the popover,
      * the popover may not be visible. Specify the parent element here instead
      */
-    rootNode?: RefObject<HTMLElement> | undefined;
+    dropdownRootNode?: RefObject<HTMLElement> | undefined;
 }
 
 /** To be exposed for Form component inheritance */

--- a/src/input-multi-select/types.ts
+++ b/src/input-multi-select/types.ts
@@ -1,3 +1,4 @@
+import { RefObject } from "react";
 import {
     InputSelectOptionsProps,
     InputSelectSharedProps,
@@ -25,6 +26,13 @@ export interface InputMultiSelectProps<T, V>
     maxSelectable?: number | undefined;
     /** @deprecated this has no effect as the dropdown will automatically resize */
     listStyleWidth?: string | undefined;
+    /**
+     * The root element that contains the popover element. Defaults to the document body.
+     *
+     * If the parent that contains the trigger element has a higher z-index than the popover,
+     * the popover may not be visible. Specify the parent element here instead
+     */
+    rootNode?: RefObject<HTMLElement> | undefined;
 }
 
 /** To be exposed for Form component inheritance */

--- a/src/input-multi-select/types.ts
+++ b/src/input-multi-select/types.ts
@@ -27,10 +27,10 @@ export interface InputMultiSelectProps<T, V>
     /** @deprecated this has no effect as the dropdown will automatically resize */
     listStyleWidth?: string | undefined;
     /**
-     * The root element that contains the popover element. Defaults to the document body.
+     * The root element that contains the dropdown element. Defaults to the document body.
      *
-     * If the parent that contains the trigger element has a higher z-index than the popover,
-     * the popover may not be visible. Specify the parent element here instead
+     * If the parent that contains the trigger element has a higher z-index than the dropdown,
+     * the dropdown may not be visible. Specify the parent element here instead
      */
     dropdownRootNode?: RefObject<HTMLElement> | undefined;
 }

--- a/src/input-nested-multi-select/input-nested-multi-select.tsx
+++ b/src/input-nested-multi-select/input-nested-multi-select.tsx
@@ -50,7 +50,7 @@ export const InputNestedMultiSelect = <V1, V2, V3>({
     variant = "default",
     alignment,
     dropdownZIndex,
-    rootNode,
+    dropdownRootNode,
 }: InputNestedMultiSelectProps<V1, V2, V3>): JSX.Element => {
     // =========================================================================
     // CONST, STATE
@@ -332,7 +332,7 @@ export const InputNestedMultiSelect = <V1, V2, V3>({
             alignment={alignment}
             fitAvailableHeight
             customZIndex={dropdownZIndex}
-            rootNode={rootNode}
+            rootNode={dropdownRootNode}
         />
     );
 };

--- a/src/input-nested-multi-select/input-nested-multi-select.tsx
+++ b/src/input-nested-multi-select/input-nested-multi-select.tsx
@@ -50,6 +50,7 @@ export const InputNestedMultiSelect = <V1, V2, V3>({
     variant = "default",
     alignment,
     dropdownZIndex,
+    rootNode,
 }: InputNestedMultiSelectProps<V1, V2, V3>): JSX.Element => {
     // =========================================================================
     // CONST, STATE
@@ -331,6 +332,7 @@ export const InputNestedMultiSelect = <V1, V2, V3>({
             alignment={alignment}
             fitAvailableHeight
             customZIndex={dropdownZIndex}
+            rootNode={rootNode}
         />
     );
 };

--- a/src/input-nested-select/input-nested-select.tsx
+++ b/src/input-nested-select/input-nested-select.tsx
@@ -65,6 +65,7 @@ export const InputNestedSelect = <V1, V2, V3>({
     variant = "default",
     alignment,
     dropdownZIndex,
+    rootNode,
 }: InputNestedSelectProps<V1, V2, V3>): JSX.Element => {
     // =========================================================================
     // CONST, STATE
@@ -288,6 +289,7 @@ export const InputNestedSelect = <V1, V2, V3>({
             alignment={alignment}
             fitAvailableHeight
             customZIndex={dropdownZIndex}
+            rootNode={rootNode}
         />
     );
 };

--- a/src/input-nested-select/input-nested-select.tsx
+++ b/src/input-nested-select/input-nested-select.tsx
@@ -65,7 +65,7 @@ export const InputNestedSelect = <V1, V2, V3>({
     variant = "default",
     alignment,
     dropdownZIndex,
-    rootNode,
+    dropdownRootNode,
 }: InputNestedSelectProps<V1, V2, V3>): JSX.Element => {
     // =========================================================================
     // CONST, STATE
@@ -289,7 +289,7 @@ export const InputNestedSelect = <V1, V2, V3>({
             alignment={alignment}
             fitAvailableHeight
             customZIndex={dropdownZIndex}
-            rootNode={rootNode}
+            rootNode={dropdownRootNode}
         />
     );
 };

--- a/src/input-nested-select/types.ts
+++ b/src/input-nested-select/types.ts
@@ -27,12 +27,12 @@ export interface InputNestedSelectSharedProps<V1, V2, V3>
     alignment?: DropdownAlignmentType | undefined;
     dropdownZIndex?: number | undefined;
     /**
-     * The root element that contains the popover element. Defaults to the document body.
+     * The root element that contains the dropdown element. Defaults to the document body.
      *
-     * If the parent that contains the trigger element has a higher z-index than the popover,
-     * the popover may not be visible. Specify the parent element here instead
+     * If the parent that contains the trigger element has a higher z-index than the dropdown,
+     * the dropdown may not be visible. Specify the parent element here instead
      */
-    rootNode?: RefObject<HTMLElement> | undefined;
+    dropdownRootNode?: RefObject<HTMLElement> | undefined;
     /** Function to convert selected value into a string */
     valueToStringFunction?: ((value: V1 | V2 | V3) => string) | undefined;
 }

--- a/src/input-nested-select/types.ts
+++ b/src/input-nested-select/types.ts
@@ -1,3 +1,4 @@
+import { RefObject } from "react";
 import {
     InputSelectOptionsProps,
     InputSelectSharedProps,
@@ -25,6 +26,13 @@ export interface InputNestedSelectSharedProps<V1, V2, V3>
     variant?: DropdownVariantType | undefined;
     alignment?: DropdownAlignmentType | undefined;
     dropdownZIndex?: number | undefined;
+    /**
+     * The root element that contains the popover element. Defaults to the document body.
+     *
+     * If the parent that contains the trigger element has a higher z-index than the popover,
+     * the popover may not be visible. Specify the parent element here instead
+     */
+    rootNode?: RefObject<HTMLElement> | undefined;
     /** Function to convert selected value into a string */
     valueToStringFunction?: ((value: V1 | V2 | V3) => string) | undefined;
 }

--- a/src/input-select/input-select.tsx
+++ b/src/input-select/input-select.tsx
@@ -51,7 +51,7 @@ export const InputSelect = <T, V>({
     readOnly,
     alignment,
     dropdownZIndex,
-    rootNode,
+    dropdownRootNode,
 }: InputSelectProps<T, V>): JSX.Element => {
     // =============================================================================
     // CONST, STATE
@@ -277,7 +277,7 @@ export const InputSelect = <T, V>({
                 alignment={alignment}
                 fitAvailableHeight
                 customZIndex={dropdownZIndex}
-                rootNode={rootNode}
+                rootNode={dropdownRootNode}
             />
         </DropdownListState>
     );

--- a/src/input-select/input-select.tsx
+++ b/src/input-select/input-select.tsx
@@ -51,6 +51,7 @@ export const InputSelect = <T, V>({
     readOnly,
     alignment,
     dropdownZIndex,
+    rootNode,
 }: InputSelectProps<T, V>): JSX.Element => {
     // =============================================================================
     // CONST, STATE
@@ -276,6 +277,7 @@ export const InputSelect = <T, V>({
                 alignment={alignment}
                 fitAvailableHeight
                 customZIndex={dropdownZIndex}
+                rootNode={rootNode}
             />
         </DropdownListState>
     );

--- a/src/input-select/types.ts
+++ b/src/input-select/types.ts
@@ -61,10 +61,10 @@ export interface InputSelectProps<T, V>
     alignment?: DropdownAlignmentType | undefined;
     dropdownZIndex?: number | undefined;
     /**
-     * The root element that contains the popover element. Defaults to the document body.
+     * The root element that contains the dropdown element. Defaults to the document body.
      *
-     * If the parent that contains the trigger element has a higher z-index than the popover,
-     * the popover may not be visible. Specify the parent element here instead
+     * If the parent that contains the trigger element has a higher z-index than the dropdown,
+     * the dropdown may not be visible. Specify the parent element here instead
      */
     dropdownRootNode?: RefObject<HTMLElement> | undefined;
     /** @deprecated this has no effect as the dropdown will automatically resize */

--- a/src/input-select/types.ts
+++ b/src/input-select/types.ts
@@ -1,3 +1,4 @@
+import { RefObject } from "react";
 import {
     DropdownDisplayProps,
     DropdownSearchProps,
@@ -59,6 +60,13 @@ export interface InputSelectProps<T, V>
     variant?: DropdownVariantType | undefined;
     alignment?: DropdownAlignmentType | undefined;
     dropdownZIndex?: number | undefined;
+    /**
+     * The root element that contains the popover element. Defaults to the document body.
+     *
+     * If the parent that contains the trigger element has a higher z-index than the popover,
+     * the popover may not be visible. Specify the parent element here instead
+     */
+    rootNode?: RefObject<HTMLElement> | undefined;
     /** @deprecated this has no effect as the dropdown will automatically resize */
     listStyleWidth?: string | undefined;
 }

--- a/src/input-select/types.ts
+++ b/src/input-select/types.ts
@@ -66,7 +66,7 @@ export interface InputSelectProps<T, V>
      * If the parent that contains the trigger element has a higher z-index than the popover,
      * the popover may not be visible. Specify the parent element here instead
      */
-    rootNode?: RefObject<HTMLElement> | undefined;
+    dropdownRootNode?: RefObject<HTMLElement> | undefined;
     /** @deprecated this has no effect as the dropdown will automatically resize */
     listStyleWidth?: string | undefined;
 }

--- a/src/predictive-text-input/types.ts
+++ b/src/predictive-text-input/types.ts
@@ -1,5 +1,4 @@
 import { ListItemDisplayProps } from "../shared/dropdown-list/types";
-import { DropdownAlignmentType } from "../shared/dropdown-wrapper";
 
 export interface PredictiveTextInputProps<T, V> {
     id?: string | undefined;
@@ -12,7 +11,6 @@ export interface PredictiveTextInputProps<T, V> {
     disabled?: boolean | undefined;
     error?: boolean | undefined;
     selectedOption?: T | undefined;
-    alignment?: DropdownAlignmentType | undefined;
     /** Async Function to populate options */
     fetchOptions: (input: string) => Promise<T[]>;
     /** Function to derive value from an item */

--- a/src/predictive-text-input/types.ts
+++ b/src/predictive-text-input/types.ts
@@ -1,4 +1,3 @@
-import { RefObject } from "react";
 import { ListItemDisplayProps } from "../shared/dropdown-list/types";
 import { DropdownAlignmentType } from "../shared/dropdown-wrapper";
 
@@ -14,13 +13,6 @@ export interface PredictiveTextInputProps<T, V> {
     error?: boolean | undefined;
     selectedOption?: T | undefined;
     alignment?: DropdownAlignmentType | undefined;
-    /**
-     * The root element that contains the popover element. Defaults to the document body.
-     *
-     * If the parent that contains the trigger element has a higher z-index than the popover,
-     * the popover may not be visible. Specify the parent element here instead
-     */
-    rootNode?: RefObject<HTMLElement> | undefined;
     /** Async Function to populate options */
     fetchOptions: (input: string) => Promise<T[]>;
     /** Function to derive value from an item */

--- a/src/predictive-text-input/types.ts
+++ b/src/predictive-text-input/types.ts
@@ -1,4 +1,6 @@
+import { RefObject } from "react";
 import { ListItemDisplayProps } from "../shared/dropdown-list/types";
+import { DropdownAlignmentType } from "../shared/dropdown-wrapper";
 
 export interface PredictiveTextInputProps<T, V> {
     id?: string | undefined;
@@ -11,6 +13,14 @@ export interface PredictiveTextInputProps<T, V> {
     disabled?: boolean | undefined;
     error?: boolean | undefined;
     selectedOption?: T | undefined;
+    alignment?: DropdownAlignmentType | undefined;
+    /**
+     * The root element that contains the popover element. Defaults to the document body.
+     *
+     * If the parent that contains the trigger element has a higher z-index than the popover,
+     * the popover may not be visible. Specify the parent element here instead
+     */
+    rootNode?: RefObject<HTMLElement> | undefined;
     /** Async Function to populate options */
     fetchOptions: (input: string) => Promise<T[]>;
     /** Function to derive value from an item */

--- a/src/select-histogram/select-histogram.tsx
+++ b/src/select-histogram/select-histogram.tsx
@@ -35,7 +35,7 @@ export const SelectHistogram = ({
     readOnly,
     renderRangeLabel,
     value,
-    rootNode,
+    dropdownRootNode,
     ...otherProps
 }: SelectHistogramProps): JSX.Element => {
     const {
@@ -221,7 +221,7 @@ export const SelectHistogram = ({
                 alignment={alignment}
                 fitAvailableHeight
                 customZIndex={dropdownZIndex}
-                rootNode={rootNode}
+                rootNode={dropdownRootNode}
             />
         </DropdownListState>
     );

--- a/src/select-histogram/select-histogram.tsx
+++ b/src/select-histogram/select-histogram.tsx
@@ -35,6 +35,7 @@ export const SelectHistogram = ({
     readOnly,
     renderRangeLabel,
     value,
+    rootNode,
     ...otherProps
 }: SelectHistogramProps): JSX.Element => {
     const {
@@ -220,6 +221,7 @@ export const SelectHistogram = ({
                 alignment={alignment}
                 fitAvailableHeight
                 customZIndex={dropdownZIndex}
+                rootNode={rootNode}
             />
         </DropdownListState>
     );

--- a/src/select-histogram/types.ts
+++ b/src/select-histogram/types.ts
@@ -25,10 +25,10 @@ export interface SelectHistogramProps {
     readOnly?: boolean | undefined;
     value?: [number, number] | undefined;
     /**
-     * The root element that contains the popover element. Defaults to the document body.
+     * The root element that contains the dropdown element. Defaults to the document body.
      *
-     * If the parent that contains the trigger element has a higher z-index than the popover,
-     * the popover may not be visible. Specify the parent element here instead
+     * If the parent that contains the trigger element has a higher z-index than the dropdown,
+     * the dropdown may not be visible. Specify the parent element here instead
      */
     dropdownRootNode?: RefObject<HTMLElement> | undefined;
     onBlur?: (() => void) | undefined;

--- a/src/select-histogram/types.ts
+++ b/src/select-histogram/types.ts
@@ -1,3 +1,4 @@
+import { RefObject } from "react";
 import { HistogramSliderProps } from "../histogram-slider";
 import { TruncateType } from "../shared/dropdown-list-v2/types";
 import { DropdownAlignmentType } from "../shared/dropdown-wrapper";
@@ -23,6 +24,13 @@ export interface SelectHistogramProps {
     rangeLabelSuffix?: string | undefined;
     readOnly?: boolean | undefined;
     value?: [number, number] | undefined;
+    /**
+     * The root element that contains the popover element. Defaults to the document body.
+     *
+     * If the parent that contains the trigger element has a higher z-index than the popover,
+     * the popover may not be visible. Specify the parent element here instead
+     */
+    rootNode?: RefObject<HTMLElement> | undefined;
     onBlur?: (() => void) | undefined;
     onChange?: ((value: [number, number]) => void) | undefined;
     onChangeEnd?: ((value: [number, number]) => void) | undefined;

--- a/src/select-histogram/types.ts
+++ b/src/select-histogram/types.ts
@@ -30,7 +30,7 @@ export interface SelectHistogramProps {
      * If the parent that contains the trigger element has a higher z-index than the popover,
      * the popover may not be visible. Specify the parent element here instead
      */
-    rootNode?: RefObject<HTMLElement> | undefined;
+    dropdownRootNode?: RefObject<HTMLElement> | undefined;
     onBlur?: (() => void) | undefined;
     onChange?: ((value: [number, number]) => void) | undefined;
     onChangeEnd?: ((value: [number, number]) => void) | undefined;

--- a/src/shared/dropdown-wrapper/element-with-dropdown.tsx
+++ b/src/shared/dropdown-wrapper/element-with-dropdown.tsx
@@ -16,7 +16,7 @@ import {
     useInteractions,
     useTransitionStyles,
 } from "@floating-ui/react";
-import { useRef } from "react";
+import { RefObject, useRef } from "react";
 import { useResizeDetector } from "react-resize-detector";
 import { useTheme } from "styled-components";
 import { useFloatingChild } from "../../overlay/use-floating-context";
@@ -43,6 +43,13 @@ interface ElementWithDropdownProps {
     /* the alignment of the dropdown to the left or right of the reference element */
     alignment?: DropdownAlignmentType | undefined;
     fitAvailableHeight?: boolean | undefined;
+    /**
+     * The root element that contains the popover element. Defaults to the document body.
+     *
+     * If the parent that contains the trigger element has a higher z-index than the popover,
+     * the popover may not be visible. Specify the parent element here instead
+     */
+    rootNode?: RefObject<HTMLElement> | undefined;
 }
 
 const getFloatingPlacement = (alignment: DropdownAlignmentType): Placement => {
@@ -70,6 +77,7 @@ export const ElementWithDropdown = ({
     offset: dropdownOffset = 0,
     alignment = "left",
     fitAvailableHeight,
+    rootNode,
 }: ElementWithDropdownProps) => {
     // =============================================================================
     // CONST, STATE, REF
@@ -163,7 +171,7 @@ export const ElementWithDropdown = ({
                 {renderElement()}
             </div>
             {isMounted && (
-                <FloatingPortal>
+                <FloatingPortal root={rootNode}>
                     <FloatingFocusManager
                         context={context}
                         modal={false}

--- a/stories/date-navigator/props-table.tsx
+++ b/stories/date-navigator/props-table.tsx
@@ -79,28 +79,27 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["(currentDate: string) => void"],
             },
             {
-                name: "rootNode",
+                name: "dropdownRootNode",
                 description: (
                     <>
-                        The root element that hosts the date navigator element.
-                        Only specify this if you absolutely need to change the
-                        parent of the calendar dropdown component.
+                        The root element that hosts the calendar dropdown
+                        element. Only specify this if you absolutely need to
+                        change the parent of the dropdown.
                         <br />
                         <br />
-                        For example, the calendar dropdown component is rendered
-                        in <code>body</code> by default. This could cause scroll
+                        For example, the dropdown is rendered in{" "}
+                        <code>body</code> by default. This could cause scroll
                         issues if your UI only scrolls within a certain
-                        container. In that case, you can specify the{" "}
-                        <code>rootNode</code> prop so that they share the same
-                        stacking context. However, note that this might cause
-                        z-index issues since it will no longer be rendered in{" "}
-                        <code>body</code>.
+                        container. In that case, you can specify this prop so
+                        that they share the same stacking context. However, note
+                        that this might cause z-index issues since it will no
+                        longer be rendered in <code>body</code>.
                     </>
                 ),
                 propTypes: ["RefObject<HTMLElement>"],
                 defaultValue: (
                     <>
-                        document<code>body</code>
+                        document <code>body</code>
                     </>
                 ),
             },

--- a/stories/date-navigator/props-table.tsx
+++ b/stories/date-navigator/props-table.tsx
@@ -78,6 +78,32 @@ const DATA: ApiTableSectionProps[] = [
                 description: "Called on a calendar date selection",
                 propTypes: ["(currentDate: string) => void"],
             },
+            {
+                name: "rootNode",
+                description: (
+                    <>
+                        The root element that hosts the date navigator element.
+                        Only specify this if you absolutely need to change the
+                        parent of the calendar dropdown component.
+                        <br />
+                        <br />
+                        For example, the calendar dropdown component is rendered
+                        in <code>body</code> by default. This could cause scroll
+                        issues if your UI only scrolls within a certain
+                        container. In that case, you can specify the{" "}
+                        <code>rootNode</code> prop so that they share the same
+                        stacking context. However, note that this might cause
+                        z-index issues since it will no longer be rendered in{" "}
+                        <code>body</code>.
+                    </>
+                ),
+                propTypes: ["RefObject<HTMLElement>"],
+                defaultValue: (
+                    <>
+                        document<code>body</code>
+                    </>
+                ),
+            },
         ],
     },
 ];

--- a/stories/form/form-date-input/props-table.tsx
+++ b/stories/form/form-date-input/props-table.tsx
@@ -136,7 +136,7 @@ const DATA: ApiTableSectionProps[] = [
                 name: "rootNode",
                 description: (
                     <>
-                        The root element that hosts the dropdown calendar
+                        The root element that hosts the calendar dropdown
                         element. Try specifying this if <code>zIndex</code> does
                         not work.
                         <br />

--- a/stories/form/form-date-input/props-table.tsx
+++ b/stories/form/form-date-input/props-table.tsx
@@ -133,24 +133,27 @@ const DATA: ApiTableSectionProps[] = [
                 defaultValue: "50",
             },
             {
-                name: "rootNode",
+                name: "dropdownRootNode",
                 description: (
                     <>
                         The root element that hosts the calendar dropdown
-                        element. Try specifying this if <code>zIndex</code> does
-                        not work.
+                        element. Only specify this if you absolutely need to
+                        change the parent of the dropdown.
                         <br />
                         <br />
-                        For example, if the parent of the date input element has
-                        a higher z-index than the date input, the date input
-                        dropdown may not be visible. Specify the parent here
-                        instead so that they share the same stacking context.
+                        For example, the dropdown is rendered in{" "}
+                        <code>body</code> by default. This could cause scroll
+                        issues if your UI only scrolls within a certain
+                        container. In that case, you can specify this prop so
+                        that they share the same stacking context. However, note
+                        that this might cause z-index issues since it will no
+                        longer be rendered in <code>body</code>.
                     </>
                 ),
                 propTypes: ["RefObject<HTMLElement>"],
                 defaultValue: (
                     <>
-                        document<code>body</code>
+                        document <code>body</code>
                     </>
                 ),
             },

--- a/stories/form/form-date-input/props-table.tsx
+++ b/stories/form/form-date-input/props-table.tsx
@@ -133,6 +133,28 @@ const DATA: ApiTableSectionProps[] = [
                 defaultValue: "50",
             },
             {
+                name: "rootNode",
+                description: (
+                    <>
+                        The root element that hosts the dropdown calendar
+                        element. Try specifying this if <code>zIndex</code> does
+                        not work.
+                        <br />
+                        <br />
+                        For example, if the parent of the date input element has
+                        a higher z-index than the date input, the date input
+                        dropdown may not be visible. Specify the parent here
+                        instead so that they share the same stacking context.
+                    </>
+                ),
+                propTypes: ["RefObject<HTMLElement>"],
+                defaultValue: (
+                    <>
+                        document<code>body</code>
+                    </>
+                ),
+            },
+            {
                 name: "onChange",
                 description: (
                     <>

--- a/stories/form/form-date-range-input/props-table.tsx
+++ b/stories/form/form-date-range-input/props-table.tsx
@@ -168,6 +168,32 @@ const DATA: ApiTableSectionProps[] = [
                 defaultValue: "50",
             },
             {
+                name: "rootNode",
+                description: (
+                    <>
+                        The root element that hosts the calendar dropdown
+                        element. Only specify this if you absolutely need to
+                        change the parent of the calendar dropdown component.
+                        <br />
+                        <br />
+                        For example, the calendar dropdown component is rendered
+                        in <code>body</code> by default. This could cause scroll
+                        issues if your UI only scrolls within a certain
+                        container. In that case, you can specify the{" "}
+                        <code>rootNode</code> prop so that they share the same
+                        stacking context. However, note that this might cause
+                        z-index issues since it will no longer be rendered in{" "}
+                        <code>body</code>.
+                    </>
+                ),
+                propTypes: ["RefObject<HTMLElement>"],
+                defaultValue: (
+                    <>
+                        document<code>body</code>
+                    </>
+                ),
+            },
+            {
                 name: "onChange",
                 description: (
                     <>

--- a/stories/form/form-date-range-input/props-table.tsx
+++ b/stories/form/form-date-range-input/props-table.tsx
@@ -168,28 +168,27 @@ const DATA: ApiTableSectionProps[] = [
                 defaultValue: "50",
             },
             {
-                name: "rootNode",
+                name: "dropdownRootNode",
                 description: (
                     <>
                         The root element that hosts the calendar dropdown
                         element. Only specify this if you absolutely need to
-                        change the parent of the calendar dropdown component.
+                        change the parent of the dropdown.
                         <br />
                         <br />
-                        For example, the calendar dropdown component is rendered
-                        in <code>body</code> by default. This could cause scroll
+                        For example, the dropdown is rendered in{" "}
+                        <code>body</code> by default. This could cause scroll
                         issues if your UI only scrolls within a certain
-                        container. In that case, you can specify the{" "}
-                        <code>rootNode</code> prop so that they share the same
-                        stacking context. However, note that this might cause
-                        z-index issues since it will no longer be rendered in{" "}
-                        <code>body</code>.
+                        container. In that case, you can specify this prop so
+                        that they share the same stacking context. However, note
+                        that this might cause z-index issues since it will no
+                        longer be rendered in <code>body</code>.
                     </>
                 ),
                 propTypes: ["RefObject<HTMLElement>"],
                 defaultValue: (
                     <>
-                        document<code>body</code>
+                        document <code>body</code>
                     </>
                 ),
             },

--- a/stories/form/form-multi-select/props-table.tsx
+++ b/stories/form/form-multi-select/props-table.tsx
@@ -168,6 +168,32 @@ const DATA: ApiTableSectionProps[] = [
                     "Specifies the maximum number of options that can be selected",
                 propTypes: ["number"],
             },
+            {
+                name: "rootNode",
+                description: (
+                    <>
+                        The root element that hosts the dropdown element. Only
+                        specify this if you absolutely need to change the parent
+                        of the dropdown component.
+                        <br />
+                        <br />
+                        For example, the dropdown component is rendered in{" "}
+                        <code>body</code> by default. This could cause scroll
+                        issues if your UI only scrolls within a certain
+                        container. In that case, you can specify the{" "}
+                        <code>rootNode</code> prop so that they share the same
+                        stacking context. However, note that this might cause
+                        z-index issues since it will no longer be rendered in{" "}
+                        <code>body</code>.
+                    </>
+                ),
+                propTypes: ["RefObject<HTMLElement>"],
+                defaultValue: (
+                    <>
+                        document<code>body</code>
+                    </>
+                ),
+            },
         ],
     },
     ...SHARED_FORM_PROPS_DATA,

--- a/stories/form/form-multi-select/props-table.tsx
+++ b/stories/form/form-multi-select/props-table.tsx
@@ -169,22 +169,21 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["number"],
             },
             {
-                name: "rootNode",
+                name: "dropdownRootNode",
                 description: (
                     <>
                         The root element that hosts the dropdown element. Only
                         specify this if you absolutely need to change the parent
-                        of the dropdown component.
+                        of the dropdown.
                         <br />
                         <br />
-                        For example, the dropdown component is rendered in{" "}
+                        For example, the dropdown is rendered in{" "}
                         <code>body</code> by default. This could cause scroll
                         issues if your UI only scrolls within a certain
-                        container. In that case, you can specify the{" "}
-                        <code>rootNode</code> prop so that they share the same
-                        stacking context. However, note that this might cause
-                        z-index issues since it will no longer be rendered in{" "}
-                        <code>body</code>.
+                        container. In that case, you can specify this prop so
+                        that they share the same stacking context. However, note
+                        that this might cause z-index issues since it will no
+                        longer be rendered in <code>body</code>.
                     </>
                 ),
                 propTypes: ["RefObject<HTMLElement>"],

--- a/stories/form/form-nested-multi-select/props-table.tsx
+++ b/stories/form/form-nested-multi-select/props-table.tsx
@@ -139,28 +139,27 @@ const DATA: ApiTableSectionProps[] = [
                 defaultValue: "50",
             },
             {
-                name: "rootNode",
+                name: "dropdownRootNode",
                 description: (
                     <>
                         The root element that hosts the dropdown element. Only
                         specify this if you absolutely need to change the parent
-                        of the dropdown component.
+                        of the dropdown.
                         <br />
                         <br />
-                        For example, the dropdown component is rendered in{" "}
+                        For example, the dropdown is rendered in{" "}
                         <code>body</code> by default. This could cause scroll
                         issues if your UI only scrolls within a certain
-                        container. In that case, you can specify the{" "}
-                        <code>rootNode</code> prop so that they share the same
-                        stacking context. However, note that this might cause
-                        z-index issues since it will no longer be rendered in{" "}
-                        <code>body</code>.
+                        container. In that case, you can specify this prop so
+                        that they share the same stacking context. However, note
+                        that this might cause z-index issues since it will no
+                        longer be rendered in <code>body</code>.
                     </>
                 ),
                 propTypes: ["RefObject<HTMLElement>"],
                 defaultValue: (
                     <>
-                        document<code>body</code>
+                        document <code>body</code>
                     </>
                 ),
             },

--- a/stories/form/form-nested-multi-select/props-table.tsx
+++ b/stories/form/form-nested-multi-select/props-table.tsx
@@ -139,6 +139,32 @@ const DATA: ApiTableSectionProps[] = [
                 defaultValue: "50",
             },
             {
+                name: "rootNode",
+                description: (
+                    <>
+                        The root element that hosts the dropdown element. Only
+                        specify this if you absolutely need to change the parent
+                        of the dropdown component.
+                        <br />
+                        <br />
+                        For example, the dropdown component is rendered in{" "}
+                        <code>body</code> by default. This could cause scroll
+                        issues if your UI only scrolls within a certain
+                        container. In that case, you can specify the{" "}
+                        <code>rootNode</code> prop so that they share the same
+                        stacking context. However, note that this might cause
+                        z-index issues since it will no longer be rendered in{" "}
+                        <code>body</code>.
+                    </>
+                ),
+                propTypes: ["RefObject<HTMLElement>"],
+                defaultValue: (
+                    <>
+                        document<code>body</code>
+                    </>
+                ),
+            },
+            {
                 name: "onSelectOptions",
                 description: "Called when an option is selected",
                 propTypes: [

--- a/stories/form/form-nested-select/props-table.tsx
+++ b/stories/form/form-nested-select/props-table.tsx
@@ -142,6 +142,32 @@ const DATA: ApiTableSectionProps[] = [
                 defaultValue: "50",
             },
             {
+                name: "rootNode",
+                description: (
+                    <>
+                        The root element that hosts the dropdown element. Only
+                        specify this if you absolutely need to change the parent
+                        of the dropdown component.
+                        <br />
+                        <br />
+                        For example, the dropdown component is rendered in{" "}
+                        <code>body</code> by default. This could cause scroll
+                        issues if your UI only scrolls within a certain
+                        container. In that case, you can specify the{" "}
+                        <code>rootNode</code> prop so that they share the same
+                        stacking context. However, note that this might cause
+                        z-index issues since it will no longer be rendered in{" "}
+                        <code>body</code>.
+                    </>
+                ),
+                propTypes: ["RefObject<HTMLElement>"],
+                defaultValue: (
+                    <>
+                        document<code>body</code>
+                    </>
+                ),
+            },
+            {
                 name: "onSelectOption",
                 description: "Called when an option is selected",
                 propTypes: ["(keyPath: string[], value: V1 | V2 | V3) => void"],

--- a/stories/form/form-nested-select/props-table.tsx
+++ b/stories/form/form-nested-select/props-table.tsx
@@ -142,28 +142,27 @@ const DATA: ApiTableSectionProps[] = [
                 defaultValue: "50",
             },
             {
-                name: "rootNode",
+                name: "dropdownRootNode",
                 description: (
                     <>
                         The root element that hosts the dropdown element. Only
                         specify this if you absolutely need to change the parent
-                        of the dropdown component.
+                        of the dropdown.
                         <br />
                         <br />
-                        For example, the dropdown component is rendered in{" "}
+                        For example, the dropdown is rendered in{" "}
                         <code>body</code> by default. This could cause scroll
                         issues if your UI only scrolls within a certain
-                        container. In that case, you can specify the{" "}
-                        <code>rootNode</code> prop so that they share the same
-                        stacking context. However, note that this might cause
-                        z-index issues since it will no longer be rendered in{" "}
-                        <code>body</code>.
+                        container. In that case, you can specify this prop so
+                        that they share the same stacking context. However, note
+                        that this might cause z-index issues since it will no
+                        longer be rendered in <code>body</code>.
                     </>
                 ),
                 propTypes: ["RefObject<HTMLElement>"],
                 defaultValue: (
                     <>
-                        document<code>body</code>
+                        document <code>body</code>
                     </>
                 ),
             },

--- a/stories/form/form-select-histogram/props-table.tsx
+++ b/stories/form/form-select-histogram/props-table.tsx
@@ -115,6 +115,32 @@ const DATA: ApiTableSectionProps[] = [
                 defaultValue: "50",
             },
             {
+                name: "rootNode",
+                description: (
+                    <>
+                        The root element that hosts the slider element. Only
+                        specify this if you absolutely need to change the parent
+                        of the slider component.
+                        <br />
+                        <br />
+                        For example, the slider component is rendered in{" "}
+                        <code>body</code> by default. This could cause scroll
+                        issues if your UI only scrolls within a certain
+                        container. In that case, you can specify the{" "}
+                        <code>rootNode</code> prop so that they share the same
+                        stacking context. However, note that this might cause
+                        z-index issues since it will no longer be rendered in{" "}
+                        <code>body</code>.
+                    </>
+                ),
+                propTypes: ["RefObject<HTMLElement>"],
+                defaultValue: (
+                    <>
+                        document<code>body</code>
+                    </>
+                ),
+            },
+            {
                 name: "histogramSlider",
                 description: "The histogram slider configuration",
                 mandatory: true,

--- a/stories/form/form-select-histogram/props-table.tsx
+++ b/stories/form/form-select-histogram/props-table.tsx
@@ -115,28 +115,27 @@ const DATA: ApiTableSectionProps[] = [
                 defaultValue: "50",
             },
             {
-                name: "rootNode",
+                name: "dropdownRootNode",
                 description: (
                     <>
                         The root element that hosts the dropdown element. Only
                         specify this if you absolutely need to change the parent
-                        of the slider component.
+                        of the dropdown.
                         <br />
                         <br />
-                        For example, the dropdown component is rendered in{" "}
+                        For example, the dropdown is rendered in{" "}
                         <code>body</code> by default. This could cause scroll
                         issues if your UI only scrolls within a certain
-                        container. In that case, you can specify the{" "}
-                        <code>rootNode</code> prop so that they share the same
-                        stacking context. However, note that this might cause
-                        z-index issues since it will no longer be rendered in{" "}
-                        <code>body</code>.
+                        container. In that case, you can specify this prop so
+                        that they share the same stacking context. However, note
+                        that this might cause z-index issues since it will no
+                        longer be rendered in <code>body</code>.
                     </>
                 ),
                 propTypes: ["RefObject<HTMLElement>"],
                 defaultValue: (
                     <>
-                        document<code>body</code>
+                        document <code>body</code>
                     </>
                 ),
             },

--- a/stories/form/form-select-histogram/props-table.tsx
+++ b/stories/form/form-select-histogram/props-table.tsx
@@ -118,12 +118,12 @@ const DATA: ApiTableSectionProps[] = [
                 name: "rootNode",
                 description: (
                     <>
-                        The root element that hosts the slider element. Only
+                        The root element that hosts the dropdown element. Only
                         specify this if you absolutely need to change the parent
                         of the slider component.
                         <br />
                         <br />
-                        For example, the slider component is rendered in{" "}
+                        For example, the dropdown component is rendered in{" "}
                         <code>body</code> by default. This could cause scroll
                         issues if your UI only scrolls within a certain
                         container. In that case, you can specify the{" "}

--- a/stories/form/form-select/props-table.tsx
+++ b/stories/form/form-select/props-table.tsx
@@ -200,6 +200,32 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["number"],
                 defaultValue: "50",
             },
+            {
+                name: "rootNode",
+                description: (
+                    <>
+                        The root element that hosts the dropdown element. Only
+                        specify this if you absolutely need to change the parent
+                        of the dropdown component.
+                        <br />
+                        <br />
+                        For example, the dropdown component is rendered in{" "}
+                        <code>body</code> by default. This could cause scroll
+                        issues if your UI only scrolls within a certain
+                        container. In that case, you can specify the{" "}
+                        <code>rootNode</code> prop so that they share the same
+                        stacking context. However, note that this might cause
+                        z-index issues since it will no longer be rendered in{" "}
+                        <code>body</code>.
+                    </>
+                ),
+                propTypes: ["RefObject<HTMLElement>"],
+                defaultValue: (
+                    <>
+                        document<code>body</code>
+                    </>
+                ),
+            },
         ],
     },
     {

--- a/stories/form/form-select/props-table.tsx
+++ b/stories/form/form-select/props-table.tsx
@@ -201,28 +201,27 @@ const DATA: ApiTableSectionProps[] = [
                 defaultValue: "50",
             },
             {
-                name: "rootNode",
+                name: "dropdownRootNode",
                 description: (
                     <>
                         The root element that hosts the dropdown element. Only
                         specify this if you absolutely need to change the parent
-                        of the dropdown component.
+                        of the dropdown.
                         <br />
                         <br />
-                        For example, the dropdown component is rendered in{" "}
+                        For example, the dropdown is rendered in{" "}
                         <code>body</code> by default. This could cause scroll
                         issues if your UI only scrolls within a certain
-                        container. In that case, you can specify the{" "}
-                        <code>rootNode</code> prop so that they share the same
-                        stacking context. However, note that this might cause
-                        z-index issues since it will no longer be rendered in{" "}
-                        <code>body</code>.
+                        container. In that case, you can specify this prop so
+                        that they share the same stacking context. However, note
+                        that this might cause z-index issues since it will no
+                        longer be rendered in <code>body</code>.
                     </>
                 ),
                 propTypes: ["RefObject<HTMLElement>"],
                 defaultValue: (
                     <>
-                        document<code>body</code>
+                        document <code>body</code>
                     </>
                 ),
             },


### PR DESCRIPTION
**Changes**
Expose `rootNode` prop for all components utilising floating UI for their dropdowns etc, and add documentation to props table of respective components.

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Expose `rootNode` prop in input components utilising floating UI

