### PR TITLE
Update OneService colour tokens, fix `info-40`

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -7,6 +7,7 @@ import {
     CCubeTheme,
     LifeSGTheme,
     MyLegacyTheme,
+    OneServiceTheme,
     PATheme,
     RBSTheme,
     SupportGoWhereTheme,
@@ -22,8 +23,7 @@ const preview: Preview = {
                 CCube: CCubeTheme,
                 MyLegacy: MyLegacyTheme,
                 RBS: RBSTheme,
-                // TODO: update when OS theme is added
-                //"OneService": OneServiceTheme,
+                OneService: OneServiceTheme,
                 PA: PATheme,
                 A11yPlayground: A11yPlaygroundTheme,
                 SupportGoWhere: SupportGoWhereTheme,

--- a/src/theme/colour-primitive/specs/bookingsg-colour-set.ts
+++ b/src/theme/colour-primitive/specs/bookingsg-colour-set.ts
@@ -81,7 +81,7 @@ export const BookingSgColourSet: PrimitiveColourSet = {
     "info-10": "#021824",
     "info-20": "#032B3F",
     "info-30": "#053D59",
-    "info-40": "#065478",
+    "info-40": "#06547B",
     "info-50": "#176E9B",
     "info-60": "#5296BE",
     "info-70": "#82B5DA",

--- a/src/theme/colour-primitive/specs/ccube-colour-set.ts
+++ b/src/theme/colour-primitive/specs/ccube-colour-set.ts
@@ -81,7 +81,7 @@ export const CCubeColourSet: PrimitiveColourSet = {
     "info-10": "#021824",
     "info-20": "#032B3F",
     "info-30": "#053D59",
-    "info-40": "#065478",
+    "info-40": "#06547B",
     "info-50": "#176E9B",
     "info-60": "#5296BE",
     "info-70": "#82B5DA",

--- a/src/theme/colour-primitive/specs/lifesg-colour-set.ts
+++ b/src/theme/colour-primitive/specs/lifesg-colour-set.ts
@@ -81,7 +81,7 @@ export const LifeSgColourSet: PrimitiveColourSet = {
     "info-10": "#021824",
     "info-20": "#032B3F",
     "info-30": "#053D59",
-    "info-40": "#065478",
+    "info-40": "#06547B",
     "info-50": "#176E9B",
     "info-60": "#5296BE",
     "info-70": "#82B5DA",

--- a/src/theme/colour-primitive/specs/mylegacy-colour-set.ts
+++ b/src/theme/colour-primitive/specs/mylegacy-colour-set.ts
@@ -82,7 +82,7 @@ export const MyLegacyColourSet: PrimitiveColourSet = {
     "info-10": "#021824",
     "info-20": "#032B3F",
     "info-30": "#053D59",
-    "info-40": "#065478",
+    "info-40": "#06547B",
     "info-50": "#176E9B",
     "info-60": "#5296BE",
     "info-70": "#82B5DA",

--- a/src/theme/colour-primitive/specs/oneservice-colour-set.ts
+++ b/src/theme/colour-primitive/specs/oneservice-colour-set.ts
@@ -1,6 +1,5 @@
 import { PrimitiveColourSet } from "../../types";
 
-// TODO: work in progress
 export const OneServiceColourSet: PrimitiveColourSet = {
     "brand-10": "#001A19",
     "brand-20": "#002D2B",
@@ -18,12 +17,12 @@ export const OneServiceColourSet: PrimitiveColourSet = {
     "primary-30": "#173D49",
     "primary-40": "#205666",
     "primary-50": "#2A7086",
-    "primary-60": "#2A7086",
+    "primary-60": "#5D97A9",
     "primary-70": "#8CB6C2",
     "primary-80": "#B2CED6",
     "primary-90": "#D1E2E7",
     "primary-95": "#E8F0F3",
-    "primary-100": "#F9F8FC",
+    "primary-100": "#F7FAFB",
     "secondary-10": "#001731",
     "secondary-20": "#002752",
     "secondary-30": "#003874",
@@ -82,7 +81,7 @@ export const OneServiceColourSet: PrimitiveColourSet = {
     "info-10": "#021824",
     "info-20": "#032B3F",
     "info-30": "#053D59",
-    "info-40": "#065478",
+    "info-40": "#06547B",
     "info-50": "#176E9B",
     "info-60": "#5296BE",
     "info-70": "#82B5DA",

--- a/src/theme/colour-primitive/specs/pa-colour-set.ts
+++ b/src/theme/colour-primitive/specs/pa-colour-set.ts
@@ -81,7 +81,7 @@ export const PAColourSet: PrimitiveColourSet = {
     "info-10": "#021824",
     "info-20": "#032B3F",
     "info-30": "#053D59",
-    "info-40": "#065478",
+    "info-40": "#06547B",
     "info-50": "#176E9B",
     "info-60": "#5296BE",
     "info-70": "#82B5DA",

--- a/src/theme/colour-primitive/specs/rbs-colour-set.ts
+++ b/src/theme/colour-primitive/specs/rbs-colour-set.ts
@@ -81,7 +81,7 @@ export const RBSColourSet: PrimitiveColourSet = {
     "info-10": "#021824",
     "info-20": "#032B3F",
     "info-30": "#053D59",
-    "info-40": "#065478",
+    "info-40": "#06547B",
     "info-50": "#176E9B",
     "info-60": "#5296BE",
     "info-70": "#82B5DA",

--- a/src/theme/colour-primitive/specs/supportgowhere-colour-set.ts
+++ b/src/theme/colour-primitive/specs/supportgowhere-colour-set.ts
@@ -81,7 +81,7 @@ export const SupportGoWhereColourSet: PrimitiveColourSet = {
     "info-10": "#021824",
     "info-20": "#032B3F",
     "info-30": "#053D59",
-    "info-40": "#065478",
+    "info-40": "#06547B",
     "info-50": "#176E9B",
     "info-60": "#5296BE",
     "info-70": "#82B5DA",

--- a/stories/theme/colour/g-colour-oneservice.mdx
+++ b/stories/theme/colour/g-colour-oneservice.mdx
@@ -1,13 +1,10 @@
 import { Meta } from "@storybook/blocks";
 import { OneServiceTheme } from "src/theme";
-import { DocAlert } from "stories/storybook-common";
 import { PrimitiveColourDisplay, SemanticColourDisplay } from "../doc-elements";
 
 <Meta title="Foundations/Colours/OneService" />
 
 # OneService colours
-
-<DocAlert>Work in progress</DocAlert>
 
 These are the palettes used when the `colourScheme` is `"oneservice"`.
 


### PR DESCRIPTION
**Changes**

- Update colour tokens to latest version ([Figma](https://www.figma.com/design/QVydazexiNjDa2jPxuCd7b/%F0%9F%8E%A8-Flagship-V3-Foundations-Kit?node-id=5793-3910&t=fmnyM2IYjT9s4drY-0))
- Fix typo for `info-40` value
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Update `OneService` colour tokens
- Update `info-40` colour tokens
