### PR TITLE
[BOOKINGSG-7816][JZ] [DS] Update styling of NotificationBanner component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7806,7 +7806,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
             "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -9388,7 +9388,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
             "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.1",
@@ -9653,7 +9653,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
             "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -9663,7 +9663,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">= 0.4"
             }
@@ -9723,7 +9723,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
             "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
@@ -9733,14 +9733,16 @@
             }
         },
         "node_modules/es-set-tostringtag": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-            "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
-            "dev": true,
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "devOptional": true,
+            "license": "MIT",
             "dependencies": {
-                "get-intrinsic": "^1.2.4",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
                 "has-tostringtag": "^1.0.2",
-                "hasown": "^2.0.1"
+                "hasown": "^2.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -10884,13 +10886,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
             "devOptional": true,
+            "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
                 "mime-types": "^2.1.12"
             },
             "engines": {
@@ -10993,7 +10998,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "dev": true,
+            "devOptional": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -11115,7 +11120,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
             "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
@@ -11149,7 +11154,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
             "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "dunder-proto": "^1.0.1",
@@ -11297,7 +11302,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
             "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -11370,7 +11375,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -11383,7 +11388,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
             "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "has-symbols": "^1.0.3"
             },
@@ -11404,7 +11409,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
             "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -14825,7 +14830,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"

--- a/src/notification-banner/notification-banner.styles.tsx
+++ b/src/notification-banner/notification-banner.styles.tsx
@@ -50,9 +50,7 @@ export const Wrapper = styled.div<WrapperStyleProps>`
     cursor: ${(props) => (props.$clickable ? "pointer" : "default")};
 `;
 
-export const Container = styled(Layout.Content)`
-    display: flex;
-`;
+export const Container = styled(Layout.Content)``;
 
 export const ContentContainer = styled.div`
     flex: 1;
@@ -118,8 +116,8 @@ export const StyledIconButton = styled(ClickableIcon)`
     padding-left: ${Spacing["spacing-16"]};
     height: max-content;
     svg {
-        height: ${Spacing["spacing-24"]};
-        width: ${Spacing["spacing-24"]};
+        height: 1.5rem;
+        width: 1.5rem;
         color: ${Colour["icon-inverse"]};
     }
 `;
@@ -150,9 +148,10 @@ export const AccessibleBannerButton = styled.button`
 `;
 
 export const IconContainer = styled.div`
-    height: ${Spacing["spacing-24"]};
-    width: ${Spacing["spacing-24"]};
-    margin-right: ${Spacing["spacing-24"]};
+    height: 1.5rem;
+    width: 1.5rem;
+    margin: ${Spacing["spacing-24"]} ${Spacing["spacing-24"]} 0 0;
+    flex-shrink: 0;
 
     svg {
         height: 100%;

--- a/src/notification-banner/notification-banner.styles.tsx
+++ b/src/notification-banner/notification-banner.styles.tsx
@@ -1,8 +1,8 @@
 import { CrossIcon } from "@lifesg/react-icons/cross";
 import styled, { css } from "styled-components";
+import { Layout } from "../layout";
 import { ClickableIcon } from "../shared/clickable-icon";
 import { Colour, Font, Motion, Radius } from "../theme";
-import { Layout } from "../layout";
 import { Typography } from "../typography";
 
 // =============================================================================
@@ -57,16 +57,14 @@ export const Container = styled(Layout.Content)`
 
 export const ContentContainer = styled.div`
     flex: 1;
-
-    display: flex;
-    flex-direction: column;
     align-items: flex-start;
     padding: 1.5rem 0;
 `;
 
 export const Content = styled.div<ContentStyleProps>`
-    display: inline-block;
-    width: 100%;
+    display: flex;
+    flex: 1;
+    align-items: flex-start;
 
     ${Font["body-baseline-regular"]}
     color: ${Colour["text-inverse"]};
@@ -98,6 +96,12 @@ export const Content = styled.div<ContentStyleProps>`
     }}
 `;
 
+export const ContentText = styled.div`
+    flex: 1;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+`;
+
 export const ContentLink = styled(Typography.LinkBL)`
     position: relative;
 
@@ -111,8 +115,8 @@ export const StyledIconButton = styled(ClickableIcon)`
 `;
 
 export const StyledIcon = styled(CrossIcon)`
-    height: 1.875rem;
-    width: 1.875rem;
+    height: 1.5rem !important;
+    width: 1.5rem !important;
     color: ${Colour["icon-inverse"]};
 `;
 
@@ -139,4 +143,16 @@ export const AccessibleBannerButton = styled.button`
     position: absolute;
     white-space: nowrap;
     width: 1px;
+`;
+
+export const IconContainer = styled.div`
+    height: 1.5rem;
+    width: 1.5rem;
+    margin-right: 1.5rem;
+
+    svg {
+        height: 100%;
+        width: 100%;
+        color: ${Colour["hyperlink-inverse"]};
+    }
 `;

--- a/src/notification-banner/notification-banner.styles.tsx
+++ b/src/notification-banner/notification-banner.styles.tsx
@@ -1,8 +1,7 @@
-import { CrossIcon } from "@lifesg/react-icons/cross";
 import styled, { css } from "styled-components";
 import { Layout } from "../layout";
 import { ClickableIcon } from "../shared/clickable-icon";
-import { Colour, Font, Motion, Radius } from "../theme";
+import { Colour, Font, Motion, Radius, Spacing } from "../theme";
 import { Typography } from "../typography";
 
 // =============================================================================
@@ -58,7 +57,7 @@ export const Container = styled(Layout.Content)`
 export const ContentContainer = styled.div`
     flex: 1;
     align-items: flex-start;
-    padding: 1.5rem 0;
+    padding: ${Spacing["spacing-24"]} 0;
 `;
 
 export const Content = styled.div<ContentStyleProps>`
@@ -82,24 +81,30 @@ export const Content = styled.div<ContentStyleProps>`
         ${Font["body-baseline-regular"]}
         ${commonLinkStyle}
     }
