### PR TITLE
[MOL-19016][GW] Add avatar navbar story

### DIFF
--- a/stories/navbar/doc-elements.tsx
+++ b/stories/navbar/doc-elements.tsx
@@ -76,17 +76,17 @@ export const MobileCustomComponent = ({ onClick }: Props) => {
 
 export const NavbarAvatar = () => {
     const theme = useTheme();
-    const tablet = Breakpoint["xl-min"]({ theme });
-    const [isMobile, setIsMobile] = useState(window.innerWidth < tablet);
+    const desktop = Breakpoint["xl-min"]({ theme });
+    const [isTablet, setIsTablet] = useState(window.innerWidth < desktop);
 
     useEffect(() => {
         const handleResize = () => {
-            setIsMobile(window.innerWidth < tablet);
+            setIsTablet(window.innerWidth < desktop);
         };
 
         window.addEventListener("resize", handleResize);
         return () => window.removeEventListener("resize", handleResize);
-    }, [tablet]);
+    }, [desktop]);
 
     return (
         <Menu
@@ -99,9 +99,9 @@ export const NavbarAvatar = () => {
             <Badge
                 count={8}
                 color="important"
-                variant={isMobile ? "dot-with-border" : "number-with-border"}
+                variant={isTablet ? "dot-with-border" : "number-with-border"}
             >
-                <Avatar sizeType={isMobile ? "small" : "default"}>Name</Avatar>
+                <Avatar sizeType={isTablet ? "small" : "default"}>Name</Avatar>
             </Badge>
         </Menu>
     );

--- a/stories/navbar/doc-elements.tsx
+++ b/stories/navbar/doc-elements.tsx
@@ -1,11 +1,15 @@
 import { InboxIcon } from "@lifesg/react-icons/inbox";
+import { useEffect, useState } from "react";
 import { Button } from "src/button";
 import { Divider } from "src/divider";
 import { IconButton } from "src/icon-button";
 import { PopoverTrigger } from "src/popover-v2";
-import { Colour } from "src/theme";
+import { Breakpoint, Colour } from "src/theme";
 import { Typography } from "src/typography";
-import styled from "styled-components";
+import styled, { useTheme } from "styled-components";
+import { Avatar } from "../../src/avatar";
+import { Badge } from "../../src/badge";
+import { Menu } from "../../src/menu";
 
 // =============================================================================
 // STYLING
@@ -69,3 +73,65 @@ export const MobileCustomComponent = ({ onClick }: Props) => {
         </>
     );
 };
+
+export const NavbarAvatar = () => {
+    const theme = useTheme();
+    const tablet = Breakpoint["xl-min"]({ theme });
+    const [isMobile, setIsMobile] = useState(window.innerWidth < tablet);
+
+    useEffect(() => {
+        const handleResize = () => {
+            setIsMobile(window.innerWidth < tablet);
+        };
+
+        window.addEventListener("resize", handleResize);
+        return () => window.removeEventListener("resize", handleResize);
+    }, [tablet]);
+
+    return (
+        <Menu
+            enableResize={false}
+            enableFlip={false}
+            menuContent={menuContent}
+            zIndex={100}
+            customOffset={28}
+        >
+            <Badge
+                count={8}
+                color="important"
+                variant={isMobile ? "dot-with-border" : "number-with-border"}
+            >
+                <Avatar sizeType={isMobile ? "small" : "default"}>Name</Avatar>
+            </Badge>
+        </Menu>
+    );
+};
+
+const menuContent = (
+    <Menu.Content>
+        <Menu.Section showDivider={false}>
+            <Menu.Item label="Name" subLabel="email@email.sg" />
+        </Menu.Section>
+
+        <Menu.Section label="Category 1">
+            <Menu.Item>Menu item</Menu.Item>
+            <Menu.Link href="https://www.google.com">Menu link</Menu.Link>
+            <Menu.Item>Menu item</Menu.Item>
+            <Menu.Link href="https://www.google.com">Menu link</Menu.Link>
+            <Menu.Item>Menu item</Menu.Item>
+        </Menu.Section>
+
+        <Menu.Section>
+            <Menu.Item>Menu item</Menu.Item>
+            <Menu.Item>Menu item</Menu.Item>
+            <Menu.Link href="https://www.google.com">Menu link</Menu.Link>
+            <Menu.Link href="https://www.google.com">Menu link</Menu.Link>
+        </Menu.Section>
+
+        <Menu.Section label="Category 2">
+            <Menu.Link href="https://www.google.com">Menu link</Menu.Link>
+            <Menu.Item>Menu item</Menu.Item>
+            <Menu.Link href="https://www.google.com">Menu link</Menu.Link>
+        </Menu.Section>
+    </Menu.Content>
+);

--- a/stories/navbar/navbar.mdx
+++ b/stories/navbar/navbar.mdx
@@ -102,6 +102,12 @@ When the branding elements are hidden, navigation items will be aligned to the l
 
 <Canvas of={NavbarStories.HiddenBranding} />
 
+## With Avatar
+
+The Navbar can be used in conjunction with the Avatar component to display user information, by adding it as an uncollapsible action button.
+
+<Canvas of={NavbarStories.WithAvatar} />
+
 ## Troubleshooting
 
 > The component also uses a custom script. Should you encounter a content security

