### PR TITLE
Make `DataTable` focusable

### DIFF
--- a/src/data-table/data-table.tsx
+++ b/src/data-table/data-table.tsx
@@ -455,6 +455,7 @@ export const DataTable = ({
                     );
                 }
             }}
+            tabIndex={0} // scrollable container must be focusable to support keyboard users
         >
             <TableContainer>
                 <Table


### PR DESCRIPTION
**Changes**

this [issue](https://accessibilityinsights.io/info-examples/web/scrollable-region-focusable/) was flagged for the DataTable component because it has the style `overflow: auto` but no corresponding `tabindex`

THEORETICALLY, we should only need to apply the `tabindex` when the component is scrollable (which we do compute through the `scrollable` state), but it appears the tool continues to flag this out 🤷

- [delete] branch