+`;
 
+export const ContentWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+`;
+
+export const ContentText = styled.div<{ $maxCollapsedHeight?: number }>`
+    flex: 1;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
     ${(props) => {
         const gradient =
             "linear-gradient(to bottom, black 50%, transparent 100%)";
-        if (props.$maxCollapsedHeight)
+        if (props.$maxCollapsedHeight) {
             return css`
                 max-height: ${props.$maxCollapsedHeight}px;
                 overflow: hidden;
                 -webkit-mask-image: ${gradient};
                 mask-image: ${gradient};
             `;
+        }
     }}
-`;
-
-export const ContentText = styled.div`
-    flex: 1;
-    word-wrap: break-word;
-    overflow-wrap: break-word;
 `;
 
 export const ContentLink = styled(Typography.LinkBL)`
@@ -109,23 +114,22 @@ export const ContentLink = styled(Typography.LinkBL)`
 `;
 
 export const StyledIconButton = styled(ClickableIcon)`
-    margin-right: -1.5rem;
-    padding-left: 1rem;
+    margin-right: -${Spacing["spacing-24"]};
+    padding-left: ${Spacing["spacing-16"]};
     height: max-content;
-`;
-
-export const StyledIcon = styled(CrossIcon)`
-    height: 1.5rem !important;
-    width: 1.5rem !important;
-    color: ${Colour["icon-inverse"]};
+    svg {
+        height: ${Spacing["spacing-24"]};
+        width: ${Spacing["spacing-24"]};
+        color: ${Colour["icon-inverse"]};
+    }
 `;
 
 export const ActionButton = styled.button`
     display: flex;
     align-items: center;
-    gap: 0.25rem;
-
-    margin-top: 0.5rem;
+    gap: ${Spacing["spacing-4"]};
+    align-self: flex-start;
+    margin-top: ${Spacing["spacing-8"]};
 
     border: none;
     background: transparent;
