### PR TITLE
Fix masthead dark mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
                 "@dnd-kit/sortable": "^7.0.2",
                 "@floating-ui/dom": "^1.6.10",
                 "@floating-ui/react": "^0.26.23",
+                "@govtechsg/sgds-web-component": "^3.0.6",
                 "@inquirer/prompts": "^7.0.0",
                 "@lifesg/react-icons": "^1.6.0",
                 "@playwright/test": "^1.45.0",
@@ -2112,6 +2113,18 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@babel/runtime-corejs3": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.0.tgz",
+            "integrity": "sha512-nlIXnSqLcBij8K8TtkxbBJgfzfvi75V1pAKSM7dUXejGw12vJAqez74jZrHTsJ3Z+Aczc5Q/6JgNjKRMsVU44g==",
+            "dev": true,
+            "dependencies": {
+                "core-js-pure": "^3.43.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/template": {
             "version": "7.27.2",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -2826,6 +2839,21 @@
             "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
             "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
             "dev": true
+        },
+        "node_modules/@govtechsg/sgds-web-component": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@govtechsg/sgds-web-component/-/sgds-web-component-3.0.6.tgz",
+            "integrity": "sha512-DpePFvm4S0pLxVBVTgOu857coldX+r+GOdGk/a1AX/TBVsIebzOHLrGTFlJWTD5Oy68bWkzIkagWwCJMw3zNmA==",
+            "dev": true,
+            "dependencies": {
+                "@lit/context": "^1.1.3",
+                "@lit/react": "^1.0.6",
+                "bootstrap": "^5.1.3",
+                "date-fns": "^3.3.1",
+                "imask": "^7.4.0",
+                "lit": "^3.1.4",
+                "tslib": "^2.6.2"
+            }
         },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.11.14",
@@ -3823,6 +3851,39 @@
                 "styled-components": "^5.3.5"
             }
         },
+        "node_modules/@lit-labs/ssr-dom-shim": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.3.0.tgz",
+            "integrity": "sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ==",
+            "dev": true
+        },
+        "node_modules/@lit/context": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@lit/context/-/context-1.1.5.tgz",
+            "integrity": "sha512-57KyQD9of4RlBXkOIF1N40/BLY1j+1wLB5wRmB207+VtwNIRfXbanLsB6BsnFYXrycOUIp2d8gqTNGwuW1lE9Q==",
+            "dev": true,
+            "dependencies": {
+                "@lit/reactive-element": "^1.6.2 || ^2.1.0"
+            }
+        },
+        "node_modules/@lit/react": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.7.tgz",
+            "integrity": "sha512-cencnwwLXQKiKxjfFzSgZRngcWJzUDZi/04E0fSaF86wZgchMdvTyu+lE36DrUfvuus3bH8+xLPrhM1cTjwpzw==",
+            "dev": true,
+            "peerDependencies": {
+                "@types/react": "17 || 18 || 19"
+            }
+        },
+        "node_modules/@lit/reactive-element": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.0.tgz",
+            "integrity": "sha512-L2qyoZSQClcBmq0qajBVbhYEcG6iK0XfLn66ifLe/RfC0/ihpc+pl0Wdn8bJ8o+hj38cG0fGXRgSS20MuXn7qA==",
+            "dev": true,
+            "dependencies": {
+                "@lit-labs/ssr-dom-shim": "^1.2.0"
+            }
+        },
         "node_modules/@mapbox/node-pre-gyp": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
@@ -4105,6 +4166,17 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/@popperjs/core": {
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+            "dev": true,
+            "peer": true,
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/popperjs"
             }
         },
         "node_modules/@react-native/assets-registry": {
@@ -7577,6 +7649,25 @@
             "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
             "dev": true
         },
+        "node_modules/bootstrap": {
+            "version": "5.3.7",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.7.tgz",
+            "integrity": "sha512-7KgiD8UHjfcPBHEpDNg+zGz8L3LqR3GVwqZiBRFX04a1BCArZOz1r2kjly2HQ0WokqTO0v1nF+QAt8dsW4lKlw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/twbs"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/bootstrap"
+                }
+            ],
+            "peerDependencies": {
+                "@popperjs/core": "^2.11.8"
+            }
+        },
         "node_modules/brace-expansion": {
             "version": "1.1.12",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -8477,6 +8568,17 @@
                 "url": "https://opencollective.com/core-js"
             }
         },
