### PR TITLE
[MISC][Viv] LocalNav a11y improvements

### DIFF
--- a/src/local-nav/internal-types.tsx
+++ b/src/local-nav/internal-types.tsx
@@ -10,6 +10,7 @@ interface LocalNavItemBaseComponentProps {
     ) => void;
     isSelected: boolean;
     item: LocalNavItemProps;
+    index: number;
 }
 
 export interface LocalNavMenuItemComponentProps

--- a/src/local-nav/internal-types.tsx
+++ b/src/local-nav/internal-types.tsx
@@ -5,7 +5,9 @@ import {
 } from "./types";
 
 interface LocalNavItemBaseComponentProps {
-    handleClick: React.MouseEventHandler<HTMLLIElement>;
+    handleClick: (
+        e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>
+    ) => void;
     isSelected: boolean;
     item: LocalNavItemProps;
 }

--- a/src/local-nav/internal-types.tsx
+++ b/src/local-nav/internal-types.tsx
@@ -30,4 +30,5 @@ export interface LocalNavDropdownItemComponentProps
               renderProps: LocalNavDropdownItemRenderProps
           ) => React.ReactNode)
         | undefined;
+    index: number;
 }

--- a/src/local-nav/local-nav-dropdown/local-nav-dropdown.styles.tsx
+++ b/src/local-nav/local-nav-dropdown/local-nav-dropdown.styles.tsx
@@ -74,8 +74,14 @@ export const NavSelect = styled.div<NavLabelStyleProps>`
 export const NavItem = styled.li<NavItemStyleProps>`
     padding: ${(props) =>
         props.$isSelected
-            ? `${Spacing["spacing-12"]} ${Spacing["spacing-8"]} ${Spacing["spacing-12"]} 0`
-            : `${Spacing["spacing-12"]} ${Spacing["spacing-8"]} ${Spacing["spacing-12"]} ${Spacing["spacing-32"]}`};
+            ? css`
+                  ${Spacing["spacing-12"]} ${Spacing["spacing-8"]} 
+                  ${Spacing["spacing-12"]} 0
+              `
+            : css`
+                  ${Spacing["spacing-12"]} ${Spacing["spacing-8"]}
+                  ${Spacing["spacing-12"]} ${Spacing["spacing-32"]}
+              `};
     background: ${(props) =>
         props.$isSelected ? Colour["bg-primary-subtlest"] : Colour["bg"]};
     /* Ensures that the tick mark is positioned relative to the selected item */

--- a/src/local-nav/local-nav-dropdown/local-nav-dropdown.styles.tsx
+++ b/src/local-nav/local-nav-dropdown/local-nav-dropdown.styles.tsx
@@ -1,7 +1,7 @@
 import { ChevronDownIcon } from "@lifesg/react-icons/chevron-down";
 import { TickIcon } from "@lifesg/react-icons/tick";
 import styled, { css } from "styled-components";
-import { Colour, Font, Motion, Radius } from "../../theme";
+import { Colour, Font, Motion, Radius, Spacing } from "../../theme";
 
 // =============================================================================
 // STYLE INTERFACES, transient props are denoted with $
@@ -44,7 +44,7 @@ export const NavSelectIcon = styled(ChevronDownIcon)<NavIconStyleProps>`
 export const NavSelect = styled.div<NavLabelStyleProps>`
     cursor: pointer;
     background: ${Colour["bg"]};
-    padding: 12px 16px;
+    padding: ${Spacing["spacing-12"]} ${Spacing["spacing-16"]};
     overflow: hidden;
     box-shadow: 0 0 1px 1px ${Colour["border"]};
     border-radius: ${Radius["sm"]};