--- a/stories/navbar/navbar.stories.tsx
+++ b/stories/navbar/navbar.stories.tsx
@@ -458,40 +458,39 @@ export const HiddenBranding: StoryObj<Component> = {
 export const WithAvatar: StoryObj<Component> = {
     parameters: { docs: { source: { type: "code" } } },
     decorators: [FullWidthStoryDecorator({})],
-    render: (_args) => {
-        return (
-            <Navbar
-                items={{
-                    desktop: [
-                        {
-                            id: "home",
-                            children: "Home",
-                        },
-                    ],
-                }}
-                actionButtons={{
-                    desktop: [
-                        {
-                            type: "button",
-                            args: {
-                                styleType: "link",
-                                children: "FAQ",
-                            },
-                        },
-                        {
-                            type: "download",
-                        },
-                        {
-                            type: "component",
-                            args: {
-                                render: <NavbarAvatar />,
-                            },
-                            uncollapsible: true,
-                        },
-                    ],
-                }}
-                fixed={false}
-            />
-        );
+    args: {
+        items: {
+            desktop: [
+                {
+                    id: "home",
+                    children: "Home",
+                },
+            ],
+        },
+        actionButtons: {
+            desktop: [
+                {
+                    type: "button",
+                    args: {
+                        styleType: "link",
+                        children: "FAQ",
+                    },
+                },
+                {
+                    type: "download",
+                },
+                {
+                    type: "component",
+                    args: {
+                        render: <NavbarAvatar />,
+                    },
+                    uncollapsible: true,
+                },
+            ],
+        },
+        fixed: false,
+    },
+    render: (args) => {
+        return <Navbar {...args} />;
     },
 };

--- a/stories/navbar/navbar.stories.tsx
+++ b/stories/navbar/navbar.stories.tsx
@@ -11,7 +11,11 @@ import {
     NavbarDrawerHandle,
 } from "src/navbar";
 import { FullWidthStoryDecorator } from "stories/storybook-common";
-import { DesktopCustomComponent, MobileCustomComponent } from "./doc-elements";
+import {
+    DesktopCustomComponent,
+    MobileCustomComponent,
+    NavbarAvatar,
+} from "./doc-elements";
 
 type Component = typeof Navbar;
 
@@ -446,6 +450,47 @@ export const HiddenBranding: StoryObj<Component> = {
                 selectedId="home"
                 fixed={false}
                 hideNavBranding
+            />
+        );
+    },
+};
+
+export const WithAvatar: StoryObj<Component> = {
+    parameters: { docs: { source: { type: "code" } } },
+    decorators: [FullWidthStoryDecorator({})],
+    render: (_args) => {
+        return (
+            <Navbar
+                items={{
+                    desktop: [
+                        {
+                            id: "home",
+                            children: "Home",
+                        },
+                    ],
+                }}
+                actionButtons={{
+                    desktop: [
+                        {
+                            type: "button",
+                            args: {
+                                styleType: "link",
+                                children: "FAQ",
+                            },
+                        },
+                        {
+                            type: "download",
+                        },
+                        {
+                            type: "component",
+                            args: {
+                                render: <NavbarAvatar />,
+                            },
+                            uncollapsible: true,
+                        },
+                    ],
+                }}
+                fixed={false}
             />
         );
     },

--- a/stories/navbar/navbar.stories.tsx
+++ b/stories/navbar/navbar.stories.tsx
@@ -455,19 +455,11 @@ export const HiddenBranding: StoryObj<Component> = {
     },
 };
 
-export const WithAvatar: StoryObj<Component> = {
-    parameters: { docs: { source: { type: "code" } } },
-    decorators: [FullWidthStoryDecorator({})],
-    args: {
-        items: {
-            desktop: [
-                {
-                    id: "home",
-                    children: "Home",
-                },
-            ],
-        },
-        actionButtons: {
+const _WithAvatar = (
+    <Navbar
+        items={{ desktop: navItems }}
+        selectedId="home"
+        actionButtons={{
             desktop: [
                 {
                     type: "button",
@@ -487,10 +479,13 @@ export const WithAvatar: StoryObj<Component> = {
                     uncollapsible: true,
                 },
             ],
-        },
-        fixed: false,
-    },
-    render: (args) => {
-        return <Navbar {...args} />;
+        }}
+        fixed={false}
+    />
+);
+
+export const WithAvatar: StoryObj<Component> = {
+    render: (_args) => {
+        return _WithAvatar;
     },
 };


### PR DESCRIPTION
**Changes**
Add avatar navbar story (so i can deskcheck this ticket)

- delete branch

**Additional information**
All components are there for devs to add avatar to navbar (via action button) already. Not sure if we should update navbar further to pass in avatar as additional props (menuProps, badgeProps, AvatarProps), or is it better to leave the customisability to the dev (status quo)-> i.e. if they want to add a different popover/drawer etc to their action button)

- You may refer to this [Figma](https://www.figma.com/design/tHmHQNszVzvIamtZWixjgR/%F0%9F%8C%B1-Flagship-V3-Component-Kit?node-id=10968-13915&m=dev)
- You may refer to this [MOL-19016](https://sgtechstack.atlassian.net/browse/MOL-19016)