+        "node_modules/core-js-pure": {
+            "version": "3.44.0",
+            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.44.0.tgz",
+            "integrity": "sha512-gvMQAGB4dfVUxpYD0k3Fq8J+n5bB6Ytl15lqlZrOIXFzxOhtPaObfkQGHtMRdyjIf7z2IeNULwi1jEwyS+ltKQ==",
+            "dev": true,
+            "hasInstallScript": true,
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/core-js"
+            }
+        },
         "node_modules/cosmiconfig": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -8863,6 +8965,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/date-fns": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+            "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+            "dev": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/kossnocorp"
             }
         },
         "node_modules/dayjs": {
@@ -11660,6 +11772,18 @@
                 "node": ">=16.x"
             }
         },
+        "node_modules/imask": {
+            "version": "7.6.1",
+            "resolved": "https://registry.npmjs.org/imask/-/imask-7.6.1.tgz",
+            "integrity": "sha512-sJlIFM7eathUEMChTh9Mrfw/IgiWgJqBKq2VNbyXvBZ7ev/IlO6/KQTKlV/Fm+viQMLrFLG/zCuudrLIwgK2dg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.24.4"
+            },
+            "engines": {
+                "npm": ">=4.0.0"
+            }
+        },
         "node_modules/immer": {
             "version": "10.1.1",
             "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
@@ -14332,6 +14456,37 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/lit": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.0.tgz",
+            "integrity": "sha512-DGVsqsOIHBww2DqnuZzW7QsuCdahp50ojuDaBPC7jUDRpYoH0z7kHBBYZewRzer75FwtrkmkKk7iOAwSaWdBmw==",
+            "dev": true,
+            "dependencies": {
+                "@lit/reactive-element": "^2.1.0",
+                "lit-element": "^4.2.0",
+                "lit-html": "^3.3.0"
+            }
+        },
+        "node_modules/lit-element": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.0.tgz",
+            "integrity": "sha512-MGrXJVAI5x+Bfth/pU9Kst1iWID6GHDLEzFEnyULB/sFiRLgkd8NPK/PeeXxktA3T6EIIaq8U3KcbTU5XFcP2Q==",
+            "dev": true,
+            "dependencies": {
+                "@lit-labs/ssr-dom-shim": "^1.2.0",
+                "@lit/reactive-element": "^2.1.0",
+                "lit-html": "^3.3.0"
+            }
+        },
+        "node_modules/lit-html": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.0.tgz",
+            "integrity": "sha512-RHoswrFAxY2d8Cf2mm4OZ1DgzCoBKUKSPvA1fhtSELxUERq2aQQ2h05pO9j81gS1o7RIRJ+CePLogfyahwmynw==",
+            "dev": true,
+            "dependencies": {
+                "@types/trusted-types": "^2.0.2"
             }
         },
         "node_modules/load-plugin": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         "@dnd-kit/sortable": "^7.0.2",
         "@floating-ui/dom": "^1.6.10",
         "@floating-ui/react": "^0.26.23",
+        "@govtechsg/sgds-web-component": "^3.0.6",
         "@inquirer/prompts": "^7.0.0",
         "@lifesg/react-icons": "^1.6.0",
         "@playwright/test": "^1.45.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,7 +9,7 @@ import peerDepsExternal from "rollup-plugin-peer-deps-external";
 import postcss from "rollup-plugin-postcss";
 import typescript from "rollup-plugin-typescript2";
 import pkg from "./package.json";
-import { getFolders } from "./scripts/build-util";
+import { getFolders, injectCss } from "./scripts/build-util";
 
 export const plugins = [
     peerDepsExternal(), // Add the externals for me. [react, react-dom, styled-components]
@@ -33,9 +33,8 @@ export const plugins = [
         },
     }),
     postcss({
-        extract: true,
-        modules: false,
         plugins: [require("postcss-import")],
+        inject: injectCss,
     }),
     image(),
     json(),

--- a/scripts/build-util.js
+++ b/scripts/build-util.js
@@ -19,3 +19,36 @@ export const getFolders = (entry) => {
 
     return dirsToUse;
 };
+
+export const injectCss = (cssVariableName, fileId) => {
+    const module = path.relative(".", fileId);
+
+    // known .css imports will be mapped to a unique id to prevent duplicate
+    // injection as much as possible
+    const moduleIdMap = {
+        "node_modules/@govtechsg/sgds-web-component/themes/night.css":
+            "lifesg-ds-masthead-stylesheet-night",
+        "node_modules/@govtechsg/sgds-web-component/themes/day.css":
+            "lifesg-ds-masthead-stylesheet-day",
+    };
+    const id = moduleIdMap[module] ? `"${moduleIdMap[module]}"` : undefined;
+
+    return `
+        function injectStyle(css, id) {
+            if (typeof document === "undefined" || !css) return;
+
+            var head = document.head || document.getElementsByTagName('head')[0];
+            var style = document.createElement('style');
+            style.type = 'text/css';
+            if (id) {
+                var existingStyle = document.getElementById(id);
+                if (existingStyle) return;
+
+                style.id = id;
+            }
+            head.appendChild(style);
+            style.appendChild(document.createTextNode(css));
+        }
+        injectStyle(${cssVariableName},${id})
+    `;
+};

