### PR TITLE
Reduced toggle button min-width to 5rem

### DIFF
--- a/src/filter/addons/filter-item-checkbox.styles.tsx
+++ b/src/filter/addons/filter-item-checkbox.styles.tsx
@@ -65,6 +65,7 @@ export const StyledCheckbox = styled(Checkbox)`
 
 export const StyledToggle = styled(Toggle)<{ $visible: boolean }>`
     ${(props) => !props.$visible && "visibility: hidden;"}
+    min-width: 5rem;
 `;
 
 export const SelectAllButton = styled(Button.Small)`


### PR DESCRIPTION


**Changes**
Reduced toggle button min-width to 5rem for `FilterCheckbox` component in mobile view

- [delete] branch

**Changelog entry**
Reduced toggle button min-width to 5rem for `FilterCheckbox` component in mobile view

**Additional information**

- You may refer to this [ticket](https://sgtechstack.atlassian.net/browse/BOOKINGSG-7788)