@@ -58,6 +58,13 @@ export const NavSelect = styled.div<NavLabelStyleProps>`
     justify-content: space-between;
     align-items: center;
     transition: all ${Motion["duration-250"]} ${Motion["ease-default"]};
+    transition-property: background, border-radius, box-shadow, transform;
+
+    &:focus-visible {
+        outline: 2px solid ${Colour["focus-ring"]};
+        outline-offset: 2px;
+        border-radius: ${Radius["sm"]};
+    }
 `;
 
 // -----------------------------------------------------------------------------
@@ -66,7 +73,9 @@ export const NavSelect = styled.div<NavLabelStyleProps>`
 
 export const NavItem = styled.li<NavItemStyleProps>`
     padding: ${(props) =>
-        props.$isSelected ? "12px 8px 12px 0" : "12px 8px 12px 32px"};
+        props.$isSelected
+            ? `${Spacing["spacing-12"]} ${Spacing["spacing-8"]} ${Spacing["spacing-12"]} 0`
+            : `${Spacing["spacing-12"]} ${Spacing["spacing-8"]} ${Spacing["spacing-12"]} ${Spacing["spacing-32"]}`};
     background: ${(props) =>
         props.$isSelected ? Colour["bg-primary-subtlest"] : Colour["bg"]};
     /* Ensures that the tick mark is positioned relative to the selected item */
@@ -74,13 +83,19 @@ export const NavItem = styled.li<NavItemStyleProps>`
     display: flex;
     /* Vertically align text and tick */
     align-items: center;
+
+    &:focus-visible {
+        outline: 2px solid ${Colour["focus-ring"]};
+        outline-offset: 0px;
+        border-radius: ${Radius["sm"]};
+    }
 `;
 
 export const NavItemList = styled.ul<NavItemListStyleProps>`
     transition: all ${Motion["duration-250"]} ${Motion["ease-default"]};
     transform-origin: top;
     list-style-type: none;
-    padding: 0 8px;
+    padding: 0 ${Spacing["spacing-8"]};
     margin: 0;
     background: ${Colour["bg"]};
     cursor: pointer;
@@ -101,7 +116,7 @@ export const NavItemLabel = styled.div<NavItemStyleProps>`
 
 export const StyledTickIcon = styled(TickIcon)`
     color: ${Colour["icon-selected"]};
-    margin: 0 8px;
+    margin: 0 ${Spacing["spacing-8"]};
 `;
 
 // -----------------------------------------------------------------------------
@@ -130,7 +145,7 @@ export const NavWrapper = styled.nav<DropdownNavStyleProps>`
         css`
             ${NavSelect} {
                 ${$sideMargin && `margin: 0 -${$sideMargin}px;`}
-                padding: 12px 16px;
+                padding: ${Spacing["spacing-12"]} ${Spacing["spacing-16"]};
                 border-radius: ${Radius["none"]};
             }
 

--- a/src/local-nav/local-nav-dropdown/local-nav-dropdown.tsx
+++ b/src/local-nav/local-nav-dropdown/local-nav-dropdown.tsx
@@ -44,7 +44,7 @@ const Component = (
     const [dynamicMargin, setDynamicMargin] = useState(0);
     const [focusedIndex, setFocusedIndex] = useState(0);
     const navTestId = testId || "local-nav-dropdown";
-    const dropdownListId = SimpleIdGenerator.generate();
+    const [dropdownListId] = useState(() => SimpleIdGenerator.generate());
 
     useImperativeHandle(ref, () => navWrapperRef.current!);
 
@@ -130,10 +130,6 @@ const Component = (
             window.removeEventListener("resize", adjustPadding);
         };
     }, []);
