### PR TITLE
[MISC][XY] Accessibility improvements to Navbar

### DIFF
--- a/src/navbar/brand.styles.tsx
+++ b/src/navbar/brand.styles.tsx
@@ -25,3 +25,16 @@ export const Clickable = styled.a<StyleProps>`
         object-fit: contain;
     }
 `;
+
+export const NonClickable = styled.div<StyleProps>`
+    display: flex;
+    justify-content: center;
+    height: 100%;
+
+    img {
+        width: auto;
+        height: 100%;
+        transition: ${Motion["duration-150"]} ${Motion["ease-default"]};
+        object-fit: contain;
+    }
+`;

--- a/src/navbar/brand.styles.tsx
+++ b/src/navbar/brand.styles.tsx
@@ -13,20 +13,7 @@ interface StyleProps {
 // =============================================================================
 // STYLING
 // =============================================================================
-export const Clickable = styled.a<StyleProps>`
-    display: flex;
-    justify-content: center;
-    height: 100%;
-
-    img {
-        width: auto;
-        height: 100%;
-        transition: ${Motion["duration-150"]} ${Motion["ease-default"]};
-        object-fit: contain;
-    }
-`;
-
-export const NonClickable = styled.div<StyleProps>`
+export const Container = styled.a<StyleProps>`
     display: flex;
     justify-content: center;
     height: 100%;

--- a/src/navbar/brand.tsx
+++ b/src/navbar/brand.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Clickable, NonClickable } from "./brand.styles";
+import { Container } from "./brand.styles";
 import { BrandType, NavbarBrandingProps } from "./types";
 import { ImageWithFallback } from "../shared/image-with-fallback/image-with-fallback";
 
@@ -34,36 +34,33 @@ export const Brand = ({
         }
     };
 
-    // Determine if this should be clickable - brands are clickable by default when onClick is provided
+    // Determine if this should be clickable - brands are clickable by default
     const isClickable = !!onClick;
 
-    const ariaLabel =
-        type === "primary"
+    const logoLabel = isClickable
+        ? type === "primary"
             ? `Go to ${resources.brandName} homepage`
-            : `Go to ${resources.brandName}`;
+            : `Go to ${resources.brandName}`
+        : resources.brandName;
 
-    if (isClickable) {
-        return (
-            <Clickable
-                data-id={dataId}
-                data-testid={testId}
-                $type={type}
-                href="#"
-                onClick={handleClick}
-                aria-label={ariaLabel}
-            >
-                <ImageWithFallback src={resources.logoSrc} alt="" />
-            </Clickable>
-        );
-    }
+    const props = isClickable
+        ? {
+              role: "link",
+              tabIndex: 0,
+              onClick: handleClick,
+          }
+        : {};
 
     return (
-        <NonClickable data-id={dataId} data-testid={testId} $type={type}>
-            <ImageWithFallback
-                src={resources.logoSrc}
-                alt={resources.brandName}
-            />
-        </NonClickable>
+        <Container
+            data-id={dataId}
+            data-testid={testId}
+            $type={type}
+            as={isClickable ? "a" : "div"}
+            {...props}
+        >
+            <ImageWithFallback src={resources.logoSrc} alt={logoLabel} />
+        </Container>
     );
 };
 

--- a/src/navbar/brand.tsx
+++ b/src/navbar/brand.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Clickable } from "./brand.styles";
+import { Clickable, NonClickable } from "./brand.styles";
 import { BrandType, NavbarBrandingProps } from "./types";
 import { ImageWithFallback } from "../shared/image-with-fallback/image-with-fallback";
 
