### PR TITLE
[MOL-19033][RP] Migrate the footer changes for v2 to v3

### DIFF
--- a/src/footer/footer-download-app.style.tsx
+++ b/src/footer/footer-download-app.style.tsx
@@ -17,31 +17,25 @@ export const Label = styled(Typography.BodyMD)`
     margin-bottom: ${Spacing["spacing-16"]};
 `;
 
-export const Items = styled.div`
+export const AppButtonsWrapper = styled.div`
     display: flex;
-    align-items: flex-start;
+    flex-wrap: wrap;
+    row-gap: ${Spacing["spacing-16"]};
+    column-gap: ${Spacing["spacing-16"]};
 `;
 
 export const AppStoreLink = styled.a`
-    &:not(:last-child) {
-        margin-right: ${Spacing["spacing-32"]};
-    }
-
     img {
         width: auto;
-        height: 3rem;
+        height: 3.75rem;
         object-fit: contain;
+        display: block;
     }
 
-    ${MediaQuery.MaxWidth.sm} {
-        &:not(:last-child) {
-            margin-right: ${Spacing["spacing-16"]};
-        }
-
+    ${MediaQuery.MaxWidth.lg} {
         img {
+            height: 3rem;
             width: 100%;
-            height: auto;
-            object-fit: contain;
         }
     }
 `;

--- a/src/footer/footer-download-app.tsx
+++ b/src/footer/footer-download-app.tsx
@@ -1,6 +1,6 @@
 import {
+    AppButtonsWrapper,
     AppStoreLink,
-    Items,
     Label,
     Wrapper,
 } from "./footer-download-app.style";
@@ -13,7 +13,7 @@ const PLAY_STORE_ICON =
 export const DownloadApp = () => (
     <Wrapper data-testid="download-app-section">
         <Label weight="semibold">Download the app</Label>
-        <Items>
+        <AppButtonsWrapper>
             <AppStoreLink
                 href="https://apps.apple.com/sg/app/moments-of-life/id1383218758"
                 target="_blank"
@@ -30,6 +30,6 @@ export const DownloadApp = () => (
             >
                 <img src={PLAY_STORE_ICON} alt="google-play-store" />
             </AppStoreLink>
-        </Items>
+        </AppButtonsWrapper>
     </Wrapper>
 );

--- a/src/footer/footer-helper.ts
+++ b/src/footer/footer-helper.ts
@@ -36,16 +36,35 @@ export namespace FooterHelper {
         }
     };
 
-    export const getFooterLogo = (resourceScheme?: ResourceScheme) => {
+    export const getFooterLogoAttribute = (
+        resourceScheme?: ResourceScheme
+    ): React.ImgHTMLAttributes<HTMLImageElement> => {
         switch (resourceScheme) {
             case "bookingsg":
-                return "https://home.booking.gov.sg/images/bookingsg/footer.svg";
+                return {
+                    src: "https://home.booking.gov.sg/images/bookingsg/footer.svg",
+                    alt: "BookingSG",
+                    style: { minWidth: "4rem" },
+                };
             case "mylegacy":
-                return "https://mylegacy.life.gov.sg/images/site-logo.png";
+                return {
+                    src: "https://mylegacy.life.gov.sg/images/site-logo.png",
+                    alt: "MyLegacy",
+                    style: { minWidth: "10rem", maxHeight: "2rem" },
+                };
             case "ccube":
-                return "https://assets.life.gov.sg/ccube/logo-ccube.svg";
+                return {
+                    src: "https://assets.life.gov.sg/ccube/logo-ccube.svg",
+                    alt: "Ccube",
+                    style: { minWidth: "10rem" },
+                };
+
             default:
-                return "https://assets.life.gov.sg/react-design-system/img/logo/lifesg-primary-logo.svg";
+                return {
+                    src: "https://assets.life.gov.sg/react-design-system/img/logo/lifesg-primary-logo.svg",
+                    alt: "LifeSG",
+                    style: { minWidth: "4rem" },
+                };
         }
     };
 

--- a/src/footer/footer-resource-addon.styles.tsx
+++ b/src/footer/footer-resource-addon.styles.tsx
@@ -1,0 +1,13 @@
+import styled from "styled-components";
+
+export const Img = styled.img`
+    max-height: 4.5rem;
+    max-width: 100%;
+`;
+
+export const Items = styled.div`
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    margin-top: 1rem;
+`;

--- a/src/footer/footer-resource-addon.styles.tsx
+++ b/src/footer/footer-resource-addon.styles.tsx
@@ -8,6 +8,6 @@ export const Img = styled.img`
 export const Items = styled.div`
     display: flex;
     align-items: flex-start;
-    gap: 1rem;
+    gap: 2rem;
     margin-top: 1rem;
 `;

--- a/src/footer/footer-resource-addon.styles.tsx
+++ b/src/footer/footer-resource-addon.styles.tsx
@@ -1,13 +1,14 @@
 import styled from "styled-components";
+import { Spacing } from "../theme";
 
 export const Img = styled.img`
-    max-height: 4.5rem;
+    max-height: ${Spacing["spacing-72"]};
     max-width: 100%;
 `;
 
 export const Items = styled.div`
     display: flex;
     align-items: flex-start;
-    gap: 2rem;
-    margin-top: 1rem;
+    gap: ${Spacing["spacing-32"]};
+    margin-top: ${Spacing["spacing-16"]};
 `;

--- a/src/footer/footer-resource-addon.tsx
+++ b/src/footer/footer-resource-addon.tsx
@@ -19,12 +19,13 @@ export const ResourceAddon = (): JSX.Element => {
                                 data-testid="footer-govtech-logo"
                                 src="https://mylegacy.life.gov.sg/images/agencies/govtech-logo.png"
                                 alt="GovTech Singapore"
+                                style={{ height: "4.5rem" }}
                             />
                             <Img
                                 data-testid="footer-psd-logo"
                                 src="https://mylegacy.life.gov.sg/images/agencies/psd-logo.png"
                                 alt="Public Service Division"
-                                style={{ maxHeight: "3.5rem" }}
+                                style={{ height: "3.5rem" }}
                             />
                         </Items>
                     </>

--- a/src/footer/footer-resource-addon.tsx
+++ b/src/footer/footer-resource-addon.tsx
@@ -10,10 +10,13 @@ export const ResourceAddon = (): JSX.Element => {
             case "mylegacy":
                 return (
                     <>
-                        <Typography.BodyXS>
+                        <Typography.BodySM
+                            weight="regular"
+                            data-testid="resource-addon-title"
+                        >
                             My Legacy is a LifeSG initiative, brought to you by
                             the following government agencies:
-                        </Typography.BodyXS>
+                        </Typography.BodySM>
                         <Items>
                             <Img
                                 data-testid="footer-govtech-logo"

--- a/src/footer/footer-resource-addon.tsx
+++ b/src/footer/footer-resource-addon.tsx
@@ -10,13 +10,13 @@ export const ResourceAddon = (): JSX.Element => {
             case "mylegacy":
                 return (
                     <>
-                        <Typography.BodySM
+                        <Typography.BodyMD
                             weight="regular"
                             data-testid="resource-addon-title"
                         >
                             My Legacy is a LifeSG initiative, brought to you by
                             the following government agencies:
-                        </Typography.BodySM>
+                        </Typography.BodyMD>
                         <Items>
                             <Img
                                 data-testid="footer-govtech-logo"

--- a/src/footer/footer-resource-addon.tsx
+++ b/src/footer/footer-resource-addon.tsx
@@ -1,0 +1,40 @@
+import { useTheme } from "styled-components";
+import { Typography } from "../typography";
+import { Img, Items } from "./footer-resource-addon.styles";
+
+export const ResourceAddon = (): JSX.Element => {
+    const theme = useTheme();
+
+    const getResourceContent = () => {
+        switch (theme?.resourceScheme) {
+            case "mylegacy":
+                return (
+                    <>
+                        <Typography.BodyXS>
+                            My Legacy is a LifeSG initiative, brought to you by
+                            the following government agencies:
+                        </Typography.BodyXS>
+                        <Items>
+                            <Img
+                                data-testid="footer-govtech-logo"
+                                src="https://mylegacy.life.gov.sg/images/agencies/govtech-logo.png"
+                                alt="GovTech Singapore"
+                            />
+                            <Img
+                                data-testid="footer-psd-logo"
+                                src="https://mylegacy.life.gov.sg/images/agencies/psd-logo.png"
+                                alt="Public Service Division"
+                                style={{ maxHeight: "3.5rem" }}
+                            />
+                        </Items>
+                    </>
+                );
+            default:
+                return null;
+        }
+    };
+
+    return (
+        <div data-testid="resource-addon-section">{getResourceContent()}</div>
+    );
+};

--- a/src/footer/footer.style.tsx
+++ b/src/footer/footer.style.tsx
@@ -58,7 +58,7 @@ export const LogoSection = styled.div`
 `;
 
 export const LinkSection = styled.ul`
-    max-width: 16vw;
+    max-width: 16%;
     list-style-type: none;
 
     &:nth-of-type(1) {
@@ -94,8 +94,7 @@ export const LinkSection = styled.ul`
 `;
 
 export const AddonSection = styled.div`
-    grid-column: 13 / span 6;
-    max-width: 33vw;
+    max-width: 33%;
     margin-left: auto;
 
     ${MediaQuery.MaxWidth.lg} {

--- a/src/footer/footer.style.tsx
+++ b/src/footer/footer.style.tsx
@@ -97,46 +97,38 @@ export const AddonSection = styled.div`
 export const BottomSection = styled(Layout.Content)`
     padding: ${Spacing["spacing-20"]} 0;
 
+    [data-id="container"] {
+        column-gap: ${Spacing["spacing-32"]};
+    }
+
     ${MediaQuery.MaxWidth.lg} {
         border-top: none;
-        flex-direction: column;
         padding: ${Spacing["spacing-16"]} 0;
+
+        [data-id="container"] {
+            flex-direction: column;
+        }
     }
 `;
 
 export const BottomSectionContent = styled.div`
-    grid-column: 1 / span 6;
+    flex: 1 1 50%;
     display: flex;
 
-    &:not(:last-child) {
-        margin-right: ${Spacing["spacing-16"]};
-    }
-
     ${MediaQuery.MaxWidth.lg} {
-        grid-column: 1 / span 12;
         flex-direction: column;
         &:not(:last-child) {
             margin-right: 0;
         }
     }
-
-    ${MediaQuery.MaxWidth.md} {
-        grid-column: 1 / span 8;
-    }
 `;
 
 export const CopyrightSection = styled(BottomSectionContent)`
-    grid-column: 7 / span 6;
     justify-content: flex-end;
 
     ${MediaQuery.MaxWidth.lg} {
         margin-top: ${Spacing["spacing-16"]};
         justify-content: flex-start;
-        grid-column: 1 / span 12;
-    }
-
-    ${MediaQuery.MaxWidth.md} {
-        grid-column: 1 / span 8;
     }
 `;
 

--- a/src/footer/footer.style.tsx
+++ b/src/footer/footer.style.tsx
@@ -100,7 +100,6 @@ export const AddonSection = styled.div`
     ${MediaQuery.MaxWidth.lg} {
         grid-column: 1 / span 12;
         margin-left: ${Spacing["spacing-0"]};
-        margin-top: ${Spacing["spacing-32"]};
         max-width: 100%;
     }
 `;

--- a/src/footer/footer.style.tsx
+++ b/src/footer/footer.style.tsx
@@ -26,19 +26,28 @@ export const FullWidthDivider = styled(Divider)`
 
 export const TopSection = styled(Layout.Content)`
     padding: ${Spacing["spacing-64"]} 0;
+    display: flex;
+    align-items: flex-start;
+
+    [data-id="container"] {
+        display: flex;
+        width: 100%;
+    }
 
     ${MediaQuery.MaxWidth.lg} {
         padding: ${Spacing["spacing-32"]} 0;
+
         [data-id="container"] {
-            display: grid;
+            flex-direction: column;
+            gap: ${Spacing["spacing-32"]};
         }
     }
 `;
 
 export const LogoSection = styled.div`
-    grid-column: auto;
+    display: flex;
     width: fit-content;
-    margin-right: ${Spacing["spacing-32"]};
+    margin-right: ${Spacing["spacing-64"]};
 
     img {
         max-height: 4rem;
@@ -47,24 +56,26 @@ export const LogoSection = styled.div`
     }
 
     ${MediaQuery.MaxWidth.lg} {
-        grid-column: 1 / span 12;
-        margin-right: ${Spacing["spacing-0"]};
-        margin-bottom: ${Spacing["spacing-32"]};
+        width: 100%;
+        margin-right: 0;
     }
+`;
 
-    ${MediaQuery.MaxWidth.md} {
-        margin-bottom: ${Spacing["spacing-32"]};
+export const LinkSectionWrapper = styled.div`
+    display: flex;
+    gap: ${Spacing["spacing-32"]};
+    flex: 1 1 auto;
+    max-width: calc(32% + ${Spacing["spacing-32"]});
+
+    ${MediaQuery.MaxWidth.lg} {
+        gap: ${Spacing["spacing-16"]};
+        max-width: 100%;
     }
 `;
 
 export const LinkSection = styled.ul`
-    max-width: 16%;
+    flex: 1 1 auto;
     list-style-type: none;
-
-    &:nth-of-type(1) {
-        margin-left: ${Spacing["spacing-32"]};
-        margin-right: ${Spacing["spacing-32"]};
-    }
 
     li {
         :not(:last-child) {
@@ -77,30 +88,21 @@ export const LinkSection = styled.ul`
     }
 
     ${MediaQuery.MaxWidth.lg} {
-        max-width: 100%;
-        grid-column: 1 / span 6;
-
-        &:nth-of-type(1) {
-            margin-left: ${Spacing["spacing-0"]};
-            margin-right: ${Spacing["spacing-0"]};
-            margin-bottom: ${Spacing["spacing-32"]};
-        }
-
-        &:nth-of-type(2) {
-            // 2nd col
-            grid-column: 7 / span 6;
-        }
+        flex: 1 1 50%;
+        width: 50%;
     }
 `;
 
 export const AddonSection = styled.div`
     max-width: 33%;
+    flex: 1 1 33%;
     margin-left: auto;
 
     ${MediaQuery.MaxWidth.lg} {
-        grid-column: 1 / span 12;
-        margin-left: ${Spacing["spacing-0"]};
         max-width: 100%;
+        flex: 1 1 100%;
+        margin-left: 0;
+        width: 100%;
     }
 `;
 
@@ -141,6 +143,7 @@ export const BottomSectionContent = styled.div`
 
 export const CopyrightSection = styled(BottomSectionContent)`
     grid-column: 7 / span 6;
+    justify-content: flex-end;
     justify-content: flex-end;
 
     ${MediaQuery.MaxWidth.lg} {

--- a/src/footer/footer.style.tsx
+++ b/src/footer/footer.style.tsx
@@ -29,11 +29,16 @@ export const TopSection = styled(Layout.Content)`
 
     ${MediaQuery.MaxWidth.lg} {
         padding: ${Spacing["spacing-32"]} 0;
+        [data-id="container"] {
+            display: grid;
+        }
     }
 `;
 
 export const LogoSection = styled.div`
-    grid-column: 1 / span 2;
+    grid-column: auto;
+    width: fit-content;
+    margin-right: 32px;
 
     img {
         max-height: 4rem;
@@ -43,23 +48,22 @@ export const LogoSection = styled.div`
 
     ${MediaQuery.MaxWidth.lg} {
         grid-column: 1 / span 12;
+        margin-right: 0;
         margin-bottom: ${Spacing["spacing-32"]};
     }
 
     ${MediaQuery.MaxWidth.md} {
-        grid-column: 1 / span 8;
         margin-bottom: ${Spacing["spacing-32"]};
     }
 `;
 
 export const LinkSection = styled.ul`
-    // first col
-    grid-column: 3 / span 4;
+    max-width: 16vw;
     list-style-type: none;
 
-    :nth-of-type(2) {
-        // 2nd col
-        grid-column: 7 / span 4;
+    &:nth-of-type(1) {
+        margin-left: ${Spacing["spacing-32"]};
+        margin-right: ${Spacing["spacing-32"]}; // existing desktop gap
     }
 
     li {
@@ -73,36 +77,32 @@ export const LinkSection = styled.ul`
     }
 
     ${MediaQuery.MaxWidth.lg} {
-        // first col
+        max-width: 100%;
         grid-column: 1 / span 6;
 
-        :nth-of-type(2) {
+        &:nth-of-type(1) {
+            margin-left: ${Spacing["spacing-0"]};
+            margin-right: 0;
+            margin-bottom: ${Spacing["spacing-32"]};
+        }
+
+        &:nth-of-type(2) {
             // 2nd col
             grid-column: 7 / span 6;
-        }
-    }
-
-    ${MediaQuery.MaxWidth.md} {
-        // first col
-        grid-column: 1 / span 4;
-
-        :nth-of-type(2) {
-            // 2nd col
-            grid-column: 5 / span 4;
         }
     }
 `;
 
 export const AddonSection = styled.div`
     grid-column: 13 / span 6;
+    max-width: 33vw;
+    margin-left: auto;
 
     ${MediaQuery.MaxWidth.lg} {
         grid-column: 1 / span 12;
+        margin-left: ${Spacing["spacing-0"]};
         margin-top: ${Spacing["spacing-32"]};
-    }
-
-    ${MediaQuery.MaxWidth.md} {
-        grid-column: 1 / span 8;
+        max-width: 100%;
     }
 `;
 

--- a/src/footer/footer.style.tsx
+++ b/src/footer/footer.style.tsx
@@ -12,7 +12,7 @@ export const BaseFooter = styled.footer`
     background: ${Colour["bg-strong"]};
 `;
 
-export const StyledFooterLink = styled(Typography.LinkSM)`
+export const StyledFooterLink = styled(Typography.LinkMD)`
     color: ${Colour.text};
 `;
 
@@ -26,13 +26,6 @@ export const FullWidthDivider = styled(Divider)`
 
 export const TopSection = styled(Layout.Content)`
     padding: ${Spacing["spacing-64"]} 0;
-    display: flex;
-    align-items: flex-start;
-
-    [data-id="container"] {
-        display: flex;
-        width: 100%;
-    }
 
     ${MediaQuery.MaxWidth.lg} {
         padding: ${Spacing["spacing-32"]} 0;
@@ -68,13 +61,12 @@ export const LinkSectionWrapper = styled.div`
     max-width: calc(32% + ${Spacing["spacing-32"]});
 
     ${MediaQuery.MaxWidth.lg} {
-        gap: ${Spacing["spacing-16"]};
         max-width: 100%;
     }
 `;
 
 export const LinkSection = styled.ul`
-    flex: 1 1 auto;
+    flex: 1 1 50%;
     list-style-type: none;
 
     li {
@@ -86,23 +78,15 @@ export const LinkSection = styled.ul`
             display: inline-block;
         }
     }
-
-    ${MediaQuery.MaxWidth.lg} {
-        flex: 1 1 50%;
-        width: 50%;
-    }
 `;
 
 export const AddonSection = styled.div`
-    max-width: 33%;
-    flex: 1 1 33%;
+    flex: 0 1 33%;
     margin-left: auto;
 
     ${MediaQuery.MaxWidth.lg} {
-        max-width: 100%;
         flex: 1 1 100%;
         margin-left: 0;
-        width: 100%;
     }
 `;
 
@@ -143,7 +127,6 @@ export const BottomSectionContent = styled.div`
 
 export const CopyrightSection = styled(BottomSectionContent)`
     grid-column: 7 / span 6;
-    justify-content: flex-end;
     justify-content: flex-end;
 
     ${MediaQuery.MaxWidth.lg} {

--- a/src/footer/footer.style.tsx
+++ b/src/footer/footer.style.tsx
@@ -38,7 +38,7 @@ export const TopSection = styled(Layout.Content)`
 export const LogoSection = styled.div`
     grid-column: auto;
     width: fit-content;
-    margin-right: 32px;
+    margin-right: ${Spacing["spacing-32"]};
 
     img {
         max-height: 4rem;
@@ -48,7 +48,7 @@ export const LogoSection = styled.div`
 
     ${MediaQuery.MaxWidth.lg} {
         grid-column: 1 / span 12;
-        margin-right: 0;
+        margin-right: ${Spacing["spacing-0"]};
         margin-bottom: ${Spacing["spacing-32"]};
     }
 
@@ -63,7 +63,7 @@ export const LinkSection = styled.ul`
 
     &:nth-of-type(1) {
         margin-left: ${Spacing["spacing-32"]};
-        margin-right: ${Spacing["spacing-32"]}; // existing desktop gap
+        margin-right: ${Spacing["spacing-32"]};
     }
 
     li {
@@ -82,7 +82,7 @@ export const LinkSection = styled.ul`
 
         &:nth-of-type(1) {
             margin-left: ${Spacing["spacing-0"]};
-            margin-right: 0;
+            margin-right: ${Spacing["spacing-0"]};
             margin-bottom: ${Spacing["spacing-32"]};
         }
 

--- a/src/footer/footer.tsx
+++ b/src/footer/footer.tsx
@@ -12,6 +12,7 @@ import {
     DisclaimerTextLink,
     FullWidthDivider,
     LinkSection,
+    LinkSectionWrapper,
     LogoSection,
     StyledFooterLink,
     TopSection,
@@ -109,16 +110,24 @@ export const Footer = <T,>({
                             {...otherLogoAttributes}
                         />
                     </LogoSection>
-                    {links?.[0] && (
-                        <LinkSection key="link-col-1" data-testid="link-col-1">
-                            {renderFooterLinks(links[0])}
-                        </LinkSection>
-                    )}
-                    {links?.[1] && (
-                        <LinkSection key="link-col-2" data-testid="link-col-2">
-                            {renderFooterLinks(links[1])}
-                        </LinkSection>
-                    )}
+                    <LinkSectionWrapper>
+                        {links?.[0] && (
+                            <LinkSection
+                                key="link-col-1"
+                                data-testid="link-col-1"
+                            >
+                                {renderFooterLinks(links[0])}
+                            </LinkSection>
+                        )}
+                        {links?.[1] && (
+                            <LinkSection
+                                key="link-col-2"
+                                data-testid="link-col-2"
+                            >
+                                {renderFooterLinks(links[1])}
+                            </LinkSection>
+                        )}
+                    </LinkSectionWrapper>
                     {showDownloadAddon && (
                         <AddonSection>
                             <DownloadApp />

--- a/src/footer/footer.tsx
+++ b/src/footer/footer.tsx
@@ -16,6 +16,7 @@ import {
     StyledFooterLink,
     TopSection,
 } from "./footer.style";
+import { ResourceAddon } from "./footer-resource-addon";
 import { FooterLinkProps, FooterProps } from "./types";
 
 export const Footer = <T,>({
@@ -24,6 +25,7 @@ export const Footer = <T,>({
     lastUpdated,
     disclaimerLinks,
     showDownloadAddon,
+    showResourceAddon,
     logoSrc,
     copyrightInfo,
     onFooterLinkClick,
@@ -96,18 +98,15 @@ export const Footer = <T,>({
         }
 
         if (links || showDownloadAddon) {
+            const { src, ...otherLogoAttributes } =
+                FooterHelper.getFooterLogoAttribute(theme?.resourceScheme);
             component = (
                 <>
                     <LogoSection data-testid="logo-section">
                         <img
-                            src={
-                                logoSrc ||
-                                FooterHelper.getFooterLogo(
-                                    theme?.resourceScheme
-                                )
-                            }
-                            alt="LifeSG"
+                            src={logoSrc || src}
                             data-testid="logo"
+                            {...otherLogoAttributes}
                         />
                     </LogoSection>
                     {links?.[0] && (
@@ -125,6 +124,12 @@ export const Footer = <T,>({
                             <DownloadApp />
                         </AddonSection>
                     )}
+                    {/* when showDownloadAddon and showResourceAddon are enabled, showDownloadAddon should take priority to being rendered */}
+                    {!showDownloadAddon && showResourceAddon && (
+                        <AddonSection>
+                            <ResourceAddon />
+                        </AddonSection>
+                    )}
                 </>
             );
         }
@@ -132,9 +137,7 @@ export const Footer = <T,>({
         if (component) {
             return (
                 <>
-                    <TopSection type="grid" stretch={isStretch}>
-                        {component}
-                    </TopSection>
+                    <TopSection stretch={isStretch}>{component}</TopSection>{" "}
                     <FullWidthDivider />
                 </>
             );

--- a/src/footer/footer.tsx
+++ b/src/footer/footer.tsx
@@ -157,7 +157,7 @@ export const Footer = <T,>({
     return (
         <BaseFooter {...otherProps}>
             {renderTopSection()}
-            <BottomSection type="grid" stretch={isStretch}>
+            <BottomSection stretch={isStretch}>
                 <BottomSectionContent key="disclaimer">
                     {renderDisclaimerLinks()}
                 </BottomSectionContent>

--- a/src/footer/footer.tsx
+++ b/src/footer/footer.tsx
@@ -137,7 +137,7 @@ export const Footer = <T,>({
         if (component) {
             return (
                 <>
-                    <TopSection stretch={isStretch}>{component}</TopSection>{" "}
+                    <TopSection stretch={isStretch}>{component}</TopSection>
                     <FullWidthDivider />
                 </>
             );

--- a/src/footer/types.ts
+++ b/src/footer/types.ts
@@ -19,6 +19,8 @@ export interface FooterProps<T = void> {
     links?: FooterLinkProps<T>[][] | undefined;
     /** Indicates if the download app icons are to be present */
     showDownloadAddon?: boolean | undefined;
+    /** Indicates if additional app resources should be displayed */
+    showResourceAddon?: boolean | undefined;
     /** Custom component. This overrides the logo, links and download section */
     children?: JSX.Element | JSX.Element[] | undefined;
     /** Custom disclaimer link attributes */

--- a/stories/footer/footer.mdx
+++ b/stories/footer/footer.mdx
@@ -24,6 +24,12 @@ This version is useful to be used as footers for dedicated apps that do not have
 
 <Canvas of={FooterStories.MinimalVersion} />
 
+## With resource add-on
+
+For the MyLegacy theme, additional content is available with `showResourceAddon`.
+
+<Canvas of={FooterStories.WithResourceAddOn} />
+
 ## With custom content
 
 <Canvas of={FooterStories.WithCustomContent} />

--- a/stories/footer/footer.stories.tsx
+++ b/stories/footer/footer.stories.tsx
@@ -63,6 +63,52 @@ export const MinimalVersion: StoryObj<Component> = {
     },
 };
 
+export const WithResourceAddOn: StoryObj<Component> = {
+    render: () => {
+        return (
+            <Footer
+                lastUpdated={new Date()}
+                showResourceAddon
+                links={[
+                    [
+                        { children: "Home", href: "https://www.life.gov.sg" },
+                        {
+                            children: "How it works",
+                            href: "https://www.life.gov.sg/#how-it-works",
+                        },
+                        {
+                            children: "Ways we help",
+                            href: "https://www.life.gov.sg/#ways-we-help",
+                        },
+                        {
+                            children: "Campaigns",
+                            href: "https://www.life.gov.sg/#campaigns",
+                        },
+                        {
+                            children: "News and media",
+                            href: "https://www.life.gov.sg/#newsandmedia",
+                        },
+                    ],
+                    [
+                        {
+                            children: "About us",
+                            href: "https://www.life.gov.sg/about-us",
+                        },
+                        {
+                            children: "Help & Support",
+                            href: "https://www.life.gov.sg/help-support",
+                        },
+                        {
+                            children: "Get in touch with us",
+                            href: "https://www.life.gov.sg/get-in-touch",
+                        },
+                    ],
+                ]}
+            />
+        );
+    },
+};
+
 export const WithCustomContent: StoryObj<Component> = {
     render: (_args) => {
         return (

--- a/stories/footer/footer.stories.tsx
+++ b/stories/footer/footer.stories.tsx
@@ -7,6 +7,7 @@ type Component = typeof Footer;
 const meta: Meta<Component> = {
     title: "Navigation/Footer",
     component: Footer,
+    parameters: { layout: "fullscreen" },
 };
 
 export default meta;
@@ -190,6 +191,7 @@ export const StretchedLayout: StoryObj<Component> = {
     render: (_args) => {
         return (
             <Footer
+                // style={{ width: "1200px" }}
                 layout={"stretch"}
                 lastUpdated={new Date()}
                 showDownloadAddon

--- a/stories/footer/footer.stories.tsx
+++ b/stories/footer/footer.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Footer } from "src/footer";
 import { Layout } from "src/layout";
+import { MyLegacyTheme } from "src/theme";
+import { ThemeProvider } from "styled-components";
 
 type Component = typeof Footer;
 
@@ -65,14 +67,17 @@ export const MinimalVersion: StoryObj<Component> = {
 };
 
 export const WithResourceAddOn: StoryObj<Component> = {
-    render: () => {
+    render: (_args) => {
         return (
             <Footer
                 lastUpdated={new Date()}
                 showResourceAddon
                 links={[
                     [
-                        { children: "Home", href: "https://www.life.gov.sg" },
+                        {
+                            children: "Home",
+                            href: "https://www.life.gov.sg",
+                        },
                         {
                             children: "How it works",
                             href: "https://www.life.gov.sg/#how-it-works",
@@ -108,6 +113,13 @@ export const WithResourceAddOn: StoryObj<Component> = {
             />
         );
     },
+    decorators: [
+        (Story) => (
+            <ThemeProvider theme={MyLegacyTheme}>
+                <Story />
+            </ThemeProvider>
+        ),
+    ],
 };
 
 export const WithCustomContent: StoryObj<Component> = {

--- a/stories/footer/props-table.tsx
+++ b/stories/footer/props-table.tsx
@@ -70,6 +70,19 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["Date"],
             },
             {
+                name: "showResourceAddon",
+                description: (
+                    <>
+                        When enabled, this will display theme-specific content
+                        in the right section of the footer. If both{" "}
+                        <code>showDownloadAddon</code> and{" "}
+                        <code>showResourceAddon</code> are set to true, the
+                        download addon will take precedence.
+                    </>
+                ),
+                propTypes: ["boolean"],
+            },
+            {
                 name: "onFooterLinkClick",
                 description: "Called when a footer link item is clicked",
                 propTypes: ["(link: FooterLinkProps<T>) => void"],


### PR DESCRIPTION
**Changes**
- Add new props `showResourceAddon` to Footer component
- when `showDownloadAddon` and `showResourceAddon` are enabled, `showDownloadAddon` should take priority to being rendered
- corrected the footer layout for v3. [figma](https://www.figma.com/design/tHmHQNszVzvIamtZWixjgR/%F0%9F%8C%B1-Flagship-V3-Component-Kit?node-id=10680-125043&m=dev)
- Modify brand logo size and gap size between logos in resource addon

[delete] branch

**Changelog entry**
Added showResourceAddon prop to Footer component to conditionally render additional resources.


**Additional information**

- You may refer to this [[MOL-19033](https://sgtechstack.atlassian.net/browse/MOL-19033)]
- V2 changes [MR](https://github.com/LifeSG/react-design-system/pull/710) to refer