### PR TITLE
[MISC][ZY] Improve a11y for Form.Input

### DIFF
--- a/src/form/form-date-input.tsx
+++ b/src/form/form-date-input.tsx
@@ -1,11 +1,13 @@
+import { useState } from "react";
 import { DateInput } from "../date-input";
 import { FormWrapper } from "./form-wrapper";
 import { FormDateInputProps } from "./types";
+import { SimpleIdGenerator } from "../util";
 
 export const FormDateInput = ({
     label,
     errorMessage,
-    id = "form-date-input",
+    id,
     "data-error-testid": errorTestId,
     "data-testid": testId,
     layoutType,
@@ -21,9 +23,14 @@ export const FormDateInput = ({
     xxlCols,
     ...otherProps
 }: FormDateInputProps): JSX.Element => {
+    const [internalId] = useState(
+        () => `form-date-input-${SimpleIdGenerator.generate()}`
+    );
+    const inputId = id ?? internalId;
+
     return (
         <FormWrapper
-            id={id}
+            id={inputId}
             label={label}
             errorMessage={errorMessage}
             data-error-testid={errorTestId}
@@ -41,9 +48,9 @@ export const FormDateInput = ({
             xxlCols={xxlCols}
         >
             <DateInput
-                id={`${id}-base`}
+                id={`${inputId}-base`}
                 data-testid={testId || id}
-                aria-labelledby={`${id}-label`}
+                aria-labelledby={`${inputId}-label`}
                 error={!!errorMessage}
                 {...otherProps}
             />

--- a/src/form/form-date-range-input.tsx
+++ b/src/form/form-date-range-input.tsx
@@ -1,11 +1,13 @@
+import { useState } from "react";
 import { DateRangeInput } from "../date-range-input";
+import { SimpleIdGenerator } from "../util";
 import { FormWrapper } from "./form-wrapper";
 import { FormDateRangeInputProps } from "./types";
 
 export const FormDateRangeInput = ({
     label,
     errorMessage,
-    id = "form-date-range-input",
+    id,
     "data-error-testid": errorTestId,
     "data-testid": testId,
     layoutType,
@@ -21,9 +23,14 @@ export const FormDateRangeInput = ({
     xxlCols,
     ...otherProps
 }: FormDateRangeInputProps): JSX.Element => {
+    const [internalId] = useState(
+        () => `form-date-range-input-${SimpleIdGenerator.generate()}`
+    );
+    const inputId = id ?? internalId;
+
     return (
         <FormWrapper
-            id={id}
+            id={inputId}
             label={label}
             errorMessage={errorMessage}
             data-error-testid={errorTestId}
@@ -42,8 +49,8 @@ export const FormDateRangeInput = ({
         >
             <DateRangeInput
                 id={`${id}-base`}
-                data-testid={testId || id}
-                aria-labelledby={`${id}-label`}
+                data-testid={testId ? `${testId}-base` : undefined}
+                aria-labelledby={`${inputId}-label`}
                 error={!!errorMessage}
                 {...otherProps}
             />

--- a/src/form/form-input.tsx
+++ b/src/form/form-input.tsx
@@ -3,12 +3,13 @@ import { Input } from "../input";
 import { InputRef } from "../input/types";
 import { FormWrapper } from "./form-wrapper";
 import { FormInputProps } from "./types";
+import { SimpleIdGenerator } from "../util";
 
 const Component = (props: FormInputProps, ref: InputRef): JSX.Element => {
     const {
         label,
         errorMessage,
-        id = "form-field",
+        id = `form-field-${SimpleIdGenerator.generate()}`,
         "data-error-testid": errorTestId,
         "data-testid": testId,
         layoutType,

--- a/src/form/form-input.tsx
+++ b/src/form/form-input.tsx
@@ -34,6 +34,7 @@ const Component = (props: FormInputProps, ref: InputRef): JSX.Element => {
 
     return (
         <FormWrapper
+            id={inputId}
             data-testid={testId}
             label={label}
             errorMessage={errorMessage}

--- a/src/form/form-input.tsx
+++ b/src/form/form-input.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Input } from "../input";
 import { InputRef } from "../input/types";
 import { FormWrapper } from "./form-wrapper";
@@ -9,7 +9,7 @@ const Component = (props: FormInputProps, ref: InputRef): JSX.Element => {
     const {
         label,
         errorMessage,
-        id = `form-field-${SimpleIdGenerator.generate()}`,
+        id,
         "data-error-testid": errorTestId,
         "data-testid": testId,
         layoutType,
@@ -26,9 +26,13 @@ const Component = (props: FormInputProps, ref: InputRef): JSX.Element => {
         ...otherProps
     } = props;
 
+    const [inputId] = useState(
+        () => id ?? `form-field-${SimpleIdGenerator.generate()}`
+    );
+
     return (
         <FormWrapper
-            id={id}
+            id={inputId}
             label={label}
             errorMessage={errorMessage}
             disabled={otherProps.disabled}
@@ -46,8 +50,8 @@ const Component = (props: FormInputProps, ref: InputRef): JSX.Element => {
             xxlCols={xxlCols}
         >
             <Input
-                id={`${id}-base`}
-                data-testid={testId || id}
+                id={`${inputId}-base`}
+                data-testid={testId || inputId}
                 ref={ref}
                 error={!!errorMessage}
                 {...otherProps}

--- a/src/form/form-input.tsx
+++ b/src/form/form-input.tsx
@@ -26,13 +26,15 @@ const Component = (props: FormInputProps, ref: InputRef): JSX.Element => {
         ...otherProps
     } = props;
 
-    const [inputId] = useState(
-        () => id ?? `form-field-${SimpleIdGenerator.generate()}`
+    const [internalId] = useState(
+        () => `form-field-${SimpleIdGenerator.generate()}`
     );
+
+    const inputId = id ?? internalId;
 
     return (
         <FormWrapper
-            id={inputId}
+            data-testid={testId}
             label={label}
             errorMessage={errorMessage}
             disabled={otherProps.disabled}
@@ -51,7 +53,7 @@ const Component = (props: FormInputProps, ref: InputRef): JSX.Element => {
         >
             <Input
                 id={`${inputId}-base`}
-                data-testid={testId || inputId}
+                data-testid={testId ? `${testId}-base` : undefined}
                 ref={ref}
                 error={!!errorMessage}
                 {...otherProps}

--- a/src/form/form-label.style.tsx
+++ b/src/form/form-label.style.tsx
@@ -5,9 +5,11 @@ import { Colour, Font, Spacing } from "../theme";
 // =============================================================================
 // STYLING
 // =============================================================================
+export const LabelContainer = styled.div`
+    margin-bottom: ${Spacing["spacing-8"]};
+`;
 export const Label = styled.label`
     color: ${Colour["text-subtle"]};
-    margin-bottom: ${Spacing["spacing-8"]};
     display: inline-block;
 
     ${Font["form-label"]}

--- a/src/form/form-label.tsx
+++ b/src/form/form-label.tsx
@@ -13,6 +13,7 @@ export const FormLabel = ({
     addon,
     subtitle,
     "data-testid": testId,
+    className,
     ...otherProps
 }: FormLabelProps): JSX.Element => {
     // -------------------------------------------------------------------------
@@ -28,14 +29,14 @@ export const FormLabel = ({
     };
 
     return (
-        <LabelContainer>
+        <LabelContainer className={className}>
             <Label {...otherProps}>
                 {children}
                 {addon && addon.type && renderAddon()}
             </Label>
             {typeof subtitle === "string" ? (
                 <Subtitle
-                    id={labelId ? `${labelId}-subtitle` : "subtitle"}
+                    id={labelId ? `${labelId}-subtitle` : undefined}
                     data-testid={testId ? `${testId}-subtitle` : "subtitle"}
                     {...otherProps}
                 >

--- a/src/form/form-label.tsx
+++ b/src/form/form-label.tsx
@@ -38,7 +38,6 @@ export const FormLabel = ({
                 <Subtitle
                     id={labelId ? `${labelId}-subtitle` : undefined}
                     data-testid={testId ? `${testId}-subtitle` : "subtitle"}
-                    {...otherProps}
                 >
                     {subtitle}
                 </Subtitle>

--- a/src/form/form-label.tsx
+++ b/src/form/form-label.tsx
@@ -8,12 +8,13 @@ import {
 import { FormLabelProps } from "./types";
 
 export const FormLabel = ({
-    id: labelId,
+    id,
     children,
     addon,
     subtitle,
     "data-testid": testId,
     className,
+    style,
     ...otherProps
 }: FormLabelProps): JSX.Element => {
     // -------------------------------------------------------------------------
@@ -29,14 +30,18 @@ export const FormLabel = ({
     };
 
     return (
-        <LabelContainer className={className}>
-            <Label {...otherProps}>
+        <LabelContainer
+            className={className}
+            style={style}
+            data-testid={testId}
+        >
+            <Label id={id} {...otherProps}>
                 {children}
                 {addon && addon.type && renderAddon()}
             </Label>
             {typeof subtitle === "string" ? (
                 <Subtitle
-                    id={labelId ? `${labelId}-subtitle` : undefined}
+                    id={id ? `${id}-subtitle` : undefined}
                     data-testid={testId ? `${testId}-subtitle` : "subtitle"}
                 >
                     {subtitle}

--- a/src/form/form-label.tsx
+++ b/src/form/form-label.tsx
@@ -1,8 +1,14 @@
 import { PopoverAddon } from "./form-label-addon";
-import { ErrorMessage, Label, Subtitle } from "./form-label.style";
+import {
+    ErrorMessage,
+    Label,
+    LabelContainer,
+    Subtitle,
+} from "./form-label.style";
 import { FormLabelProps } from "./types";
 
 export const FormLabel = ({
+    id: labelId,
     children,
     addon,
     subtitle,
@@ -22,11 +28,14 @@ export const FormLabel = ({
     };
 
     return (
-        <Label {...otherProps}>
-            {children}
-            {addon && addon.type && renderAddon()}
+        <LabelContainer>
+            <Label {...otherProps}>
+                {children}
+                {addon && addon.type && renderAddon()}
+            </Label>
             {typeof subtitle === "string" ? (
                 <Subtitle
+                    id={labelId ? `${labelId}-subtitle` : "subtitle"}
                     data-testid={testId ? `${testId}-subtitle` : "subtitle"}
                     {...otherProps}
                 >
@@ -35,7 +44,7 @@ export const FormLabel = ({
             ) : (
                 subtitle
             )}
-        </Label>
+        </LabelContainer>
     );
 };
 

--- a/src/form/form-wrapper.tsx
+++ b/src/form/form-wrapper.tsx
@@ -51,6 +51,14 @@ export const FormWrapper = ({
         return !!errorMessage;
     };
 
+    const hasSubtitleLabel = (): boolean => {
+        return typeof label === "object" && !!label?.subtitle;
+    };
+
+    const getSubtitleId = (): string => {
+        return `${id}-label-subtitle`;
+    };
+
     function getLayoutType(): FormElementLayoutType {
         if (!layoutType && (mobileCols || tabletCols || desktopCols)) {
             return "v2-grid";
@@ -141,6 +149,8 @@ export const FormWrapper = ({
             "aria-invalid": isInvalidState(),
             "aria-describedby": isInvalidState()
                 ? getErrorTestMessageId()
+                : hasSubtitleLabel()
+                ? getSubtitleId()
                 : undefined,
         };
         return Children.map(children, (child) =>

--- a/src/form/form-wrapper.tsx
+++ b/src/form/form-wrapper.tsx
@@ -56,7 +56,7 @@ export const FormWrapper = ({
     };
 
     const getSubtitleId = (): string => {
-        return `${id}-subtitle`;
+        return `${id}-label-subtitle`;
     };
 
     const getAriaDescribedBy = (): string | undefined => {

--- a/src/form/form-wrapper.tsx
+++ b/src/form/form-wrapper.tsx
@@ -56,7 +56,18 @@ export const FormWrapper = ({
     };
 
     const getSubtitleId = (): string => {
-        return `${id}-label-subtitle`;
+        return `${id}-subtitle`;
+    };
+
+    const getAriaDescribedBy = (): string | undefined => {
+        return (
+            [
+                isInvalidState() ? getErrorTestMessageId() : undefined,
+                hasSubtitleLabel() ? getSubtitleId() : undefined,
+            ]
+                .filter(Boolean)
+                .join(" ") || undefined
+        );
     };
 
     function getLayoutType(): FormElementLayoutType {
@@ -147,11 +158,7 @@ export const FormWrapper = ({
     const renderChildren = (): JSX.Element | JSX.Element[] => {
         const ariaState = {
             "aria-invalid": isInvalidState(),
-            "aria-describedby": isInvalidState()
-                ? getErrorTestMessageId()
-                : hasSubtitleLabel()
-                ? getSubtitleId()
-                : undefined,
+            "aria-describedby": getAriaDescribedBy(),
         };
         return Children.map(children, (child) =>
             cloneElement(child, ariaState)

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -120,13 +120,14 @@ const Component = (
                 <InputElement
                     data-testid="input"
                     ref={elementRef}
-                    disabled={disabled}
+                    aria-disabled={disabled}
                     value={updatedValue}
                     onChange={handleChange}
                     type={type}
-                    readOnly={readOnly}
+                    readOnly={readOnly || disabled}
                     $showClear={showClear}
                     $styleType={styleType}
+                    tabIndex={0}
                     {...otherProps}
                 />
                 {showClear && (

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -127,7 +127,6 @@ const Component = (
                     readOnly={readOnly || disabled}
                     $showClear={showClear}
                     $styleType={styleType}
-                    tabIndex={0}
                     {...otherProps}
                 />
                 {showClear && (

--- a/stories/form/form-custom-field/form-custom-field.mdx
+++ b/stories/form/form-custom-field/form-custom-field.mdx
@@ -1,4 +1,5 @@
 import { Canvas, Meta } from "@storybook/blocks";
+import { DocAlert } from "stories/storybook-common";
 import * as FormCustomFieldStories from "./form-custom-field.stories";
 import { PropsTable } from "./props-table";
 
@@ -8,13 +9,28 @@ import { PropsTable } from "./props-table";
 
 ## Overview
 
-Allows for a custom form element to be specified, and still have the label and error message.
+Allows for a custom form element to be specified, and still have the label and
+error message.
 
 ```tsx
 import { Form } from "@lifesg/react-design-system/form";
 ```
 
 <Canvas of={FormCustomFieldStories.Default} />
+
+## Accessibility
+
+The component injects the following props into the form element:
+
+-   `aria-describedby`
+-   `aria-invalid`
+
+The form element can be associated with the subtitle and error message by
+forwarding them accordingly.
+
+<DocAlert>`aria-labelledby` will be supported in a future enhancement</DocAlert>
+
+<Canvas of={FormCustomFieldStories.Accessibility} />
 
 ## Component API
 

--- a/stories/form/form-custom-field/form-custom-field.stories.tsx
+++ b/stories/form/form-custom-field/form-custom-field.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { Checkbox } from "src/checkbox";
 import { Form } from "src/form";
+import { Input } from "src/input";
 import { StoryDecorator } from "stories/storybook-common";
 
 type Component = typeof Form.CustomField;
@@ -37,6 +38,26 @@ export const Default: StoryObj<Component> = {
                     <Checkbox checked={cb3} onClick={() => setCb3(!cb3)} />
                 </Form.CustomField>
             </>
+        );
+    },
+    decorators: [StoryDecorator({ maxWidth: true })],
+};
+
+export const Accessibility: StoryObj<Component> = {
+    render: (_args) => {
+        return (
+            <Form.CustomField
+                id="custom-field"
+                label={{
+                    children: "This is a custom field",
+                    subtitle: "This is the custom field subtitle",
+                }}
+                errorMessage="This is the error message"
+            >
+                <Input id="custom-field-base" />
+                <br />
+                <Input aria-labelledby="custom-field-label" />
+            </Form.CustomField>
         );
     },
     decorators: [StoryDecorator({ maxWidth: true })],

--- a/stories/form/form-input/form-input.stories.tsx
+++ b/stories/form/form-input/form-input.stories.tsx
@@ -27,6 +27,22 @@ export const Default: StoryObj<Component> = {
                     placeholder="Enter here..."
                 />
                 <Form.Input
+                    label={{
+                        children: "This is a input field with subtitle",
+                        subtitle: "This is a subtitle",
+                    }}
+                    placeholder="Enter here..."
+                />
+                <Form.Input
+                    label={{
+                        children: "This is a input field with addon",
+                        addon: {
+                            type: "popover",
+                            content: "This is an addon",
+                        },
+                    }}
+                />
+                <Form.Input
                     label="This is the error state"
                     errorMessage="Input is required"
                     placeholder="Enter here..."

--- a/stories/form/form-input/form-input.stories.tsx
+++ b/stories/form/form-input/form-input.stories.tsx
@@ -27,22 +27,6 @@ export const Default: StoryObj<Component> = {
                     placeholder="Enter here..."
                 />
                 <Form.Input
-                    label={{
-                        children: "This is a input field with subtitle",
-                        subtitle: "This is a subtitle",
-                    }}
-                    placeholder="Enter here..."
-                />
-                <Form.Input
-                    label={{
-                        children: "This is a input field with addon",
-                        addon: {
-                            type: "popover",
-                            content: "This is an addon",
-                        },
-                    }}
-                />
-                <Form.Input
                     label="This is the error state"
                     errorMessage="Input is required"
                     placeholder="Enter here..."


### PR DESCRIPTION
Use simpleidgenerator for Form.Input, also enabling tab access for disabled Input

**Changes**
- Update `Form.Input` to use `form-field-{generatedId}` instead of just `form-field`
- Update `disabled` state to `readonly` + `aria-disabled` to allow keyboard tab access
- Added more stories to cover a11y cases
- [delete] branch

**Changelog entry**
- Fix accessibility warnings for `Form.Input`
- [BREAKING] Update `Form.Input` to no longer apply `disabled` attribute to underlying `input` element

https://github.com/user-attachments/assets/157af52e-6873-48de-b5f3-5c3c76c3f22f