@@ -29,24 +29,41 @@ export const Brand = ({
     // =============================================================================
     const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
         if (onClick) {
+            event.preventDefault();
             onClick(event, type);
         }
     };
 
+    // Determine if this should be clickable - brands are clickable by default when onClick is provided
+    const isClickable = !!onClick;
+
+    const ariaLabel =
+        type === "primary"
+            ? `Go to ${resources.brandName} homepage`
+            : `Go to ${resources.brandName}`;
+
+    if (isClickable) {
+        return (
+            <Clickable
+                data-id={dataId}
+                data-testid={testId}
+                $type={type}
+                href="#"
+                onClick={handleClick}
+                aria-label={ariaLabel}
+            >
+                <ImageWithFallback src={resources.logoSrc} alt="" />
+            </Clickable>
+        );
+    }
+
     return (
-        <Clickable
-            role="link"
-            onClick={handleClick}
-            tabIndex={0}
-            data-id={dataId}
-            data-testid={testId}
-            $type={type}
-        >
+        <NonClickable data-id={dataId} data-testid={testId} $type={type}>
             <ImageWithFallback
                 src={resources.logoSrc}
                 alt={resources.brandName}
             />
-        </Clickable>
+        </NonClickable>
     );
 };
 

--- a/src/navbar/drawer.styles.tsx
+++ b/src/navbar/drawer.styles.tsx
@@ -51,6 +51,7 @@ export const Container = styled.div<StyleProps>`
     background-color: ${Colour.bg};
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
     visibility: ${(props) => (props.$show ? "visible" : "hidden")};
+    outline: none;
 
     ${(props) => VISIBILITY_STYLE(props.$show)}
     ${(props) => {

--- a/src/navbar/drawer.styles.tsx
+++ b/src/navbar/drawer.styles.tsx
@@ -41,7 +41,7 @@ export const Wrapper = styled.div`
     }
 `;
 
-export const Container = styled.div<StyleProps>`
+export const Container = styled.nav<StyleProps>`
     position: absolute;
     overflow-y: auto;
     overflow-x: hidden;

--- a/src/navbar/drawer.tsx
+++ b/src/navbar/drawer.tsx
@@ -31,6 +31,7 @@ const Component = (
         hideNavBranding,
         onClose,
         onBrandClick,
+        drawerLabel = "Mobile navigation menu",
     } = props;
     const [viewHeight, setViewHeight] = useState<number>(0);
     const [focusedIndex, setFocusedIndex] = useState<number>(-1);
@@ -127,30 +128,19 @@ const Component = (
         };
     }, []);
 
-    // Focus management for keyboard navigation - focus container after transition
+    // Focus management for keyboard navigation
     useLayoutEffect(() => {
         if (show) {
-            // Reset navigation state when drawer opens
             setFocusedIndex(-1);
             setIsNavigating(false);
 
-            // Focus the container after animation completes (300ms + 200ms delay = 500ms total)
             const timer = setTimeout(() => {
                 if (containerRef.current) {
                     containerRef.current.focus({ preventScroll: true });
-                    // Ensure the container is visually focused for screen readers
-                    containerRef.current.setAttribute("aria-live", "polite");
-                    containerRef.current.setAttribute("aria-expanded", "true");
                 }
             }, 550);
 
             return () => clearTimeout(timer);
-        } else {
-            // Clean up attributes when drawer closes
-            if (containerRef.current) {
-                containerRef.current.removeAttribute("aria-live");
-                containerRef.current.setAttribute("aria-expanded", "false");
-            }
         }
     }, [show]);
 
@@ -219,14 +209,13 @@ const Component = (
     return (
         <Wrapper ref={ref} data-testid="drawer">
             <Container
+                as="nav"
                 ref={containerRef}
                 $show={show}
                 $viewHeight={viewHeight}
                 onKeyDown={handleKeyDown}
                 tabIndex={show ? 0 : -1}
-                role="navigation"
-                aria-label="Mobile navigation menu"
-                style={{ outline: "none" }}
+                aria-label={drawerLabel}
             >
                 <Content>
                     {renderTopBar()}

--- a/src/navbar/drawer.tsx
+++ b/src/navbar/drawer.tsx
@@ -1,10 +1,4 @@
-import React, {
-    useCallback,
-    useEffect,
-    useLayoutEffect,
-    useRef,
-    useState,
-} from "react";
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Brand } from "./brand";
 import {
     CloseButton,
@@ -53,21 +47,18 @@ const Component = (
         }
     };
 
-    const handleKeyDown = useCallback(
-        (event: React.KeyboardEvent<HTMLDivElement>) => {
-            if (!show) return;
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (!show) return;
 
-            if (event.key === "Escape") {
-                event.preventDefault();
-                onClose?.();
-                // Return focus to the hamburger menu button
-                setTimeout(() => {
-                    mobileMenuRef?.current?.focus();
-                }, 300);
-            }
-        },
-        [show, onClose, mobileMenuRef]
-    );
+        if (event.key === "Escape") {
+            event.preventDefault();
+            onClose?.();
+            // Return focus to the hamburger menu button
+            setTimeout(() => {
+                mobileMenuRef?.current?.focus();
+            }, 300);
+        }
+    };
 
     // =============================================================================
     // EFFECTS

--- a/src/navbar/drawer.tsx
+++ b/src/navbar/drawer.tsx
@@ -32,6 +32,7 @@ const Component = (
         onClose,
         onBrandClick,
         drawerLabel = "Mobile navigation menu",
+        mobileMenuRef,
     } = props;
     const [viewHeight, setViewHeight] = useState<number>(0);
     const containerRef = useRef<HTMLDivElement>(null);
@@ -61,14 +62,11 @@ const Component = (
                 onClose?.();
                 // Return focus to the hamburger menu button
                 setTimeout(() => {
-                    const hamburgerButton = document.querySelector(
-                        '[data-testid="button__mobile-menu"]'
-                    ) as HTMLElement;
-                    hamburgerButton?.focus();
+                    mobileMenuRef?.current?.focus();
                 }, 300);
             }
         },
-        [show, onClose]
+        [show, onClose, mobileMenuRef]
     );
 
     // =============================================================================
@@ -147,7 +145,6 @@ const Component = (
     return (
         <Wrapper ref={ref} data-testid="drawer">
             <Container
-                as="nav"
                 ref={containerRef}
                 $show={show}
                 $viewHeight={viewHeight}

--- a/src/navbar/drawer.tsx
+++ b/src/navbar/drawer.tsx
@@ -34,8 +34,6 @@ const Component = (
         drawerLabel = "Mobile navigation menu",
     } = props;
     const [viewHeight, setViewHeight] = useState<number>(0);
-    const [focusedIndex, setFocusedIndex] = useState<number>(-1);
-    const [isNavigating, setIsNavigating] = useState<boolean>(false);
     const containerRef = useRef<HTMLDivElement>(null);
 
     const { primary, secondary } = resources;
@@ -68,52 +66,9 @@ const Component = (
                     ) as HTMLElement;
                     hamburgerButton?.focus();
                 }, 300);
-                return;
-            }
-
-            // Handle arrow key navigation when drawer is open
-            const navLinks =
-                containerRef.current?.querySelectorAll(
-                    '[data-testid^="link__mobile-"]'
-                ) || [];
-            const maxIndex = navLinks.length - 1;
-
-            switch (event.key) {
-                case "ArrowDown":
-                    event.preventDefault();
-                    setIsNavigating(true);
-                    setFocusedIndex((prev) => {
-                        const newIndex =
-                            prev < 0 ? 0 : prev < maxIndex ? prev + 1 : 0;
-                        return newIndex;
-                    });
-                    break;
-                case "ArrowUp":
-                    event.preventDefault();
-                    setIsNavigating(true);
-                    setFocusedIndex((prev) => {
-                        const newIndex =
-                            prev < 0
-                                ? maxIndex
-                                : prev > 0
-                                ? prev - 1
-                                : maxIndex;
-                        return newIndex;
-                    });
-                    break;
-                case "Enter":
-                case " ":
-                    event.preventDefault();
-                    if (focusedIndex >= 0) {
-                        const currentLink = navLinks[
-                            focusedIndex
-                        ] as HTMLElement;
-                        currentLink?.click();
-                    }
-                    break;
             }
         },
-        [show, onClose, focusedIndex]
+        [show, onClose]
     );
 
     // =============================================================================
@@ -128,12 +83,9 @@ const Component = (
         };
     }, []);
 
-    // Focus management for keyboard navigation
+    // Focus management when drawer opens
     useLayoutEffect(() => {
         if (show) {
-            setFocusedIndex(-1);
-            setIsNavigating(false);
-
             const timer = setTimeout(() => {
                 if (containerRef.current) {
                     containerRef.current.focus({ preventScroll: true });
@@ -143,20 +95,6 @@ const Component = (
             return () => clearTimeout(timer);
         }
     }, [show]);
-
-    // Update focus when focusedIndex changes (only for arrow key navigation)
-    useEffect(() => {
-        if (show && isNavigating && focusedIndex >= 0) {
-            const navLinks =
-                containerRef.current?.querySelectorAll(
-                    '[data-testid^="link__mobile-"]'
-                ) || [];
-            if (focusedIndex < navLinks.length) {
-                const currentLink = navLinks[focusedIndex] as HTMLElement;
-                currentLink?.focus();
-            }
-        }
-    }, [focusedIndex, show, isNavigating]);
 
     // =============================================================================
     // RENDER FUNCTIONS

--- a/src/navbar/navbar-items.tsx
+++ b/src/navbar/navbar-items.tsx
@@ -62,25 +62,6 @@ export const NavbarItems = <T,>({
         setShowSubMenu(false);
     };
 
-    const addAriaHiddenToIcon = (children: React.ReactNode) => {
-        // Only add aria-hidden to React elements (icons) that don't have text content
-        if (React.isValidElement(children)) {
-            const hasText = React.Children.toArray(
-                children.props?.children || []
-            ).some(
-                (child) => typeof child === "string" && child.trim().length > 0
-            );
-
-            if (!hasText) {
-                return React.cloneElement(children, {
-                    "aria-hidden": children.props["aria-hidden"] ?? true,
-                    ...children.props,
-                });
-            }
-        }
-        return children;
-    };
-
     const checkSelected = (item: NavItemLinkProps<T>): boolean => {
         if (item.id === selectedId) {
             return true;
@@ -158,9 +139,7 @@ export const NavbarItems = <T,>({
                                 }
                                 {...options}
                             >
-                                <LinkLabel>
-                                    {addAriaHiddenToIcon(children)}
-                                </LinkLabel>
+                                <LinkLabel>{children}</LinkLabel>
                                 {selected && (
                                     <LinkIndicator
                                         data-testid={`${testId}-indicator`}

--- a/src/navbar/navbar-items.tsx
+++ b/src/navbar/navbar-items.tsx
@@ -62,6 +62,25 @@ export const NavbarItems = <T,>({
         setShowSubMenu(false);
     };
 
+    const addAriaHiddenToIcon = (children: React.ReactNode) => {
+        // Only add aria-hidden to React elements (icons) that don't have text content
+        if (React.isValidElement(children)) {
+            const hasText = React.Children.toArray(
+                children.props?.children || []
+            ).some(
+                (child) => typeof child === "string" && child.trim().length > 0
+            );
+
+            if (!hasText) {
+                return React.cloneElement(children, {
+                    "aria-hidden": children.props["aria-hidden"] ?? true,
+                    ...children.props,
+                });
+            }
+        }
+        return children;
+    };
+
     const checkSelected = (item: NavItemLinkProps<T>): boolean => {
         if (item.id === selectedId) {
             return true;
@@ -130,9 +149,18 @@ export const NavbarItems = <T,>({
                                 $selected={selected} /* for mobile */
                                 {...otherItemAttrs}
                                 onClick={handleLinkClick(item, index)}
+                                aria-current={selected ? "page" : undefined}
+                                aria-haspopup={item.subMenu ? true : undefined}
+                                aria-expanded={
+                                    mobile && item.subMenu
+                                        ? expanded
+                                        : undefined
+                                }
                                 {...options}
                             >
-                                <LinkLabel>{children}</LinkLabel>
+                                <LinkLabel>
+                                    {addAriaHiddenToIcon(children)}
+                                </LinkLabel>
                                 {selected && (
                                     <LinkIndicator
                                         data-testid={`${testId}-indicator`}
@@ -146,9 +174,6 @@ export const NavbarItems = <T,>({
                                             $selected={expanded}
                                             focusHighlight={false}
                                             focusOutline="browser"
-                                            aria-label={
-                                                expanded ? "Collapse" : "Expand"
-                                            }
                                         >
                                             <ChevronIcon $selected={selected} />
                                         </ExpandCollapseButton>

--- a/src/navbar/navbar-items.tsx
+++ b/src/navbar/navbar-items.tsx
@@ -153,6 +153,9 @@ export const NavbarItems = <T,>({
                                             $selected={expanded}
                                             focusHighlight={false}
                                             focusOutline="browser"
+                                            aria-label={
+                                                expanded ? "Collapse" : "Expand"
+                                            }
                                         >
                                             <ChevronIcon $selected={selected} />
                                         </ExpandCollapseButton>

--- a/src/navbar/navbar.tsx
+++ b/src/navbar/navbar.tsx
@@ -147,7 +147,6 @@ const Component = <T,>(
         type: BrandType
     ) => {
         if (onBrandClick) {
-            event.preventDefault();
             onBrandClick(type);
         }
 
@@ -216,7 +215,7 @@ const Component = <T,>(
     const renderDrawer = () => (
         <Overlay
             show={showOverlay}
-            enableOverlayClick={true}
+            enableOverlayClick
             onOverlayClick={handleDrawerClose}
         >
             <Drawer
@@ -292,7 +291,7 @@ const Component = <T,>(
     const renderNavbar = () => {
         return (
             <Layout.Content stretch={isStretch}>
-                <Nav $compress={compress}>
+                <Nav $compress={compress} aria-label="Main navigation menu">
                     {!hideNavBranding && renderBrand()}
                     {!hideNavElements && (
                         <NavElementsContainer

--- a/src/navbar/navbar.tsx
+++ b/src/navbar/navbar.tsx
@@ -56,6 +56,7 @@ const Component = <T,>(
         masthead = true,
         layout = "default",
         headerLabel = "Main navigation menu",
+        drawerLabel,
         ...otherProps
     }: NavbarProps<T>,
     ref: React.Ref<NavbarDrawerHandle>
@@ -65,6 +66,7 @@ const Component = <T,>(
     // =============================================================================
     const [showDrawer, setShowDrawer] = useState<boolean>(false);
     const [showOverlay, setShowOverlay] = useState<boolean>(false);
+    const mobileMenuRef = useRef<HTMLButtonElement>(null);
     const isStretch = layout === "stretch";
     const elementRef = useRef<HTMLDivElement>(null);
     const theme = useTheme();
@@ -226,6 +228,8 @@ const Component = <T,>(
                 onBrandClick={handleBrandClick}
                 actionButtons={actionButtons}
                 hideNavBranding={hideNavBranding}
+                mobileMenuRef={mobileMenuRef}
+                drawerLabel={drawerLabel}
             >
                 <NavbarItems
                     items={items.mobile || items.desktop}
@@ -276,6 +280,7 @@ const Component = <T,>(
         ) {
             return (
                 <MobileMenuButton
+                    ref={mobileMenuRef}
                     aria-label={showDrawer ? "Close nav menu" : "Open nav menu"}
                     aria-expanded={showDrawer}
                     data-testid="button__mobile-menu"

--- a/src/navbar/navbar.tsx
+++ b/src/navbar/navbar.tsx
@@ -55,6 +55,7 @@ const Component = <T,>(
         onBrandClick,
         masthead = true,
         layout = "default",
+        headerLabel = "Main navigation menu",
         ...otherProps
     }: NavbarProps<T>,
     ref: React.Ref<NavbarDrawerHandle>
@@ -275,7 +276,8 @@ const Component = <T,>(
         ) {
             return (
                 <MobileMenuButton
-                    aria-label="Open nav menu"
+                    aria-label={showDrawer ? "Close nav menu" : "Open nav menu"}
+                    aria-expanded={showDrawer}
                     data-testid="button__mobile-menu"
                     onClick={handleMobileMenuButtonClick}
                     focusHighlight={false}
@@ -291,7 +293,7 @@ const Component = <T,>(
     const renderNavbar = () => {
         return (
             <Layout.Content stretch={isStretch}>
-                <Nav $compress={compress} aria-label="Main navigation menu">
+                <Nav $compress={compress} aria-label={headerLabel}>
                     {!hideNavBranding && renderBrand()}
                     {!hideNavElements && (
                         <NavElementsContainer

--- a/src/navbar/types.ts
+++ b/src/navbar/types.ts
@@ -101,6 +101,8 @@ export interface NavbarDrawerProps extends NavbarSharedProps {
               type: BrandType
           ) => void)
         | undefined;
+    /** Custom aria-label for the mobile navigation drawer */
+    drawerLabel?: string | undefined;
 }
 
 export type BrandType = "primary" | "secondary";
@@ -134,4 +136,6 @@ export interface NavbarProps<T = void> extends NavbarSharedProps {
     /** Specifies if masthead should be rendered */
     masthead?: boolean | undefined;
     layout?: "default" | "stretch" | undefined;
+    /** Custom aria-label for the main navigation header */
+    headerLabel?: string | undefined;
 }

--- a/src/navbar/types.ts
+++ b/src/navbar/types.ts
@@ -103,6 +103,8 @@ export interface NavbarDrawerProps extends NavbarSharedProps {
         | undefined;
     /** Custom aria-label for the mobile navigation drawer */
     drawerLabel?: string | undefined;
+    /** Ref to the mobile menu button for focus management */
+    mobileMenuRef?: React.RefObject<HTMLButtonElement> | undefined;
 }
 
 export type BrandType = "primary" | "secondary";
@@ -138,4 +140,6 @@ export interface NavbarProps<T = void> extends NavbarSharedProps {
     layout?: "default" | "stretch" | undefined;
     /** Custom aria-label for the main navigation header */
     headerLabel?: string | undefined;
+    /** Custom aria-label for the mobile navigation drawer */
+    drawerLabel?: string | undefined;
 }

--- a/stories/navbar/props-table.tsx
+++ b/stories/navbar/props-table.tsx
@@ -115,6 +115,20 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["stretch | default"],
                 defaultValue: "default",
             },
+            {
+                name: "headerLabel",
+                description:
+                    "Specifies the accessible label for the main navigation header",
+                propTypes: ["string"],
+                defaultValue: "Main navigation menu",
+            },
+            {
+                name: "drawerLabel",
+                description:
+                    "Specifies the accessible label for the mobile navigation drawer",
+                propTypes: ["string"],
+                defaultValue: "Mobile navigation menu",
+            },
         ],
     },
     {


### PR DESCRIPTION
**Changes**

_Navbar_
- add `aria-label="Main navigation menu"`
- add `aria-hidden` to links using icons to prevent it from announcing the link as an image

_Brand_
- add `aria-label` for primary and secondary branding
- add `NonClickable` so screen reader doesn't read non-interactive logos as a link

_Drawer_
- add `aria-label="Mobile navigation menu"`
- add arrow keyboard navigation

- keep branch

**Additional information**

- You may refer to this [figma](https://www.figma.com/design/wDAxbRmlq4xOn4UJ8zPuEF/%F0%9F%A7%91%F0%9F%8F%BB%E2%80%8D%F0%9F%A6%AF-Flagship-A11y-Annotations?node-id=1647-949)
- This update only includes changes to elements used by A11y Playground (navbar-items, brand & drawer)