@@ -146,9 +150,9 @@ export const AccessibleBannerButton = styled.button`
 `;
 
 export const IconContainer = styled.div`
-    height: 1.5rem;
-    width: 1.5rem;
-    margin-right: 1.5rem;
+    height: ${Spacing["spacing-24"]};
+    width: ${Spacing["spacing-24"]};
+    margin-right: ${Spacing["spacing-24"]};
 
     svg {
         height: 100%;

--- a/src/notification-banner/notification-banner.tsx
+++ b/src/notification-banner/notification-banner.tsx
@@ -97,7 +97,6 @@ export const NBComponent = ({
                 id={formatId("action-button", id)}
                 data-testid={formatId("action-button", testId)}
                 type="button"
-                aria-label=""
                 {...actionButton}
                 onClick={handleActionButtonOnClick}
             >
@@ -107,11 +106,7 @@ export const NBComponent = ({
     };
 
     const renderContent = () => (
-        <Content
-            ref={contentRef}
-            data-testid={formatId("text-content", testId)}
-        >
-            {icon && <IconContainer aria-hidden>{icon}</IconContainer>}
+        <Content data-testid={formatId("text-content", testId)}>
             <ContentWrapper>
                 <ContentText
                     $maxCollapsedHeight={
@@ -120,7 +115,7 @@ export const NBComponent = ({
                             : undefined
                     }
                 >
-                    {children}
+                    <div ref={contentRef}>{children}</div>
                 </ContentText>
                 {renderActionButton()}
             </ContentWrapper>
@@ -137,13 +132,11 @@ export const NBComponent = ({
             $sticky={sticky}
             $clickable={!!onClick}
             onClick={onClick}
-            role="landmark"
-            aria-describedby={
-                dismissible ? formatId("dismiss-button", id) : undefined
-            }
+            role="region"
             {...otherProps}
         >
             <Container id={formatId("container", id)}>
+                {icon && <IconContainer aria-hidden>{icon}</IconContainer>}
                 <ContentContainer>{renderContent()}</ContentContainer>
                 {dismissible && renderDismissButton()}
             </Container>

--- a/src/notification-banner/notification-banner.tsx
+++ b/src/notification-banner/notification-banner.tsx
@@ -1,3 +1,4 @@
+import { CrossIcon } from "@lifesg/react-icons";
 import React, { NamedExoticComponent, useEffect, useState } from "react";
 import { useResizeDetector } from "react-resize-detector";
 import {
@@ -7,9 +8,9 @@ import {
     Content,
     ContentContainer,
     ContentText,
+    ContentWrapper,
     IconContainer,
     ContentLink as NBLink,
-    StyledIcon,
     StyledIconButton,
     Wrapper,
 } from "./notification-banner.styles";
@@ -75,14 +76,16 @@ export const NBComponent = ({
 
     const renderDismissButton = () => (
         <StyledIconButton
+            tabIndex={0}
             onClick={handleDismiss}
             id={formatId("dismiss-button", id)}
             data-testid={formatId("dismiss-button", testId)}
+            focusOutline="browser"
             focusHighlight={false}
             type="button"
-            aria-label="Dismiss notification"
+            aria-label="close"
         >
-            <StyledIcon aria-hidden />
+            <CrossIcon aria-hidden />
         </StyledIconButton>
     );
 
@@ -94,6 +97,7 @@ export const NBComponent = ({
                 id={formatId("action-button", id)}
                 data-testid={formatId("action-button", testId)}
                 type="button"
+                aria-label=""
                 {...actionButton}
                 onClick={handleActionButtonOnClick}
             >
@@ -104,15 +108,22 @@ export const NBComponent = ({
 
     const renderContent = () => (
         <Content
+            ref={contentRef}
             data-testid={formatId("text-content", testId)}
-            $maxCollapsedHeight={
-                maxCollapsedHeight && contentHeight > maxCollapsedHeight
-                    ? maxCollapsedHeight
-                    : undefined
-            }
         >
-            {icon && <IconContainer aria-label="Icon" role="img">{icon}</IconContainer>}
-            <ContentText ref={contentRef}>{children}</ContentText>
+            {icon && <IconContainer aria-hidden>{icon}</IconContainer>}
+            <ContentWrapper>
+                <ContentText
+                    $maxCollapsedHeight={
+                        maxCollapsedHeight && contentHeight > maxCollapsedHeight
+                            ? maxCollapsedHeight
+                            : undefined
+                    }
+                >
+                    {children}
+                </ContentText>
+                {renderActionButton()}
+            </ContentWrapper>
         </Content>
     );
 
@@ -126,18 +137,14 @@ export const NBComponent = ({
             $sticky={sticky}
             $clickable={!!onClick}
             onClick={onClick}
-            role="marquee"
-            aria-live="polite"
-            aria-atomic="true"
-            aria-label="Notification banner"
-            aria-describedby={dismissible ? formatId("dismiss-button", id) : undefined}
+            role="landmark"
+            aria-describedby={
+                dismissible ? formatId("dismiss-button", id) : undefined
+            }
             {...otherProps}
         >
             <Container id={formatId("container", id)}>
-                <ContentContainer>
-                    {renderContent()}
-                    {renderActionButton()}
-                </ContentContainer>
+                <ContentContainer>{renderContent()}</ContentContainer>
                 {dismissible && renderDismissButton()}
             </Container>
             {onClick && renderAccessibleBannerButton()}

--- a/src/notification-banner/notification-banner.tsx
+++ b/src/notification-banner/notification-banner.tsx
@@ -6,6 +6,8 @@ import {
     Container,
     Content,
     ContentContainer,
+    ContentText,
+    IconContainer,
     ContentLink as NBLink,
     StyledIcon,
     StyledIconButton,
@@ -27,6 +29,7 @@ export const NBComponent = ({
     maxCollapsedHeight,
     onClick,
     actionButton,
+    icon,
     ...otherProps
 }: NotificationBannerWithForwardedRefProps) => {
     // =============================================================================
@@ -108,7 +111,8 @@ export const NBComponent = ({
                     : undefined
             }
         >
-            <div ref={contentRef}>{children}</div>
+            {icon && <IconContainer aria-label="Icon" role="img">{icon}</IconContainer>}
+            <ContentText ref={contentRef}>{children}</ContentText>
         </Content>
     );
 
@@ -122,6 +126,11 @@ export const NBComponent = ({
             $sticky={sticky}
             $clickable={!!onClick}
             onClick={onClick}
+            role="marquee"
+            aria-live="polite"
+            aria-atomic="true"
+            aria-label="Notification banner"
+            aria-describedby={dismissible ? formatId("dismiss-button", id) : undefined}
             {...otherProps}
         >
             <Container id={formatId("container", id)}>

--- a/src/notification-banner/types.ts
+++ b/src/notification-banner/types.ts
@@ -6,6 +6,7 @@ export interface NotificationBannerProps
     dismissible?: boolean | undefined;
     visible?: boolean | undefined;
     sticky?: boolean | undefined;
+    icon?: JSX.Element | undefined;
     onDismiss?: (() => void) | undefined;
     "data-testid"?: string | undefined;
     /** Specifies the maximum height of content, after which it is collapsed */

--- a/stories/notification-banner/notification-banner.mdx
+++ b/stories/notification-banner/notification-banner.mdx
@@ -24,6 +24,12 @@ property.
 
 <Canvas of={NotificationBannerStories.NonSticky} />
 
+## Banner with icon
+
+The `NotificationBanner` supports rendering of icons within when passed in as a prop.
+
+<Canvas of={NotificationBannerStories.WithIcon} />
+
 ## Non dismissible banner
 
 <Canvas of={NotificationBannerStories.NonDismissible} />

--- a/stories/notification-banner/notification-banner.stories.tsx
+++ b/stories/notification-banner/notification-banner.stories.tsx
@@ -1,3 +1,4 @@
+import { SpeakerFillIcon } from "@lifesg/react-icons";
 import { ArrowRightIcon } from "@lifesg/react-icons/arrow-right";
 import { GearFillIcon } from "@lifesg/react-icons/gear-fill";
 import type { Meta, StoryObj } from "@storybook/react";
@@ -54,6 +55,19 @@ export const NonSticky: StoryObj<Component> = {
     },
 };
 
+export const WithIcon: StoryObj<Component> = {
+    render: (_args) => {
+        return (
+            <div>
+                <NotificationBanner icon={<SpeakerFillIcon />}>
+                    This is a notification banner with icon that can be
+                    dismissed by default.
+                </NotificationBanner>
+            </div>
+        );
+    },
+};
+
 export const NonDismissible: StoryObj<Component> = {
     render: (_args) => {
         return (
@@ -107,6 +121,7 @@ export const CustomContent: StoryObj<Component> = {
                         padding: "1rem",
                         alignItems: "center",
                         gap: "1rem",
+                        width: "100%",
                     }}
                 >
                     <GearFillIcon />

--- a/stories/notification-banner/props-table.tsx
+++ b/stories/notification-banner/props-table.tsx
@@ -35,6 +35,20 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["boolean"],
             },
             {
+                name: "icon",
+                description: (
+                    <>
+                        Specifies the icon to be displayed in the banner.
+                        Available icons can be found in the{" "}
+                        <StorybookLink path="/docs/core-icon--docs">
+                            Icon component API
+                        </StorybookLink>
+                        . If not specified, no icon will be displayed.
+                    </>
+                ),
+                propTypes: ["JSX.Element"],
+            },
+            {
                 name: "sticky",
                 description: (
                     <>


### PR DESCRIPTION
**Changes**
- Expose `icon` prop in NotificationBanner component to allow consumers to pass in the icon they want rendered on the banner, instead of relying on consumers to always do the icon themselves within the content.
- Added some accessibility attributes
- Styled NotificationBanner to follow Figma designs
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**
- Update NotificationBanner stylings and added accessibility attributes, exposed optional `icon` props for rendering icons.

**Additional information**

- You may refer to this [BOOKINGSG-7816](https://sgtechstack.atlassian.net/browse/BOOKINGSG-7816)