--- a/src/masthead/masthead.tsx
+++ b/src/masthead/masthead.tsx
@@ -1,8 +1,14 @@
+import "@govtechsg/sgds-web-component/themes/day.css";
+import "@govtechsg/sgds-web-component/themes/night.css";
 import { useEffect } from "react";
+import { useTheme } from "styled-components";
 import { Wrapper } from "./masthead.style";
 import { MastheadProps } from "./types";
 
 export const Masthead = ({ stretch = false }: MastheadProps): JSX.Element => {
+    const theme = useTheme();
+    const isDarkMode = theme?.colourMode === "dark";
+
     // =============================================================================
     // EFFECTS
     // =============================================================================
@@ -11,6 +17,17 @@ export const Masthead = ({ stretch = false }: MastheadProps): JSX.Element => {
             addAssets();
         }
     }, []);
+
+    useEffect(() => {
+        // SGDS dark mode only takes effect when this class is set on the :root element
+        if (isDarkMode) {
+            document.documentElement.classList.add(SGDS_THEME_NIGHT_CLASSNAME);
+        } else {
+            document.documentElement.classList.remove(
+                SGDS_THEME_NIGHT_CLASSNAME
+            );
+        }
+    }, [isDarkMode]);
 
     // =============================================================================
     // HELPER FUNCTIONS
@@ -55,4 +72,5 @@ export const Masthead = ({ stretch = false }: MastheadProps): JSX.Element => {
 // =============================================================================
 const SCRIPT_ID = "lifesg-ds-masthead-script";
 const SCRIPT_SRC =
-    "https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component/Masthead/index.js";
+    "https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3/components/Masthead/index.umd.js";
+const SGDS_THEME_NIGHT_CLASSNAME = "sgds-night-theme";

--- a/stories/masthead/masthead.mdx
+++ b/stories/masthead/masthead.mdx
@@ -22,8 +22,8 @@ customised to align with the [Layout](/docs/core-layout--docs) container.
 <Canvas of={MastheadStories.Default} />
 
 > The component also uses a custom script. Should you encounter a content security
-> policy error, do add this script in the `scriptSrc` blob.
-> https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component/Masthead/index.js
+> policy error, do whitelist this url in the `script-src` directive.
+> https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3/components/Masthead/index.umd.js
 
 ## Component API
 

--- a/stories/navbar/navbar.mdx
+++ b/stories/navbar/navbar.mdx
@@ -105,8 +105,8 @@ When the branding elements are hidden, navigation items will be aligned to the l
 ## Troubleshooting
 
 > The component also uses a custom script. Should you encounter a content security
-> policy error, do add this script in the `scriptSrc` blob.
-> https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component/Masthead/index.js
+> policy error, do whitelist this url in the `script-src` directive.
+> https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3/components/Masthead/index.umd.js
 
 <br />
 


### PR DESCRIPTION
**Changes**

Resolves #724 

- [delete] branch

_Load SGDS themes_
- Import the css from `@govtechsg/sgds-web-component` and inject the values at build time
- This uses the PostCSS plugin to insert style tags into the `<head>` at run time
- To prevent duplicate style tags from being inserted (e.g. when both Masthead and Navbar are conditionally rendered on a page), a unique id is set

_Pin SGDS components to major version_
- Note: this is a **breaking change** as consumers have to update their CSP whitelist if applicable
- This ensures that Masthead and css are kept in sync as much as possible and reduce the possibility of unexpected breaking changes
- Ideally we could have imported the React version of the Masthead from the library as well, however I faced difficulties with loading it in CRA/NextJS apps and decided to leave this for now
- Updated the script url to match the latest example provided in the [installation instructions](https://www.webcomponent.designsystem.tech.gov.sg/?path=/docs/getting-started-installation--docs#method-2-using-cdn)

<!-- Remove if not required -->
**Changelog entry**

- Fix `Masthead`
- [BREAKING] Pin SGDS `Masthead` to v3. If your site has whitelisted the url in the Content Security Policy previously, update it to match the new value.

```diff
- https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component/Masthead/index.js
+ https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3/components/Masthead/index.umd.js
```
