### PR TITLE
Sidenav a11y

### DIFF
--- a/src/sidenav/sidenav-context.tsx
+++ b/src/sidenav/sidenav-context.tsx
@@ -6,6 +6,7 @@ export interface SidenavContextItem {
 }
 
 interface SidenavContextProps {
+    internalId: string;
     currentItem: SidenavContextItem | undefined;
     previouslySelectedItemId: string | undefined;
     selectedItem: SidenavContextItem | undefined;
@@ -15,6 +16,7 @@ interface SidenavContextProps {
 }
 
 export const SidenavContext = createContext<SidenavContextProps>({
+    internalId: "sidenav",
     selectedItem: undefined,
     currentItem: undefined,
     previouslySelectedItemId: undefined,

--- a/src/sidenav/sidenav-context.tsx
+++ b/src/sidenav/sidenav-context.tsx
@@ -7,6 +7,7 @@ export interface SidenavContextItem {
 
 interface SidenavContextProps {
     internalId: string;
+    menuRef: React.RefObject<HTMLDivElement>;
     currentItem: SidenavContextItem | undefined;
     previouslySelectedItemId: string | undefined;
     selectedItem: SidenavContextItem | undefined;
@@ -17,6 +18,7 @@ interface SidenavContextProps {
 
 export const SidenavContext = createContext<SidenavContextProps>({
     internalId: "sidenav",
+    menuRef: { current: null },
     selectedItem: undefined,
     currentItem: undefined,
     previouslySelectedItemId: undefined,

--- a/src/sidenav/sidenav-drawer-item.tsx
+++ b/src/sidenav/sidenav-drawer-item.tsx
@@ -1,6 +1,7 @@
-import { useContext, useState } from "react";
-import { useSpring } from "react-spring";
+import { HTMLAttributes, useContext, useState } from "react";
 import { useResizeDetector } from "react-resize-detector";
+import { useSpring } from "react-spring";
+import { SidenavContext } from "./sidenav-context";
 import {
     ChevronIcon,
     Container,
@@ -10,7 +11,6 @@ import {
     TextElement,
 } from "./sidenav-drawer-item.styles";
 import { SidenavDrawerItemProps } from "./types";
-import { SidenavContext } from "./sidenav-context";
 
 export const SidenavDrawerItem = ({
     id,
@@ -30,6 +30,10 @@ export const SidenavDrawerItem = ({
         setPreviouslySelectedItemId,
         setCurrentItem,
     } = useContext(SidenavContext);
+
+    const [internalId] = useState<boolean>(true);
+    const subitemId = `${internalId}-submenu`;
+
     const containerAnimationProps = useSpring({
         from: { opacity: 0 },
         to: { opacity: 1 },
@@ -67,6 +71,13 @@ export const SidenavDrawerItem = ({
     // =========================================================================
     // RENDER FUNCTIONS
     // =========================================================================
+    const ariaControlProps: HTMLAttributes<HTMLButtonElement> = children
+        ? {
+              "aria-controls": subitemId,
+              "aria-expanded": expanded,
+          }
+        : {};
+
     return (
         <Container
             onMouseEnter={handleMouseEnter}
@@ -79,12 +90,15 @@ export const SidenavDrawerItem = ({
                 onClick={handleOnClick}
                 $highlight={highlight && expanded}
                 $noChildren={!children}
+                {...ariaControlProps}
             >
                 <TextElement>{title}</TextElement>
                 {children && <ChevronIcon aria-hidden $expanded={expanded} />}
             </LinkButton>
             <DrawerSubitemContainer style={contentAnimationProps}>
-                <DrawerContent ref={childRef}>{children}</DrawerContent>
+                <DrawerContent id={subitemId} ref={childRef}>
+                    {children}
+                </DrawerContent>
             </DrawerSubitemContainer>
         </Container>
     );

--- a/src/sidenav/sidenav-group.tsx
+++ b/src/sidenav/sidenav-group.tsx
@@ -12,7 +12,7 @@ export const SidenavGroup = ({
     return (
         <Container {...otherProps}>
             {children}
-            {separator && <Divider data-testid="divider" aria-hidden />}
+            {separator && <Divider data-testid="divider" />}
         </Container>
     );
 };

--- a/src/sidenav/sidenav-group.tsx
+++ b/src/sidenav/sidenav-group.tsx
@@ -12,7 +12,7 @@ export const SidenavGroup = ({
     return (
         <Container {...otherProps}>
             {children}
-            {separator && <Divider data-testid="divider" />}
+            {separator && <Divider data-testid="divider" aria-hidden />}
         </Container>
     );
 };

--- a/src/sidenav/sidenav-item.styles.tsx
+++ b/src/sidenav/sidenav-item.styles.tsx
@@ -1,7 +1,7 @@
 import styled, { css } from "styled-components";
 import { BasicButton } from "../shared/input-wrapper";
 import { lineClampCss } from "../shared/styles";
-import { Colour, Font, Motion, Radius } from "../theme";
+import { Border, Colour, Font, Motion, Radius } from "../theme";
 import { Typography } from "../typography";
 
 //=============================================================================
@@ -9,6 +9,11 @@ import { Typography } from "../typography";
 //=============================================================================
 interface StyleProps {
     $highlight: boolean;
+}
+
+interface DrawerStyleProps {
+    $showDrawer: boolean;
+    $showShadow: boolean;
 }
 
 //=============================================================================
@@ -73,5 +78,25 @@ export const DefaultButton = styled(BasicButton)<StyleProps>`
                 ${Font["body-xs-semibold"]}
                 color: ${Colour["text-selected"]};
             }
+        `}
+`;
+
+export const DesktopDrawer = styled.ul<DrawerStyleProps>`
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    overflow: auto;
+    width: 15rem;
+    height: 100%;
+    padding: 1rem 0.5rem;
+    background-color: ${Colour["bg-primary-subtlest"]};
+    border-top-right-radius: ${Radius["md"]};
+    border-bottom-right-radius: ${Radius["md"]};
+    border: ${Border["width-010"]} ${Border["solid"]} ${Colour.border};
+    ${(props) =>
+        props.$showShadow &&
+        css`
+            box-shadow: 0 0 4px
+                rgb(from ${Colour.Primitive["neutral-20"]} r g b / 25%);
         `}
 `;

--- a/src/sidenav/sidenav-item.tsx
+++ b/src/sidenav/sidenav-item.tsx
@@ -1,4 +1,5 @@
-import { useContext, useEffect } from "react";
+import { HTMLAttributes, useContext, useEffect } from "react";
+import { SidenavContext } from "./sidenav-context";
 import {
     Container,
     DefaultButton,
@@ -6,7 +7,6 @@ import {
     TitleText,
 } from "./sidenav-item.styles";
 import { SidenavItemProps } from "./types";
-import { SidenavContext } from "./sidenav-context";
 
 export const SidenavItem = ({
     children,
@@ -20,6 +20,7 @@ export const SidenavItem = ({
     // =============================================================================
     const id = otherProps.id || title.toLowerCase().replaceAll(" ", "-");
     const {
+        internalId,
         currentItem,
         previouslySelectedItemId,
         selectedItem,
@@ -27,6 +28,8 @@ export const SidenavItem = ({
         setPreviouslySelectedItemId,
         setSelectedItem,
     } = useContext(SidenavContext);
+    const isSelected = !!selectedItem && selectedItem.itemId === id;
+    const isCurrent = !!currentItem && currentItem.itemId === id;
 
     // =============================================================================
     // EFFECTS
@@ -67,19 +70,28 @@ export const SidenavItem = ({
     // =========================================================================
     // RENDER FUNCTIONS
     // =========================================================================
+    const ariaControlProps: HTMLAttributes<HTMLButtonElement> = children
+        ? {
+              "aria-controls": `${internalId}-drawer`,
+              "aria-haspopup": true,
+              "aria-expanded":
+                  (isCurrent && !!currentItem.content) ||
+                  (isSelected && !!selectedItem.content),
+          }
+        : {};
+
     return (
         <Container>
             <DefaultButton
                 type="button"
                 onClick={handleOnClick}
                 onMouseEnter={handleMouseEnter}
+                aria-current={isSelected ? "page" : undefined}
+                {...ariaControlProps}
                 {...otherProps}
-                $highlight={
-                    (!!selectedItem && selectedItem.itemId === id) ||
-                    (!!currentItem && currentItem.itemId === id)
-                }
+                $highlight={isSelected || isCurrent}
             >
-                <IconContainer>{icon}</IconContainer>
+                <IconContainer aria-hidden>{icon}</IconContainer>
                 <TitleText>{title}</TitleText>
             </DefaultButton>
         </Container>

--- a/src/sidenav/sidenav.styles.tsx
+++ b/src/sidenav/sidenav.styles.tsx
@@ -1,16 +1,11 @@
-import styled, { css } from "styled-components";
-import { animated } from "react-spring";
-import { Border, Colour, MediaQuery, Radius } from "../theme";
+import styled from "styled-components";
+import { Border, Colour, MediaQuery } from "../theme";
 
 //=============================================================================
 // STYLE INTERFACE
 //=============================================================================
 interface StyleProps {
     $fixed?: boolean;
-}
-
-interface DrawerStyleProps {
-    $showDrawer: boolean;
 }
 
 //=============================================================================
@@ -49,30 +44,4 @@ export const MobileContainer = styled(Container)`
     ${MediaQuery.MaxWidth.sm} {
         display: none; // NOTE: Since mobile view not supported yet
     }
-`;
-
-export const DesktopDrawer = styled(animated.ul)<DrawerStyleProps>`
-    display: flex;
-    flex-direction: column;
-    overflow: auto;
-    left: 8.5rem;
-    top: 0;
-    width: 15rem;
-    z-index: 10;
-    padding: 1rem 0.5rem;
-    background-color: ${Colour["bg-primary-subtlest"]};
-    border-top-right-radius: ${Radius["md"]};
-    border-bottom-right-radius: ${Radius["md"]};
-    border: ${Border["width-010"]} ${Border["solid"]} ${Colour.border};
-
-    ${(props) =>
-        props.$showDrawer
-            ? css`
-                  box-shadow: 0 0 4px
-                      rgb(from ${Colour.Primitive["neutral-20"]} r g b / 25%);
-              `
-            : css`
-                  border: 0;
-                  padding: 0;
-              `};
 `;

--- a/src/sidenav/sidenav.tsx
+++ b/src/sidenav/sidenav.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useSpring } from "react-spring";
+import { SimpleIdGenerator, useEventListener } from "../util";
+import { SidenavContext, SidenavContextItem } from "./sidenav-context";
+import { SidenavDrawerItem } from "./sidenav-drawer-item";
+import { SidenavDrawerSubitem } from "./sidenav-drawer-subitem";
+import { SidenavGroup } from "./sidenav-group";
+import { SidenavItem } from "./sidenav-item";
 import {
     DesktopContainer,
     DesktopDrawer,
@@ -6,13 +13,6 @@ import {
     Wrapper,
 } from "./sidenav.styles";
 import { SidenavProps } from "./types";
-import { SidenavItem } from "./sidenav-item";
-import { SidenavGroup } from "./sidenav-group";
-import { SidenavContext, SidenavContextItem } from "./sidenav-context";
-import { SidenavDrawerItem } from "./sidenav-drawer-item";
-import { SidenavDrawerSubitem } from "./sidenav-drawer-subitem";
-import { useSpring } from "react-spring";
-import { useEventListener } from "../util/use-event-listener";
 
 const SidenavBase = ({
     fixed = true,
@@ -23,6 +23,8 @@ const SidenavBase = ({
     // CONST, STATE, REF
     // =============================================================================
     const wrapperRef = useRef<HTMLDivElement>(null);
+    const [internalId] = useState(() => SimpleIdGenerator.generate());
+    const drawerId = `${internalId}-drawer`;
 
     const [currentItem, setCurrentItem] = useState<
         SidenavContextItem | undefined
@@ -34,25 +36,6 @@ const SidenavBase = ({
         string | undefined
     >(undefined);
     const [showDrawer, setShowDrawer] = useState<boolean>(false);
-
-    const value = useMemo(
-        () => ({
-            currentItem,
-            selectedItem,
-            previouslySelectedItemId,
-            setCurrentItem,
-            setSelectedItem,
-            setPreviouslySelectedItemId,
-        }),
-        [
-            currentItem,
-            selectedItem,
-            previouslySelectedItemId,
-            setCurrentItem,
-            setSelectedItem,
-            setPreviouslySelectedItemId,
-        ]
-    );
 
     const drawerAnimationProps = useSpring({
         width: showDrawer ? 240 : 0,
@@ -104,7 +87,17 @@ const SidenavBase = ({
     // RENDER FUNCTIONS
     // =========================================================================
     return (
-        <SidenavContext.Provider value={value}>
+        <SidenavContext.Provider
+            value={{
+                internalId,
+                currentItem,
+                selectedItem,
+                previouslySelectedItemId,
+                setCurrentItem,
+                setSelectedItem,
+                setPreviouslySelectedItemId,
+            }}
+        >
             <Wrapper
                 $fixed={fixed}
                 {...otherProps}
@@ -113,6 +106,7 @@ const SidenavBase = ({
             >
                 <DesktopContainer>{children}</DesktopContainer>
                 <DesktopDrawer
+                    id={drawerId}
                     style={drawerAnimationProps}
                     $showDrawer={showDrawer}
                     data-testid="sidenav-drawer"

--- a/src/sidenav/sidenav.tsx
+++ b/src/sidenav/sidenav.tsx
@@ -1,17 +1,11 @@
-import { useEffect, useRef, useState } from "react";
-import { useSpring } from "react-spring";
-import { SimpleIdGenerator, useEventListener } from "../util";
+import { useRef, useState } from "react";
+import { SimpleIdGenerator } from "../util";
 import { SidenavContext, SidenavContextItem } from "./sidenav-context";
 import { SidenavDrawerItem } from "./sidenav-drawer-item";
 import { SidenavDrawerSubitem } from "./sidenav-drawer-subitem";
 import { SidenavGroup } from "./sidenav-group";
 import { SidenavItem } from "./sidenav-item";
-import {
-    DesktopContainer,
-    DesktopDrawer,
-    MobileContainer,
-    Wrapper,
-} from "./sidenav.styles";
+import { DesktopContainer, MobileContainer, Wrapper } from "./sidenav.styles";
 import { SidenavProps } from "./types";
 
 const SidenavBase = ({
@@ -23,8 +17,8 @@ const SidenavBase = ({
     // CONST, STATE, REF
     // =============================================================================
     const wrapperRef = useRef<HTMLDivElement>(null);
+    const menuRef = useRef<HTMLDivElement>(null);
     const [internalId] = useState(() => SimpleIdGenerator.generate());
-    const drawerId = `${internalId}-drawer`;
 
     const [currentItem, setCurrentItem] = useState<
         SidenavContextItem | undefined
@@ -35,53 +29,6 @@ const SidenavBase = ({
     const [previouslySelectedItemId, setPreviouslySelectedItemId] = useState<
         string | undefined
     >(undefined);
-    const [showDrawer, setShowDrawer] = useState<boolean>(false);
-
-    const drawerAnimationProps = useSpring({
-        width: showDrawer ? 240 : 0,
-        /** NOTE
-         * borderWidth property divided to avoid mixing shorthand and non-shorthand propertied.
-         * Otherwise, it will throw an error
-         */
-        borderRightWidth: showDrawer ? 1 : 0,
-        borderTopWidth: showDrawer ? 1 : 0,
-        borderBottomWidth: showDrawer ? 1 : 0,
-        borderLeftWidth: 0,
-    });
-
-    // =========================================================================
-    // EVENT HANDLERS
-    // =========================================================================
-    const handleOutsideClicks = (e: MouseEvent) => {
-        if (
-            wrapperRef.current &&
-            !wrapperRef.current.contains(e.target as Node)
-        ) {
-            setSelectedItem({
-                itemId: previouslySelectedItemId
-                    ? previouslySelectedItemId
-                    : selectedItem
-                    ? selectedItem.itemId
-                    : undefined,
-                content: undefined,
-            });
-            setPreviouslySelectedItemId(undefined);
-            setCurrentItem(undefined);
-        }
-    };
-
-    const handleMouseLeave = () => {
-        setCurrentItem(undefined);
-    };
-
-    // =============================================================================
-    // EFFECTS
-    // =============================================================================
-    useEventListener("click", handleOutsideClicks, "window", true);
-
-    useEffect(() => {
-        setShowDrawer(!!selectedItem?.content || !!currentItem?.content);
-    }, [currentItem, selectedItem]);
 
     // =========================================================================
     // RENDER FUNCTIONS
@@ -90,6 +37,7 @@ const SidenavBase = ({
         <SidenavContext.Provider
             value={{
                 internalId,
+                menuRef,
                 currentItem,
                 selectedItem,
                 previouslySelectedItemId,
@@ -98,22 +46,8 @@ const SidenavBase = ({
                 setPreviouslySelectedItemId,
             }}
         >
-            <Wrapper
-                $fixed={fixed}
-                {...otherProps}
-                ref={wrapperRef}
-                onMouseLeave={handleMouseLeave}
-            >
-                <DesktopContainer>{children}</DesktopContainer>
-                <DesktopDrawer
-                    id={drawerId}
-                    style={drawerAnimationProps}
-                    $showDrawer={showDrawer}
-                    data-testid="sidenav-drawer"
-                >
-                    {(currentItem && currentItem.content) ||
-                        (selectedItem && selectedItem.content)}
-                </DesktopDrawer>
+            <Wrapper $fixed={fixed} ref={wrapperRef} {...otherProps}>
+                <DesktopContainer ref={menuRef}>{children}</DesktopContainer>
                 {/** NOTE: Since mobile view not supported yet, children will not be rendered */}
                 <MobileContainer></MobileContainer>
             </Wrapper>

--- a/src/sidenav/sidenav.tsx
+++ b/src/sidenav/sidenav.tsx
@@ -11,6 +11,7 @@ import { SidenavProps } from "./types";
 const SidenavBase = ({
     fixed = true,
     children,
+    "aria-label": ariaLabel = "Sidebar",
     ...otherProps
 }: SidenavProps) => {
     // =============================================================================
@@ -47,7 +48,9 @@ const SidenavBase = ({
             }}
         >
             <Wrapper $fixed={fixed} ref={wrapperRef} {...otherProps}>
-                <DesktopContainer ref={menuRef}>{children}</DesktopContainer>
+                <DesktopContainer ref={menuRef} aria-label={ariaLabel}>
+                    {children}
+                </DesktopContainer>
                 {/** NOTE: Since mobile view not supported yet, children will not be rendered */}
                 <MobileContainer></MobileContainer>
             </Wrapper>

--- a/src/sidenav/types.ts
+++ b/src/sidenav/types.ts
@@ -13,6 +13,8 @@ export interface SidenavProps extends SidenavBaseProps {
      * </Sidenav.Group>
      */
     children: React.ReactNode;
+    /** the accessible label */
+    "aria-label"?: string | undefined;
 }
 
 export interface SidenavGroupProps extends SidenavBaseProps {
@@ -24,6 +26,8 @@ export interface SidenavGroupProps extends SidenavBaseProps {
      * </Sidenav.Item>
      */
     children: React.ReactNode;
+    /** the accessible label */
+    "aria-label"?: string | undefined;
 }
 
 export interface SidenavItemProps extends SidenavBaseProps {

--- a/stories/sidenav/props-table.tsx
+++ b/stories/sidenav/props-table.tsx
@@ -46,6 +46,14 @@ const SIDENAV_DATA: ApiTableSectionProps[] = [
                 propTypes: ["boolean"],
                 defaultValue: "true",
             },
+            {
+                name: "aria-label",
+                description: (
+                    <>The accessible label for the {code("Sidenav")}</>
+                ),
+                propTypes: ["string"],
+                defaultValue: `"Sidebar"`,
+            },
         ],
     },
 ];
@@ -64,6 +72,16 @@ const SIDENAV_GROUP_DATA: ApiTableSectionProps[] = [
                 name: "separator",
                 description: "Specifies if bottom divider will be rendered",
                 propTypes: ["boolean"],
+            },
+            {
+                name: "aria-label",
+                description: (
+                    <>
+                        The accessible label to describe the category of the{" "}
+                        {code("Sidenav.Item")} elements
+                    </>
+                ),
+                propTypes: ["string"],
             },
         ],
     },

--- a/tests/sidenav/sidenav.spec.tsx
+++ b/tests/sidenav/sidenav.spec.tsx
@@ -1,6 +1,10 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
-import { Sidenav } from "../../src";
 import { Person2Icon, Square2x2Icon } from "@lifesg/react-icons";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Sidenav } from "src/sidenav";
+import { waitForElementToBeRemoved } from "../common/waitForElementRemoved";
+
+const SIDENAV_DRAWER_TEST_ID = "sidenav-drawer";
 
 // =============================================================================
 // UNIT TESTS
@@ -104,8 +108,10 @@ describe("Sidenav", () => {
         expect(screen.getAllByTestId("divider").length).toEqual(1);
     });
 
-    it("should trigger onClick when click on Sidenav item", () => {
-        const spy = jest.fn();
+    it("should trigger onClick when clicking sidenav item without subitems", async () => {
+        const user = userEvent.setup();
+        const mockOnClick = jest.fn();
+
         render(
             <Sidenav data-testid="side-nav">
                 <Sidenav.Group data-testid="side-nav-group">
@@ -114,23 +120,22 @@ describe("Sidenav", () => {
                         title="Dashboard"
                         icon={<Square2x2Icon />}
                         data-testid="dashboard-item"
-                        onClick={spy}
+                        onClick={mockOnClick}
                     ></Sidenav.Item>
                 </Sidenav.Group>
             </Sidenav>
         );
 
-        const dashboardElement = screen.getByTestId("dashboard-item");
-        act(() => {
-            fireEvent.click(dashboardElement);
+        await act(async () => {
+            await user.click(screen.getByTestId("dashboard-item"));
         });
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(mockOnClick).toHaveBeenCalledTimes(1);
     });
 
-    it("should open drawer if sidenav item contain children", () => {
-        const LEVEL2_TEXT1 = "Mini Dashboard";
-        const LEVEL2_TEXT2 = "Big Dashboard";
-        const LEVEL3_TEXT = "Part 1";
+    it("should trigger onClick when selecting sidenav item without subitems", async () => {
+        const user = userEvent.setup();
+        const mockOnClick = jest.fn();
+
         render(
             <Sidenav data-testid="side-nav">
                 <Sidenav.Group data-testid="side-nav-group">
@@ -139,21 +144,45 @@ describe("Sidenav", () => {
                         title="Dashboard"
                         icon={<Square2x2Icon />}
                         data-testid="dashboard-item"
+                        onClick={mockOnClick}
+                    ></Sidenav.Item>
+                </Sidenav.Group>
+            </Sidenav>
+        );
+
+        await act(async () => {
+            await user.keyboard("{Tab}");
+            await user.keyboard(" ");
+        });
+        expect(mockOnClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("should open drawer if Sidenav item contain children", async () => {
+        const user = userEvent.setup();
+        const ITEM = "Dashboard";
+        const DRAWER_ITEM = "Mini Dashboard";
+        const DRAWER_ITEM_2 = "Big Dashboard";
+        const DRAWER_SUBITEM = "Part 1";
+
+        render(
+            <Sidenav data-testid="side-nav">
+                <Sidenav.Group data-testid="side-nav-group">
+                    <Sidenav.Item
+                        id="dashboard"
+                        title={ITEM}
+                        icon={<Square2x2Icon />}
                     >
                         <Sidenav.DrawerItem
-                            title={LEVEL2_TEXT1}
-                            data-testid="mini-dashboard-item"
+                            title={DRAWER_ITEM}
                             id="mini-dashboard"
-                        ></Sidenav.DrawerItem>
+                        />
                         <Sidenav.DrawerItem
-                            title={LEVEL2_TEXT2}
-                            data-testid="big-dashboard-item"
+                            title={DRAWER_ITEM_2}
                             id="big-dashboard"
                         >
                             <Sidenav.DrawerSubitem
-                                title={LEVEL3_TEXT}
+                                title={DRAWER_SUBITEM}
                                 id="part-1"
-                                data-testid="part-1"
                             />
                         </Sidenav.DrawerItem>
                     </Sidenav.Item>
@@ -161,12 +190,125 @@ describe("Sidenav", () => {
             </Sidenav>
         );
 
-        const sideNavItem = screen.getByTestId("dashboard-item");
-        act(() => {
-            fireEvent.click(sideNavItem);
+        await act(async () => {
+            await user.click(screen.getByRole("button", { name: ITEM }));
         });
-        expect(screen.getByTestId("sidenav-drawer"));
-        expect(screen.getByText(LEVEL2_TEXT1)).toBeInTheDocument();
-        expect(screen.getByText(LEVEL3_TEXT)).toBeInTheDocument();
+
+        await waitFor(() =>
+            expect(screen.queryByTestId(SIDENAV_DRAWER_TEST_ID)).toBeVisible()
+        );
+        expect(screen.getByText(DRAWER_ITEM)).toBeInTheDocument();
+        expect(screen.getByText(DRAWER_ITEM_2)).toBeInTheDocument();
+        expect(screen.getByText(DRAWER_SUBITEM)).toBeInTheDocument();
+
+        await act(async () => {
+            await user.click(document.body);
+        });
+
+        await waitForElementToBeRemoved(() =>
+            screen.queryByTestId(SIDENAV_DRAWER_TEST_ID)
+        );
+    });
+
+    it("should apply the correct tab sequence", async () => {
+        const user = userEvent.setup();
+        const ITEM_1 = "Dashboard";
+        const ITEM_2 = "Profile";
+        const DRAWER_ITEM_1 = "Mini Dashboard";
+        const DRAWER_ITEM_2 = "Big Dashboard";
+        const DRAWER_SUBITEM = "Part 1";
+
+        render(
+            <>
+                <button data-testid="before" />
+                <Sidenav data-testid="side-nav">
+                    <Sidenav.Group data-testid="side-nav-group">
+                        <Sidenav.Item
+                            id="dashboard"
+                            title={ITEM_1}
+                            icon={<Square2x2Icon />}
+                        >
+                            <Sidenav.DrawerItem
+                                title={DRAWER_ITEM_1}
+                                id="mini-dashboard"
+                            />
+                            <Sidenav.DrawerItem
+                                title={DRAWER_ITEM_2}
+                                id="big-dashboard"
+                            >
+                                <Sidenav.DrawerSubitem
+                                    title={DRAWER_SUBITEM}
+                                    id="part-1"
+                                />
+                            </Sidenav.DrawerItem>
+                        </Sidenav.Item>
+                        <Sidenav.Item
+                            id="profile"
+                            title={ITEM_2}
+                            icon={<Square2x2Icon />}
+                        />
+                    </Sidenav.Group>
+                </Sidenav>
+                <button data-testid="after" />
+            </>
+        );
+
+        /* forward tab navigation */
+
+        await user.keyboard("{Tab}");
+
+        expect(screen.getByTestId("before")).toHaveFocus();
+
+        await user.keyboard("{Tab}");
+
+        expect(screen.getByRole("button", { name: ITEM_1 })).toHaveFocus();
+        await waitFor(() => screen.getByTestId(SIDENAV_DRAWER_TEST_ID));
+
+        await user.keyboard("{Tab}");
+
+        expect(
+            screen.getByRole("button", { name: DRAWER_ITEM_1 })
+        ).toHaveFocus();
+
+        await user.keyboard("{Tab}");
+
+        expect(
+            screen.getByRole("button", { name: DRAWER_ITEM_2 })
+        ).toHaveFocus();
+
+        await user.keyboard("{Tab}");
+
+        expect(
+            screen.getByRole("button", { name: DRAWER_SUBITEM })
+        ).toHaveFocus();
+
+        await user.keyboard("{Tab}");
+
+        expect(screen.getByRole("button", { name: ITEM_2 })).toHaveFocus();
+        await waitForElementToBeRemoved(() =>
+            screen.queryByTestId(SIDENAV_DRAWER_TEST_ID)
+        );
+
+        await user.keyboard("{Tab}");
+
+        expect(screen.getByTestId("after")).toHaveFocus();
+
+        /* backward tab navigation */
+
+        await user.keyboard("{Shift>}{Tab}{/Shift}");
+
+        expect(screen.getByRole("button", { name: ITEM_2 })).toHaveFocus();
+
+        await act(async () => {
+            await user.keyboard("{Shift>}{Tab}{/Shift}");
+        });
+
+        expect(screen.getByRole("button", { name: ITEM_1 })).toHaveFocus();
+
+        await act(async () => {
+            await user.keyboard("{Shift>}{Tab}{/Shift}");
+        });
+
+        expect(screen.getByTestId("before")).toHaveFocus();
     });
 });


### PR DESCRIPTION
**Changes**

- [delete] branch
- 68be36387debd417b49c46101d323c3e88030a4a
  - Adds aria markup to expose the item or subitem's expanded state
- 306dabcf29d6de7a5a64bb7ba256e3032181cefb
  - Adds focus handling using Floating UI library
  - As Floating UI can only support 1 reference element to 1 floating element, the drawer rendering is moved from the top-level `Sidenav` into the `Sidenav.Item` component
  - Upon Tab on a menu item that has subitems, the drawer opens. Pressing Tab again places focus on the first drawer item

<!-- Remove if not required -->
**Changelog entry**

- Improvements to aria annotations and keyboard navigation for `Sidenav`

**Additional information**

- You may refer to this [Figma](https://www.figma.com/design/wDAxbRmlq4xOn4UJ8zPuEF/%F0%9F%A7%91%F0%9F%8F%BB%E2%80%8D%F0%9F%A6%AF-Flagship-A11y-Annotations?node-id=1891-3888&m=dev)
