### PR TITLE
[MISC][Viv] Checkbox a11y improvements (keyboard navigation, option to set custom id to link to label)

### DIFF
--- a/src/checkbox/checkbox.style.tsx
+++ b/src/checkbox/checkbox.style.tsx
@@ -75,10 +75,7 @@ export const Container = styled.div<StyleProps>`
     `}
 
     // Show custom focus ring when input is focused
-    input:focus-visible + ${StyledUncheckedIcon},
-    input:focus-visible + ${StyledUncheckedDisabledIcon},
-    input:focus-visible + ${StyledCheckedIcon},
-    input:focus-visible + ${StyledInteremediateIcon} {
+    input:focus-visible + svg {
         outline: 2px solid ${Colour["focus-ring"]};
         outline-offset: 0px;
         border-radius: 4px;

--- a/src/checkbox/checkbox.style.tsx
+++ b/src/checkbox/checkbox.style.tsx
@@ -30,18 +30,6 @@ const fadeIn = keyframes`
   }
 `;
 
-export const Container = styled.div<StyleProps>`
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    position: relative;
-
-    ${(props) => css`
-        height: ${props.$displaySize === "small" ? "1.5rem" : "2rem"};
-        width: ${props.$displaySize === "small" ? "1.5rem" : "2rem"};
-    `}
-`;
-
 const BaseIconStyles = css`
     animation: ${Motion["duration-150"]} ${Motion["ease-default"]} ${fadeIn};
     width: 100%;
@@ -73,6 +61,28 @@ export const StyledInteremediateIcon = styled(MinusSquareFillIcon)<StyleProps>`
         props.$disabled
             ? Colour["icon-disabled-subtle"](props)
             : Colour["icon-selected"](props)};
+`;
+
+export const Container = styled.div<StyleProps>`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+
+    ${(props) => css`
+        height: ${props.$displaySize === "small" ? "1.5rem" : "2rem"};
+        width: ${props.$displaySize === "small" ? "1.5rem" : "2rem"};
+    `}
+
+    // Show custom focus ring when input is focused
+    input:focus-visible + ${StyledUncheckedIcon},
+    input:focus-visible + ${StyledUncheckedDisabledIcon},
+    input:focus-visible + ${StyledCheckedIcon},
+    input:focus-visible + ${StyledInteremediateIcon} {
+        outline: 2px solid ${Colour["focus-ring"]};
+        outline-offset: 0px;
+        border-radius: 4px;
+    }
 `;
 
 export const Input = styled.input<CheckboxProps>`

--- a/src/checkbox/checkbox.tsx
+++ b/src/checkbox/checkbox.tsx
@@ -14,8 +14,6 @@ export const Checkbox = ({
     checked,
     disabled,
     indeterminate,
-    onChange,
-    onKeyPress, // will still need this for now else keyboard events are not handled
     displaySize = "default",
     id,
     ...otherProps
@@ -30,34 +28,6 @@ export const Checkbox = ({
             checkRef.current.indeterminate = indeterminate ?? false;
         }
     }, [indeterminate]);
-
-    // =============================================================================
-    // EVENT HANDLERS
-    // =============================================================================
-    const handleOnCheck = (
-        event:
-            | React.ChangeEvent<HTMLInputElement>
-            | React.KeyboardEvent<HTMLDivElement>
-    ) => {
-        if (!disabled) {
-            const keyboardEvent =
-                event as React.KeyboardEvent<HTMLInputElement>;
-            const isValid =
-                keyboardEvent.key === " " || event.type === "change";
-
-            if (!isValid) {
-                return;
-            }
-
-            if (onChange) {
-                onChange(event as React.ChangeEvent<HTMLInputElement>);
-            }
-
-            if (onKeyPress) {
-                onKeyPress(keyboardEvent);
-            }
-        }
-    };
 
     // =============================================================================
     // RENDER FUNCTION
@@ -114,10 +84,8 @@ export const Checkbox = ({
                 checked={checked}
                 ref={checkRef}
                 tabIndex={disabled ? -1 : 0}
-                onChange={handleOnCheck}
                 disabled={disabled}
                 aria-checked={indeterminate ? "mixed" : checked}
-                aria-labelledby="checkbox-input"
                 {...otherProps}
             />
             {renderIcon()}

--- a/src/checkbox/checkbox.tsx
+++ b/src/checkbox/checkbox.tsx
@@ -17,6 +17,7 @@ export const Checkbox = ({
     onChange,
     onKeyPress, // will still need this for now else keyboard events are not handled
     displaySize = "default",
+    id,
     ...otherProps
 }: CheckboxProps): JSX.Element => {
     // =============================================================================
@@ -67,6 +68,7 @@ export const Checkbox = ({
                 <StyledInteremediateIcon
                     $disabled={disabled}
                     data-testid="indeterminate"
+                    aria-hidden="true"
                 />
             );
         }
@@ -76,13 +78,17 @@ export const Checkbox = ({
                 <StyledCheckedIcon
                     $disabled={disabled}
                     data-testid="checkmark"
+                    aria-hidden="true"
                 />
             );
         }
 
         if (disabled) {
             return (
-                <StyledUncheckedDisabledIcon data-testid="empty-disabled-checkbox" />
+                <StyledUncheckedDisabledIcon
+                    data-testid="empty-disabled-checkbox"
+                    aria-hidden="true"
+                />
             );
         }
 
@@ -90,6 +96,7 @@ export const Checkbox = ({
             <StyledUncheckedIcon
                 $disabled={disabled}
                 data-testid="empty-checkbox"
+                aria-hidden="true"
             />
         );
     };
@@ -98,25 +105,19 @@ export const Checkbox = ({
         <Container
             className={className}
             data-testid="checkbox"
-            role="checkbox"
-            aria-checked={indeterminate ? "mixed" : checked}
-            aria-labelledby="checkbox-input"
-            tabIndex={disabled ? -1 : 0}
-            onKeyDown={handleOnCheck}
             $displaySize={displaySize}
-            $disabled={disabled}
-            $unchecked={!(indeterminate || checked || disabled)}
         >
             <Input
-                id="checkbox-input"
+                id={id}
                 data-testid="checkbox-input"
-                aria-hidden="true"
                 type="checkbox"
                 checked={checked}
                 ref={checkRef}
-                tabIndex={-1}
+                tabIndex={disabled ? -1 : 0}
                 onChange={handleOnCheck}
                 disabled={disabled}
+                aria-checked={indeterminate ? "mixed" : checked}
+                aria-labelledby="checkbox-input"
                 {...otherProps}
             />
             {renderIcon()}

--- a/src/checkbox/checkbox.tsx
+++ b/src/checkbox/checkbox.tsx
@@ -38,7 +38,7 @@ export const Checkbox = ({
                 <StyledInteremediateIcon
                     $disabled={disabled}
                     data-testid="indeterminate"
-                    aria-hidden="true"
+                    aria-hidden
                 />
             );
         }
@@ -48,7 +48,7 @@ export const Checkbox = ({
                 <StyledCheckedIcon
                     $disabled={disabled}
                     data-testid="checkmark"
-                    aria-hidden="true"
+                    aria-hidden
                 />
             );
         }
@@ -57,7 +57,7 @@ export const Checkbox = ({
             return (
                 <StyledUncheckedDisabledIcon
                     data-testid="empty-disabled-checkbox"
-                    aria-hidden="true"
+                    aria-hidden
                 />
             );
         }
@@ -66,7 +66,7 @@ export const Checkbox = ({
             <StyledUncheckedIcon
                 $disabled={disabled}
                 data-testid="empty-checkbox"
-                aria-hidden="true"
+                aria-hidden
             />
         );
     };

--- a/stories/checkbox/checkbox.stories.tsx
+++ b/stories/checkbox/checkbox.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { Checkbox } from "src/checkbox";
 import { GridDecorator } from "stories/storybook-common";
-import { Label, SubOption } from "./doc-elements";
+import { Label, SelectAll, SubOption } from "./doc-elements";
 
 type Component = typeof Checkbox;
 
@@ -51,22 +51,26 @@ export const IndeterminateState: StoryObj<Component> = {
         const [checked1, setChecked1] = useState(true);
         const [checked2, setChecked2] = useState(false);
         return (
-            <div role="group" aria-label="All options">
-                <Checkbox
-                    id="all-sub-options"
-                    checked={checked1 && checked2}
-                    indeterminate={checked1 !== checked2}
-                    onChange={() => {
-                        if (checked1 !== checked2) {
-                            setChecked1(true);
-                            setChecked2(true);
-                        } else {
-                            setChecked1(!checked1);
-                            setChecked2(!checked1);
-                        }
-                    }}
-                    aria-controls="sub-option-1 sub-option-2"
-                />
+            <div role="group">
+                <SelectAll>
+                    <Checkbox
+                        id="all-sub-options"
+                        checked={checked1 && checked2}
+                        indeterminate={checked1 !== checked2}
+                        onChange={() => {
+                            if (checked1 !== checked2) {
+                                setChecked1(true);
+                                setChecked2(true);
+                            } else {
+                                setChecked1(!checked1);
+                                setChecked2(!checked1);
+                            }
+                        }}
+                        aria-controls="sub-option-1 sub-option-2"
+                    />
+                    <Label htmlFor="all-sub-options">Select all</Label>
+                </SelectAll>
+
                 <div role="list">
                     <SubOption role="listitem">
                         <Checkbox

--- a/stories/checkbox/checkbox.stories.tsx
+++ b/stories/checkbox/checkbox.stories.tsx
@@ -51,8 +51,9 @@ export const IndeterminateState: StoryObj<Component> = {
         const [checked1, setChecked1] = useState(true);
         const [checked2, setChecked2] = useState(false);
         return (
-            <>
+            <div role="group" aria-label="All options">
                 <Checkbox
+                    id="all-sub-options"
                     checked={checked1 && checked2}
                     indeterminate={checked1 !== checked2}
                     onChange={() => {
@@ -64,24 +65,28 @@ export const IndeterminateState: StoryObj<Component> = {
                             setChecked2(!checked1);
                         }
                     }}
+                    aria-controls="sub-option-1 sub-option-2"
                 />
-                <SubOption>
-                    <Checkbox
-                        id="sub-option-1"
-                        checked={checked1}
-                        onChange={() => setChecked1(!checked1)}
-                    />
-                    <Label htmlFor="sub-option-1">Sub-option 1</Label>
-                </SubOption>
-                <SubOption>
-                    <Checkbox
-                        id="sub-option-2"
-                        checked={checked2}
-                        onChange={() => setChecked2(!checked2)}
-                    />
-                    <Label htmlFor="sub-option-2">Sub-option 2</Label>
-                </SubOption>
-            </>
+                <div role="list">
+                    <SubOption role="listitem">
+                        <Checkbox
+                            id="sub-option-1"
+                            checked={checked1}
+                            onChange={() => setChecked1(!checked1)}
+                        />
+                        <Label htmlFor="sub-option-1">Sub-option 1</Label>
+                    </SubOption>
+
+                    <SubOption role="listitem">
+                        <Checkbox
+                            id="sub-option-2"
+                            checked={checked2}
+                            onChange={() => setChecked2(!checked2)}
+                        />
+                        <Label htmlFor="sub-option-2">Sub-option 2</Label>
+                    </SubOption>
+                </div>
+            </div>
         );
     },
 };

--- a/stories/checkbox/doc-elements.tsx
+++ b/stories/checkbox/doc-elements.tsx
@@ -17,3 +17,9 @@ export const Label = styled.label`
     color: ${Colour.text};
     cursor: pointer;
 `;
+
+export const SelectAll = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+`;


### PR DESCRIPTION
**Changes**
- Changed structure of the checkbox component to follow example given
- Added `id` prop so that the checkbox label can be read out by the screen reader
- Added custom focus ring styles
- Adjusted the story for "Indeterminate state" to follow the example on w3 website (group the checkboxes tgt, and use list so the screenreader reads out the number of checkbox options in the list)

- delete branch
