### PR TITLE
Fixed FilterItem render in mobile view

### DIFF
--- a/src/filter/addons/filter-item-checkbox.styles.tsx
+++ b/src/filter/addons/filter-item-checkbox.styles.tsx
@@ -65,7 +65,6 @@ export const StyledCheckbox = styled(Checkbox)`
 
 export const StyledToggle = styled(Toggle)<{ $visible: boolean }>`
     ${(props) => !props.$visible && "visibility: hidden;"}
-    min-width: 5rem;
 `;
 
 export const SelectAllButton = styled(Button.Small)`

--- a/src/filter/addons/filter-item-checkbox.tsx
+++ b/src/filter/addons/filter-item-checkbox.tsx
@@ -204,7 +204,9 @@ export const FilterItemCheckbox = <T,>({
 
     return (
         <StyledFilterItem
-            minimisable={options.length > 5}
+            minimisable={
+                mode === "default" ? options.length > 5 : !!minimisedHeight
+            }
             minimisedHeight={minimisedHeight}
             {...filterItemProps}
         >

--- a/src/filter/filter-item.tsx
+++ b/src/filter/filter-item.tsx
@@ -59,6 +59,9 @@ export const FilterItem = ({
         setExpanded(getInitialExpandState());
     }, [desktopCollapsible, controlledExpanded]);
 
+    useEffect(() => {
+        setContentMinimised(minimisable);
+    }, [minimisable]);
     // =============================================================================
     // EVENT HANDLERS
     // =============================================================================


### PR DESCRIPTION
**Changes**
Fixed FilterCheckbox component to not minimise when ther are more than 5 toggles but less than 3 rows in mobile view

- [delete] branch

**Changelog entry**
Fixed FilterCheckbox component to not minimise when there are more than 5 toggles but less than 3 rows in mobile view


**Additional information**

- You may refer to this [ticket](https://sgtechstack.atlassian.net/browse/BOOKINGSG-7795)
