### PR TITLE
[MISC][Viv] Fix CCube brand-100 value

### DIFF
--- a/src/theme/colour-primitive/specs/ccube-colour-set.ts
+++ b/src/theme/colour-primitive/specs/ccube-colour-set.ts
@@ -11,7 +11,7 @@ export const CCubeColourSet: PrimitiveColourSet = {
     "brand-80": "#FFB3D9",
     "brand-90": "#FFD4E9",
     "brand-95": "#FFE8F3",
-    "brand-100": "#FFD6EB",
+    "brand-100": "#FFF8FC",
     "primary-10": "#1F1221",
     "primary-20": "#371F3B",
     "primary-30": "#4E2C53",


### PR DESCRIPTION
**Changes**
Fixed CCube's brand-100 from #FFD6EB to #FFF8FC

- [delete] branch

**Additional information**

- [Figma link](https://www.figma.com/design/QVydazexiNjDa2jPxuCd7b/branch/ZD9hdXYRnFz37dP7tBiueY/%F0%9F%8E%A8-Flagship-V3-Foundations-Kit?node-id=5939-6241&t=N6jzTBGEf97mKDZ5-11)