-
-    useEffect(() => {
-        listItemRefs.current = Array(items.length).fill(null);
-    }, [items.length]);
 
     useEffect(() => {
         if (isDropdownExpanded) {

--- a/src/local-nav/local-nav-dropdown/local-nav-dropdown.tsx
+++ b/src/local-nav/local-nav-dropdown/local-nav-dropdown.tsx
@@ -282,6 +282,7 @@ const Component = (
             return (
                 <li
                     id={id}
+                    key={index}
                     role="menuitem"
                     onClick={handleClick}
                     onKeyDown={(e) => handleNavItemKeyDown(e, handleClick)}
@@ -302,6 +303,7 @@ const Component = (
         return (
             <NavItem
                 id={id}
+                key={index}
                 role="menuitem"
                 $isSelected={isSelected && isStickied}
                 onClick={handleClick}

--- a/src/local-nav/local-nav-menu/local-nav-menu.styles.tsx
+++ b/src/local-nav/local-nav-menu/local-nav-menu.styles.tsx
@@ -25,9 +25,10 @@ export const TextLabel = styled(Typography.BodyBL)<NavItemStyleProps>`
 `;
 
 export const NavItem = styled.li<NavItemStyleProps>`
+    display: block;
     position: relative;
     margin: 0;
-    padding: 1rem;
+    padding: 0;
     cursor: pointer;
 
     &::before {
@@ -44,7 +45,14 @@ export const NavItem = styled.li<NavItemStyleProps>`
         transition: all 250ms linear;
     }
 
-    &:hover {
+    &:hover,
+    &:focus-within {
         background-color: ${Colour["bg-hover-subtle"]};
+    }
+
+    div[role="link"] {
+        display: block;
+        padding: 16px;
+        padding-left: 20px; // Account for left border
     }
 `;

--- a/src/local-nav/local-nav-menu/local-nav-menu.styles.tsx
+++ b/src/local-nav/local-nav-menu/local-nav-menu.styles.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { Colour } from "../../theme";
+import { Colour, Radius, Spacing } from "../../theme";
 import { Typography } from "../../typography";
 
 // =============================================================================
@@ -49,10 +49,16 @@ export const NavItem = styled.li<NavItemStyleProps>`
     &:focus-within {
         background-color: ${Colour["bg-hover-subtle"]};
     }
+`;
 
-    div[role="link"] {
-        display: block;
-        padding: 16px;
-        padding-left: 20px; // Account for left border
+export const NavItemContent = styled.div`
+    display: block;
+    padding: ${Spacing["spacing-16"]};
+    padding-left: ${Spacing["spacing-20"]};
+
+    &:focus-visible {
+        outline: 2px solid ${Colour["focus-ring"]};
+        outline-offset: 2px;
+        border-radius: ${Radius["sm"]};
     }
 `;

--- a/src/local-nav/local-nav-menu/local-nav-menu.tsx
+++ b/src/local-nav/local-nav-menu/local-nav-menu.tsx
@@ -51,8 +51,21 @@ const Component = (
         };
 
         return (
-            <NavItem id={id} $isSelected={isSelected} onClick={handleClick}>
-                {renderTitle()}
+            <NavItem id={id} $isSelected={isSelected}>
+                <div
+                    role="link"
+                    onClick={handleClick}
+                    onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            handleClick(e);
+                        }
+                    }}
+                    tabIndex={0}
+                    aria-current={isSelected ? true : undefined}
+                >
+                    {renderTitle()}
+                </div>
             </NavItem>
         );
     };

--- a/src/local-nav/local-nav-menu/local-nav-menu.tsx
+++ b/src/local-nav/local-nav-menu/local-nav-menu.tsx
@@ -58,6 +58,7 @@ const Component = (
         isSelected,
         item,
         renderItem,
+        index,
     }: LocalNavMenuItemComponentProps) => {
         const { id, title } = item;
 
@@ -73,7 +74,7 @@ const Component = (
         };
 
         return (
-            <NavItem id={id} $isSelected={isSelected}>
+            <NavItem id={id} key={index} $isSelected={isSelected}>
                 <NavItemContent
                     role="link"
                     onClick={handleClick}
@@ -100,6 +101,7 @@ const Component = (
                     isSelected,
                     item,
                     renderItem,
+                    index: i,
                 });
             })}
         </Nav>

--- a/src/local-nav/local-nav-menu/local-nav-menu.tsx
+++ b/src/local-nav/local-nav-menu/local-nav-menu.tsx
@@ -2,7 +2,12 @@
 import React from "react";
 import { LocalNavMenuItemComponentProps } from "../internal-types";
 import { LocalNavMenuProps } from "../types";
-import { Nav, NavItem, TextLabel } from "./local-nav-menu.styles";
+import {
+    Nav,
+    NavItem,
+    NavItemContent,
+    TextLabel,
+} from "./local-nav-menu.styles";
 
 /**
  * A sidebar navigation element. The currently visible section will be highlighted.
@@ -26,6 +31,23 @@ const Component = (
     // CONST, STATE, REF
     // =============================================================================
     const localNavMenuId = dataTestId || "local-nav-menu";
+
+    // =============================================================================
+    // EVENT HANDLERS
+    // ============================================================================
+    const handleNavItemKeyDown = (
+        e: React.KeyboardEvent<HTMLElement>,
+        handleClick: (
+            e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>
+        ) => void
+    ) => {
+        const { key } = e;
+
+        if (key === "Enter" || key === " ") {
+            e.preventDefault();
+            handleClick(e);
+        }
+    };
 
     // =============================================================================
     // RENDER FUNCTIONS
@@ -52,20 +74,15 @@ const Component = (
 
         return (
             <NavItem id={id} $isSelected={isSelected}>
-                <div
+                <NavItemContent
                     role="link"
                     onClick={handleClick}
-                    onKeyDown={(e) => {
-                        if (e.key === "Enter" || e.key === " ") {
-                            e.preventDefault();
-                            handleClick(e);
-                        }
-                    }}
+                    onKeyDown={(e) => handleNavItemKeyDown(e, handleClick)}
                     tabIndex={0}
                     aria-current={isSelected ? true : undefined}
                 >
                     {renderTitle()}
-                </div>
+                </NavItemContent>
             </NavItem>
         );
     };

--- a/src/local-nav/types.ts
+++ b/src/local-nav/types.ts
@@ -8,7 +8,7 @@ interface BaseLocalNavProps {
     id?: string | undefined;
     "data-testid"?: string | undefined;
     onNavItemSelect: (
-        e: React.MouseEvent,
+        e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
         item: LocalNavItemProps,
         index: number
     ) => void;

--- a/stories/local-nav/doc-elements.tsx
+++ b/stories/local-nav/doc-elements.tsx
@@ -26,7 +26,7 @@ const renderSection = (index: number) => (
         </Typography.HeadingMD>
         <Typography.BodyBL style={{ margin: "1rem 0" }}>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus a
-            tortor vitae magna sagittis bibendum.
+            tortor vitae magna sagittis bibendum. <a href="#">Link</a>
         </Typography.BodyBL>
     </div>
 );

--- a/stories/local-nav/local-nav.stories.tsx
+++ b/stories/local-nav/local-nav.stories.tsx
@@ -145,7 +145,7 @@ export const DropdownWithCustomTitle: StoryObj<DropdownComponent> = {
         const contentRef = useRef<HTMLDivElement>(null);
 
         const handleNavItemClick = (
-            e: React.MouseEvent | React.KeyboardEvent<HTMLElement>,
+            e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
             item: LocalNavItemProps,
             index: number
         ) => {

--- a/stories/local-nav/local-nav.stories.tsx
+++ b/stories/local-nav/local-nav.stories.tsx
@@ -30,7 +30,7 @@ export const Menu: StoryObj<MenuComponent> = {
         const [selectedIndex, setSelectedIndex] = useState(-1);
 
         const handleNavItemClick = (
-            e: React.MouseEvent,
+            e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
             item: LocalNavItemProps,
             index: number
         ) => {
@@ -54,7 +54,7 @@ export const MenuWithCustomTitle: StoryObj<MenuComponent> = {
         const [selectedIndex, setSelectedIndex] = useState(-1);
 
         const handleNavItemClick = (
-            e: React.MouseEvent,
+            e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
             item: LocalNavItemProps,
             index: number
         ) => {
@@ -95,7 +95,7 @@ export const Dropdown: StoryObj<DropdownComponent> = {
         const contentRef = useRef<HTMLDivElement>(null);
 
         const handleNavItemClick = (
-            e: React.MouseEvent,
+            e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
             item: LocalNavItemProps,
             index: number
         ) => {
@@ -145,7 +145,7 @@ export const DropdownWithCustomTitle: StoryObj<DropdownComponent> = {
         const contentRef = useRef<HTMLDivElement>(null);
 
         const handleNavItemClick = (
-            e: React.MouseEvent,
+            e: React.MouseEvent | React.KeyboardEvent<HTMLElement>,
             item: LocalNavItemProps,
             index: number
         ) => {
@@ -214,7 +214,7 @@ export const CombinedUsage: StoryObj = {
         });
 
         const handleNavItemClick = (
-            e: React.MouseEvent,
+            e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
             item: LocalNavItemProps,
             index: number
         ) => {

--- a/stories/local-nav/props-table.tsx
+++ b/stories/local-nav/props-table.tsx
@@ -36,7 +36,7 @@ const COMMON_ATTRIBUTES: ApiTableAttributeRowProps[] = [
         name: "onNavItemSelect",
         description: "Called when the nav item is selected",
         propTypes: [
-            "(e: React.MouseEvent, item: LocalNavItemProps, index: number) => void",
+            "(e: React.MouseEvent | React.KeyboardEvent, item: LocalNavItemProps, index: number) => void",
         ],
     },
     {

--- a/tests/local-nav/local-nav.spec.tsx
+++ b/tests/local-nav/local-nav.spec.tsx
@@ -1,0 +1,277 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { LocalNavDropdown, LocalNavMenu } from "../../src/local-nav";
+import { LocalNavItemProps } from "../../src/local-nav/types";
+
+const MOCK_ITEMS: LocalNavItemProps[] = [
+    { title: "Section 1" },
+    { title: "Section 2" },
+    { title: "Section 3" },
+];
+
+describe("LocalNav", () => {
+    describe("Menu variant", () => {
+        it("should render all menu items", () => {
+            const mockOnSelect = jest.fn();
+
+            render(
+                <LocalNavMenu
+                    items={MOCK_ITEMS}
+                    onNavItemSelect={mockOnSelect}
+                />
+            );
+
+            expect(screen.getByText("Section 1")).toBeInTheDocument();
+            expect(screen.getByText("Section 2")).toBeInTheDocument();
+            expect(screen.getByText("Section 3")).toBeInTheDocument();
+        });
+
+        it("should highlight selected item", () => {
+            const mockOnSelect = jest.fn();
+
+            render(
+                <LocalNavMenu
+                    items={MOCK_ITEMS}
+                    selectedItemIndex={1}
+                    onNavItemSelect={mockOnSelect}
+                />
+            );
+
+            expect(
+                screen.getByText("Section 2").closest("div")
+            ).toHaveAttribute("aria-current", "true");
+        });
+
+        it("should call onNavItemSelect when item is clicked", async () => {
+            const user = userEvent.setup();
+            const mockOnSelect = jest.fn();
+
+            render(
+                <LocalNavMenu
+                    items={MOCK_ITEMS}
+                    onNavItemSelect={mockOnSelect}
+                />
+            );
+
+            await user.click(screen.getByText("Section 2"));
+
+            expect(mockOnSelect).toHaveBeenCalledWith(
+                expect.anything(),
+                MOCK_ITEMS[1],
+                1
+            );
+        });
+
+        it("should render custom items when renderItem is provided", () => {
+            const mockOnSelect = jest.fn();
+            const customRender = (item: LocalNavItemProps) => (
+                <span>Custom: {item.title}</span>
+            );
+
+            render(
+                <LocalNavMenu
+                    items={MOCK_ITEMS}
+                    onNavItemSelect={mockOnSelect}
+                    renderItem={customRender}
+                />
+            );
+
+            expect(screen.getByText("Custom: Section 1")).toBeInTheDocument();
+        });
+    });
+
+    describe("LocalNavDropdown", () => {
+        beforeEach(() => {
+            global.IntersectionObserver = jest.fn().mockImplementation(() => ({
+                observe: jest.fn(),
+                unobserve: jest.fn(),
+                disconnect: jest.fn(),
+            }));
+        });
+
+        it("should render with default label", () => {
+            const mockOnSelect = jest.fn();
+
+            render(
+                <LocalNavDropdown
+                    items={MOCK_ITEMS}
+                    defaultLabel="Select section"
+                    onNavItemSelect={mockOnSelect}
+                />
+            );
+
+            expect(
+                screen.getByRole("button", { name: "Select section" })
+            ).toBeInTheDocument();
+            expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+            expect(screen.queryAllByRole("menuitem")).toHaveLength(0);
+        });
+
+        it("should show default label in non-sticky mode", () => {
+            const mockOnSelect = jest.fn();
+
+            render(
+                <LocalNavDropdown
+                    items={MOCK_ITEMS}
+                    defaultLabel="Select section"
+                    selectedItemIndex={1}
+                    onNavItemSelect={mockOnSelect}
+                />
+            );
+
+            expect(
+                screen.getByRole("button", { name: "Select section" })
+            ).toBeInTheDocument();
+        });
+
+        it("should show selected item label in sticky mode", () => {
+            const mockOnSelect = jest.fn();
+
+            render(
+                <LocalNavDropdown
+                    items={MOCK_ITEMS}
+                    defaultLabel="Select section"
+                    selectedItemIndex={1}
+                    onNavItemSelect={mockOnSelect}
+                />
+            );
+
+            const callback = (global.IntersectionObserver as jest.Mock).mock
+                .lastCall?.[0];
+
+            act(() => {
+                callback([{ isIntersecting: false }]);
+            });
+
+            expect(
+                screen.getByRole("button", { name: "Section 2" })
+            ).toBeInTheDocument();
+        });
+
+        it("should open dropdown when clicked", async () => {
+            const user = userEvent.setup();
+            const mockOnSelect = jest.fn();
+
+            render(
+                <LocalNavDropdown
+                    items={MOCK_ITEMS}
+                    defaultLabel="Select section"
+                    onNavItemSelect={mockOnSelect}
+                />
+            );
+
+            await user.click(screen.getByText("Select section"));
+
+            expect(screen.getByRole("menu")).toBeInTheDocument();
+            expect(screen.getAllByRole("menuitem")).toHaveLength(3);
+            expect(screen.getByText("Section 1")).toBeInTheDocument();
+            expect(screen.getByText("Section 2")).toBeInTheDocument();
+            expect(screen.getByText("Section 3")).toBeInTheDocument();
+        });
+
+        it("should call onNavItemSelect when dropdown item is clicked", async () => {
+            const user = userEvent.setup();
+            const mockOnSelect = jest.fn();
+
+            render(
+                <LocalNavDropdown
+                    items={MOCK_ITEMS}
+                    defaultLabel="Select section"
+                    onNavItemSelect={mockOnSelect}
+                />
+            );
+
+            await user.click(screen.getByText("Select section"));
+            await user.click(screen.getByText("Section 2"));
+
+            expect(mockOnSelect).toHaveBeenCalledWith(
+                expect.any(Object),
+                MOCK_ITEMS[1],
+                1
+            );
+        });
+
+        it("should close dropdown after selection", async () => {
+            const user = userEvent.setup();
+            const mockOnSelect = jest.fn();
+
+            render(
+                <LocalNavDropdown
+                    items={MOCK_ITEMS}
+                    defaultLabel="Select section"
+                    onNavItemSelect={mockOnSelect}
+                />
+            );
+
+            await user.click(screen.getByText("Select section"));
+
+            expect(screen.queryByRole("menu")).toBeInTheDocument();
+
+            await user.click(screen.getByText("Section 1"));
+
+            expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+        });
+
+        it("should render custom dropdown items when renderItem is provided", async () => {
+            const user = userEvent.setup();
+            const mockOnSelect = jest.fn();
+            const customRender = (item: LocalNavItemProps) => (
+                <span>Custom: {item.title}</span>
+            );
+
+            render(
+                <LocalNavDropdown
+                    items={MOCK_ITEMS}
+                    defaultLabel="Select section"
+                    onNavItemSelect={mockOnSelect}
+                    renderItem={customRender}
+                />
+            );
+
+            await user.click(screen.getByText("Select section"));
+
+            expect(screen.getByText("Custom: Section 1")).toBeInTheDocument();
+        });
+
+        it("should handle keyboard navigation and selection", async () => {
+            const user = userEvent.setup();
+            const mockOnSelect = jest.fn();
+
+            render(
+                <LocalNavDropdown
+                    items={MOCK_ITEMS}
+                    defaultLabel="Select section"
+                    onNavItemSelect={mockOnSelect}
+                />
+            );
+
+            await user.keyboard("{Tab}");
+
+            expect(
+                screen.getByTestId("local-nav-dropdown-label")
+            ).toHaveFocus();
+
+            await user.keyboard(" ");
+
+            expect(screen.getByRole("menu")).toBeInTheDocument();
+            expect(
+                screen.getByRole("menuitem", { name: "Section 1" })
+            ).toHaveFocus();
+
+            await user.keyboard("{ArrowDown}");
+
+            expect(
+                screen.getByRole("menuitem", { name: "Section 2" })
+            ).toHaveFocus();
+
+            await user.keyboard(" ");
+
+            expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+            expect(mockOnSelect).toHaveBeenCalledWith(
+                expect.any(Object),
+                MOCK_ITEMS[1],
+                1
+            );
+        });
+    });
+});


### PR DESCRIPTION
**Changes**
- Added keyboard interactivity to the LocalNavMenu and LocalNavDropdown components.

- delete branch

<!-- Remove if not required -->
**Changelog entry**

**LocalNavDropdown**
- `Added focusFirstMenuItem` and `focusLastMenuItem` functions to support the interaction of "ArrowDown" and "ArrowUp" to open the LocalNav menu and focus on the first or last item in the menu. Following this example in W3's website: [Navigation Menu Button Example](https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/examples/menu-button-links/)
- Used `menu` and `menuitem` roles, following the example above
- Added keyboard event handlers as functions, to support ArrowDown, ArrowUp, Enter, Spacebar, Tab, Escape key presses
- Note: `NavItem` should not be in tab order since it's in a dropdown, need to use arrow keys to navigate up and down the list.
- Changed the story to include hyperlinks in the content, to show the behaviour with other focusable elements on the page. 

**LocalNavMenu**
- Fixed left-padding of the link to match Figma design (previously, the padding did not account for the border-width)
- Added keyboard event handlers to support Enter and Spacebar


- [BREAKING] Addition of keyboard event handlers means that the event handlers on consumers' end need to be updated to support the Keyboard Event type. 

**Additional information**

- Figma file for A11y Annotations [here](https://www.figma.com/design/wDAxbRmlq4xOn4UJ8zPuEF/%F0%9F%A7%91%F0%9F%8F%BB%E2%80%8D%F0%9F%A6%AF-Flagship-A11y-Annotations?node-id=1094-469&t=4g6yDh6mchQowEOL-11)