### PR TITLE
[COMMPORTAL-832][CWH] add in noResultsLabel option to dropdown with s…

### DIFF
--- a/src/input-multi-select/input-multi-select.tsx
+++ b/src/input-multi-select/input-multi-select.tsx
@@ -41,7 +41,10 @@ export const InputMultiSelect = <T, V>({
     optionTruncationType = "end",
     renderListItem,
     hideNoResultsDisplay,
+    noResultsLabel,
     noResultsDescription,
+    selectAllButtonLabel,
+    clearAllButtonLabel,
     renderCustomCallToAction,
     onBlur,
     variant = "default",
@@ -253,7 +256,10 @@ export const InputMultiSelect = <T, V>({
                 itemTruncationType={optionTruncationType}
                 renderListItem={renderListItem}
                 hideNoResultsDisplay={hideNoResultsDisplay}
+                noResultsLabel={noResultsLabel}
                 noResultsDescription={noResultsDescription}
+                selectAllButtonLabel={selectAllButtonLabel}
+                clearAllButtonLabel={clearAllButtonLabel}
                 renderCustomCallToAction={renderCustomCallToAction}
                 variant={variant}
                 width={elementWidth}

--- a/src/input-multi-select/input-multi-select.tsx
+++ b/src/input-multi-select/input-multi-select.tsx
@@ -55,6 +55,7 @@ export const InputMultiSelect = <T, V>({
     // =============================================================================
     // CONST, STATE
     // =============================================================================
+    const { allSelectedLabel, multiSelectedLabel } = customLabels || {};
     const [selected, setSelected] = useState<T[]>(selectedOptions || []);
     const [showOptions, setShowOptions] = useState<boolean>(false);
     const [focused, setFocused] = useState<boolean>(false);
@@ -157,10 +158,10 @@ export const InputMultiSelect = <T, V>({
     // =============================================================================
     const getDisplayValue = () => {
         if (options && selected.length === options.length) {
-            return "All selected";
+            return allSelectedLabel || "All selected";
         }
 
-        return `${selected.length} selected`;
+        return multiSelectedLabel || `${selected.length} selected`;
     };
 
     const triggerOptionDisplayCallback = (show: boolean) => {

--- a/src/input-multi-select/input-multi-select.tsx
+++ b/src/input-multi-select/input-multi-select.tsx
@@ -30,6 +30,7 @@ export const InputMultiSelect = <T, V>({
     id,
     enableSearch = false,
     searchFunction,
+    searchPlaceholder,
     valueExtractor,
     listExtractor,
     onSelectOptions,
@@ -40,6 +41,7 @@ export const InputMultiSelect = <T, V>({
     optionTruncationType = "end",
     renderListItem,
     hideNoResultsDisplay,
+    noResultsDescription,
     customLabels,
     renderCustomCallToAction,
     onBlur,
@@ -242,6 +244,7 @@ export const InputMultiSelect = <T, V>({
                 listExtractor={listExtractor}
                 enableSearch={enableSearch}
                 searchFunction={searchFunction}
+                searchPlaceholder={searchPlaceholder}
                 multiSelect
                 maxSelectable={maxSelectable}
                 selectedItems={selected}
@@ -251,6 +254,7 @@ export const InputMultiSelect = <T, V>({
                 itemTruncationType={optionTruncationType}
                 renderListItem={renderListItem}
                 hideNoResultsDisplay={hideNoResultsDisplay}
+                noResultsDescription={noResultsDescription}
                 customLabels={customLabels}
                 renderCustomCallToAction={renderCustomCallToAction}
                 variant={variant}

--- a/src/input-multi-select/input-multi-select.tsx
+++ b/src/input-multi-select/input-multi-select.tsx
@@ -30,7 +30,6 @@ export const InputMultiSelect = <T, V>({
     id,
     enableSearch = false,
     searchFunction,
-    searchPlaceholder,
     valueExtractor,
     listExtractor,
     onSelectOptions,
@@ -41,10 +40,7 @@ export const InputMultiSelect = <T, V>({
     optionTruncationType = "end",
     renderListItem,
     hideNoResultsDisplay,
-    noResultsLabel,
-    noResultsDescription,
-    selectAllButtonLabel,
-    clearAllButtonLabel,
+    customLabels,
     renderCustomCallToAction,
     onBlur,
     variant = "default",
@@ -246,7 +242,6 @@ export const InputMultiSelect = <T, V>({
                 listExtractor={listExtractor}
                 enableSearch={enableSearch}
                 searchFunction={searchFunction}
-                searchPlaceholder={searchPlaceholder}
                 multiSelect
                 maxSelectable={maxSelectable}
                 selectedItems={selected}
@@ -256,10 +251,7 @@ export const InputMultiSelect = <T, V>({
                 itemTruncationType={optionTruncationType}
                 renderListItem={renderListItem}
                 hideNoResultsDisplay={hideNoResultsDisplay}
-                noResultsLabel={noResultsLabel}
-                noResultsDescription={noResultsDescription}
-                selectAllButtonLabel={selectAllButtonLabel}
-                clearAllButtonLabel={clearAllButtonLabel}
+                customLabels={customLabels}
                 renderCustomCallToAction={renderCustomCallToAction}
                 variant={variant}
                 width={elementWidth}

--- a/src/input-multi-select/types.ts
+++ b/src/input-multi-select/types.ts
@@ -24,6 +24,8 @@ export interface InputMultiSelectProps<T, V>
     alignment?: DropdownAlignmentType | undefined;
     dropdownZIndex?: number | undefined;
     maxSelectable?: number | undefined;
+    selectAllButtonLabel?: string | undefined;
+    clearAllButtonLabel?: string | undefined;
     /** @deprecated this has no effect as the dropdown will automatically resize */
     listStyleWidth?: string | undefined;
     /**

--- a/src/input-multi-select/types.ts
+++ b/src/input-multi-select/types.ts
@@ -4,6 +4,7 @@ import {
     InputSelectSharedProps,
 } from "../input-select/types";
 import {
+    DropdownCustomLabelProps,
     DropdownDisplayProps,
     DropdownSearchProps,
     DropdownVariantType,
@@ -24,8 +25,7 @@ export interface InputMultiSelectProps<T, V>
     alignment?: DropdownAlignmentType | undefined;
     dropdownZIndex?: number | undefined;
     maxSelectable?: number | undefined;
-    selectAllButtonLabel?: string | undefined;
-    clearAllButtonLabel?: string | undefined;
+    customLabels?: DropdownCustomLabelProps | undefined;
     /** @deprecated this has no effect as the dropdown will automatically resize */
     listStyleWidth?: string | undefined;
     /**

--- a/src/input-nested-multi-select/input-nested-multi-select.tsx
+++ b/src/input-nested-multi-select/input-nested-multi-select.tsx
@@ -35,7 +35,9 @@ export const InputNestedMultiSelect = <V1, V2, V3>({
     mode,
     valueToStringFunction,
     enableSearch,
+    searchPlaceholder,
     hideNoResultsDisplay,
+    noResultsDescription,
     customLabels,
     readOnly,
     onSearch,
@@ -303,7 +305,9 @@ export const InputNestedMultiSelect = <V1, V2, V3>({
                 itemsLoadState={optionsLoadState}
                 itemTruncationType={optionTruncationType}
                 enableSearch={enableSearch}
+                searchPlaceholder={searchPlaceholder}
                 hideNoResultsDisplay={hideNoResultsDisplay}
+                noResultsDescription={noResultsDescription}
                 customLabels={customLabels}
                 onSelectItem={handleListItemClick}
                 onSelectAll={handleSelectAll}

--- a/src/input-nested-multi-select/input-nested-multi-select.tsx
+++ b/src/input-nested-multi-select/input-nested-multi-select.tsx
@@ -56,6 +56,7 @@ export const InputNestedMultiSelect = <V1, V2, V3>({
     // =========================================================================
     // CONST, STATE
     // =========================================================================
+    const { multiSelectedLabel } = customLabels || {};
     const options = _options as NestedDropdownListItemProps<V1 | V2 | V3>[];
     const [selectedKeyPaths, setSelectedKeyPaths] = useState<Set<string>>(
         _selectedKeyPaths
@@ -159,7 +160,7 @@ export const InputNestedMultiSelect = <V1, V2, V3>({
     // =========================================================================
     const getDisplayValue = (): string => {
         if (selectedItems.length > 1) {
-            return `${selectedItems.length} selected`;
+            return multiSelectedLabel || `${selectedItems.length} selected`;
         }
 
         const { label, value } = selectedItems[0];

--- a/src/input-nested-multi-select/input-nested-multi-select.tsx
+++ b/src/input-nested-multi-select/input-nested-multi-select.tsx
@@ -35,10 +35,8 @@ export const InputNestedMultiSelect = <V1, V2, V3>({
     mode,
     valueToStringFunction,
     enableSearch,
-    searchPlaceholder,
     hideNoResultsDisplay,
-    noResultsLabel,
-    noResultsDescription,
+    customLabels,
     readOnly,
     onSearch,
     onSelectOptions,
@@ -305,10 +303,8 @@ export const InputNestedMultiSelect = <V1, V2, V3>({
                 itemsLoadState={optionsLoadState}
                 itemTruncationType={optionTruncationType}
                 enableSearch={enableSearch}
-                searchPlaceholder={searchPlaceholder}
                 hideNoResultsDisplay={hideNoResultsDisplay}
-                noResultsLabel={noResultsLabel}
-                noResultsDescription={noResultsDescription}
+                customLabels={customLabels}
                 onSelectItem={handleListItemClick}
                 onSelectAll={handleSelectAll}
                 onRetry={onRetry}

--- a/src/input-nested-multi-select/input-nested-multi-select.tsx
+++ b/src/input-nested-multi-select/input-nested-multi-select.tsx
@@ -37,6 +37,7 @@ export const InputNestedMultiSelect = <V1, V2, V3>({
     enableSearch,
     searchPlaceholder,
     hideNoResultsDisplay,
+    noResultsLabel,
     noResultsDescription,
     readOnly,
     onSearch,
@@ -306,6 +307,7 @@ export const InputNestedMultiSelect = <V1, V2, V3>({
                 enableSearch={enableSearch}
                 searchPlaceholder={searchPlaceholder}
                 hideNoResultsDisplay={hideNoResultsDisplay}
+                noResultsLabel={noResultsLabel}
                 noResultsDescription={noResultsDescription}
                 onSelectItem={handleListItemClick}
                 onSelectAll={handleSelectAll}

--- a/src/input-nested-multi-select/types.ts
+++ b/src/input-nested-multi-select/types.ts
@@ -3,7 +3,10 @@ import {
     InputNestedSelectSharedProps,
     L1OptionProps,
 } from "../input-nested-select";
-import { DropdownSearchProps } from "../shared/dropdown-list-v2/types";
+import {
+    DropdownCustomLabelProps,
+    DropdownSearchProps,
+} from "../shared/dropdown-list-v2/types";
 
 // =============================================================================
 // INPUT SELECT PROPS
@@ -23,6 +26,7 @@ export interface InputNestedMultiSelectProps<V1, V2, V3>
     /** @deprecated this has no effect as the dropdown will automatically resize */
     listStyleWidth?: string | undefined;
     onBlur?: (() => void) | undefined;
+    customLabels?: DropdownCustomLabelProps | undefined;
 }
 
 /** To be exposed for Form component inheritance */

--- a/src/input-nested-select/input-nested-select.tsx
+++ b/src/input-nested-select/input-nested-select.tsx
@@ -49,11 +49,9 @@ export const InputNestedSelect = <V1, V2, V3>({
     mode,
     valueToStringFunction,
     enableSearch,
-    searchPlaceholder,
     selectableCategory,
     hideNoResultsDisplay,
-    noResultsLabel,
-    noResultsDescription,
+    customLabels,
     readOnly,
     onBlur,
     onSearch,
@@ -263,10 +261,8 @@ export const InputNestedSelect = <V1, V2, V3>({
                 itemsLoadState={optionsLoadState}
                 itemTruncationType={optionTruncationType}
                 enableSearch={enableSearch}
-                searchPlaceholder={searchPlaceholder}
                 hideNoResultsDisplay={hideNoResultsDisplay}
-                noResultsLabel={noResultsLabel}
-                noResultsDescription={noResultsDescription}
+                customLabels={customLabels}
                 onSelectItem={handleListItemClick}
                 onRetry={onRetry}
                 onSearch={onSearch}

--- a/src/input-nested-select/input-nested-select.tsx
+++ b/src/input-nested-select/input-nested-select.tsx
@@ -49,8 +49,10 @@ export const InputNestedSelect = <V1, V2, V3>({
     mode,
     valueToStringFunction,
     enableSearch,
+    searchPlaceholder,
     selectableCategory,
     hideNoResultsDisplay,
+    noResultsDescription,
     customLabels,
     readOnly,
     onBlur,
@@ -261,7 +263,9 @@ export const InputNestedSelect = <V1, V2, V3>({
                 itemsLoadState={optionsLoadState}
                 itemTruncationType={optionTruncationType}
                 enableSearch={enableSearch}
+                searchPlaceholder={searchPlaceholder}
                 hideNoResultsDisplay={hideNoResultsDisplay}
+                noResultsDescription={noResultsDescription}
                 customLabels={customLabels}
                 onSelectItem={handleListItemClick}
                 onRetry={onRetry}

--- a/src/input-nested-select/input-nested-select.tsx
+++ b/src/input-nested-select/input-nested-select.tsx
@@ -52,6 +52,7 @@ export const InputNestedSelect = <V1, V2, V3>({
     searchPlaceholder,
     selectableCategory,
     hideNoResultsDisplay,
+    noResultsLabel,
     noResultsDescription,
     readOnly,
     onBlur,
@@ -264,6 +265,7 @@ export const InputNestedSelect = <V1, V2, V3>({
                 enableSearch={enableSearch}
                 searchPlaceholder={searchPlaceholder}
                 hideNoResultsDisplay={hideNoResultsDisplay}
+                noResultsLabel={noResultsLabel}
                 noResultsDescription={noResultsDescription}
                 onSelectItem={handleListItemClick}
                 onRetry={onRetry}

--- a/src/input-nested-select/types.ts
+++ b/src/input-nested-select/types.ts
@@ -4,6 +4,7 @@ import {
     InputSelectSharedProps,
 } from "../input-select";
 import {
+    DropdownCustomLabelProps,
     DropdownSearchProps,
     DropdownVariantType,
     ExpandMode,
@@ -56,6 +57,7 @@ export interface InputNestedSelectProps<V1, V2, V3>
     /** @deprecated this has no effect as the dropdown will automatically resize */
     listStyleWidth?: string | undefined;
     onBlur?: (() => void) | undefined;
+    customLabels?: DropdownCustomLabelProps | undefined;
 }
 
 /** To be exposed for Form component inheritance */

--- a/src/input-select/input-select.tsx
+++ b/src/input-select/input-select.tsx
@@ -44,6 +44,7 @@ export const InputSelect = <T, V>({
     renderCustomSelectedOption,
     renderListItem,
     hideNoResultsDisplay,
+    noResultsLabel,
     noResultsDescription,
     renderCustomCallToAction,
     onBlur,
@@ -254,6 +255,7 @@ export const InputSelect = <T, V>({
                 itemTruncationType={optionTruncationType}
                 renderListItem={renderListItem}
                 hideNoResultsDisplay={hideNoResultsDisplay}
+                noResultsLabel={noResultsLabel}
                 noResultsDescription={noResultsDescription}
                 renderCustomCallToAction={renderCustomCallToAction}
                 variant={variant}

--- a/src/input-select/input-select.tsx
+++ b/src/input-select/input-select.tsx
@@ -30,6 +30,7 @@ export const InputSelect = <T, V>({
     id,
     enableSearch = false,
     searchFunction,
+    searchPlaceholder,
     valueExtractor,
     valueToStringFunction,
     listExtractor,
@@ -43,6 +44,7 @@ export const InputSelect = <T, V>({
     renderCustomSelectedOption,
     renderListItem,
     hideNoResultsDisplay,
+    noResultsDescription,
     customLabels,
     renderCustomCallToAction,
     onBlur,
@@ -245,6 +247,7 @@ export const InputSelect = <T, V>({
                 valueExtractor={valueExtractor}
                 listExtractor={listExtractor}
                 enableSearch={enableSearch}
+                searchPlaceholder={searchPlaceholder}
                 searchFunction={searchFunction}
                 selectedItems={selected ? [selected] : []}
                 onRetry={onRetry}
@@ -252,6 +255,7 @@ export const InputSelect = <T, V>({
                 itemTruncationType={optionTruncationType}
                 renderListItem={renderListItem}
                 hideNoResultsDisplay={hideNoResultsDisplay}
+                noResultsDescription={noResultsDescription}
                 customLabels={customLabels}
                 renderCustomCallToAction={renderCustomCallToAction}
                 variant={variant}

--- a/src/input-select/input-select.tsx
+++ b/src/input-select/input-select.tsx
@@ -30,7 +30,6 @@ export const InputSelect = <T, V>({
     id,
     enableSearch = false,
     searchFunction,
-    searchPlaceholder,
     valueExtractor,
     valueToStringFunction,
     listExtractor,
@@ -44,8 +43,7 @@ export const InputSelect = <T, V>({
     renderCustomSelectedOption,
     renderListItem,
     hideNoResultsDisplay,
-    noResultsLabel,
-    noResultsDescription,
+    customLabels,
     renderCustomCallToAction,
     onBlur,
     variant = "default",
@@ -247,7 +245,6 @@ export const InputSelect = <T, V>({
                 valueExtractor={valueExtractor}
                 listExtractor={listExtractor}
                 enableSearch={enableSearch}
-                searchPlaceholder={searchPlaceholder}
                 searchFunction={searchFunction}
                 selectedItems={selected ? [selected] : []}
                 onRetry={onRetry}
@@ -255,8 +252,7 @@ export const InputSelect = <T, V>({
                 itemTruncationType={optionTruncationType}
                 renderListItem={renderListItem}
                 hideNoResultsDisplay={hideNoResultsDisplay}
-                noResultsLabel={noResultsLabel}
-                noResultsDescription={noResultsDescription}
+                customLabels={customLabels}
                 renderCustomCallToAction={renderCustomCallToAction}
                 variant={variant}
                 width={elementWidth}

--- a/src/input-select/types.ts
+++ b/src/input-select/types.ts
@@ -1,5 +1,6 @@
 import { RefObject } from "react";
 import {
+    DropdownCustomLabelProps,
     DropdownDisplayProps,
     DropdownSearchProps,
     DropdownVariantType,
@@ -69,6 +70,7 @@ export interface InputSelectProps<T, V>
     dropdownRootNode?: RefObject<HTMLElement> | undefined;
     /** @deprecated this has no effect as the dropdown will automatically resize */
     listStyleWidth?: string | undefined;
+    customLabels?: DropdownCustomLabelProps | undefined;
 }
 
 /** To be exposed for Form component inheritance */

--- a/src/shared/dropdown-list-v2/dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.tsx
@@ -66,7 +66,9 @@ export const DropdownList = <T, V>({
     /* DropdownSearchProps */
     enableSearch,
     hideNoResultsDisplay,
+    noResultsDescription: _noResultsDescription,
     customLabels,
+    searchPlaceholder: _searchPlaceholder,
     searchFunction,
     onSearch,
 }: DropdownListProps<T, V>): JSX.Element => {
@@ -75,11 +77,13 @@ export const DropdownList = <T, V>({
     // =========================================================================
     const {
         noResultsLabel = "No results found.",
-        noResultsDescription,
-        searchPlaceholder = "Search",
         selectAllButtonLabel = "Select all",
         clearAllButtonLabel = "Clear all",
     } = customLabels || {};
+    const searchPlaceholder =
+        _searchPlaceholder || customLabels?.searchPlaceholder || "Search";
+    const noResultsDescription =
+        _noResultsDescription || customLabels?.noResultsDescription;
     const { focusedIndex, setFocusedIndex } = useContext(
         DropdownListStateContext
     );
@@ -466,7 +470,7 @@ export const DropdownList = <T, V>({
                     </ResultStateContainer>
                     {noResultsDescription && (
                         <NoResultDescContainer data-testid="no-result-desc">
-                            {noResultsDescription()}
+                            {noResultsDescription}
                         </NoResultDescContainer>
                     )}
                 </>

--- a/src/shared/dropdown-list-v2/dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.tsx
@@ -81,9 +81,9 @@ export const DropdownList = <T, V>({
         clearAllButtonLabel = "Clear all",
     } = customLabels || {};
     const searchPlaceholder =
-        _searchPlaceholder || customLabels?.searchPlaceholder || "Search";
+        customLabels?.searchPlaceholder || _searchPlaceholder || "Search";
     const noResultsDescription =
-        _noResultsDescription || customLabels?.noResultsDescription;
+        customLabels?.noResultsDescription || _noResultsDescription;
     const { focusedIndex, setFocusedIndex } = useContext(
         DropdownListStateContext
     );

--- a/src/shared/dropdown-list-v2/dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.tsx
@@ -66,7 +66,10 @@ export const DropdownList = <T, V>({
     /* DropdownSearchProps */
     enableSearch,
     hideNoResultsDisplay,
+    noResultsLabel = "No results found.",
     noResultsDescription,
+    selectAllButtonLabel = "Select all",
+    clearAllButtonLabel = "Clear all",
     searchPlaceholder = "Search",
     searchFunction,
     onSearch,
@@ -437,8 +440,8 @@ export const DropdownList = <T, V>({
                         $variant={variant}
                     >
                         {maxSelectable || selectedItems.length !== 0
-                            ? "Clear all"
-                            : "Select all"}
+                            ? clearAllButtonLabel
+                            : selectAllButtonLabel}
                     </SelectAllButton>
                 </SelectAllContainer>
             );
@@ -456,7 +459,7 @@ export const DropdownList = <T, V>({
                 <>
                     <ResultStateContainer data-testid="list-no-results">
                         <LabelIcon data-testid="no-result-icon" />
-                        No results found.
+                        {noResultsLabel}
                     </ResultStateContainer>
                     {noResultsDescription && (
                         <NoResultDescContainer data-testid="no-result-desc">

--- a/src/shared/dropdown-list-v2/dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.tsx
@@ -66,17 +66,20 @@ export const DropdownList = <T, V>({
     /* DropdownSearchProps */
     enableSearch,
     hideNoResultsDisplay,
-    noResultsLabel = "No results found.",
-    noResultsDescription,
-    selectAllButtonLabel = "Select all",
-    clearAllButtonLabel = "Clear all",
-    searchPlaceholder = "Search",
+    customLabels,
     searchFunction,
     onSearch,
 }: DropdownListProps<T, V>): JSX.Element => {
     // =========================================================================
     // CONST, REF, STATE
     // =========================================================================
+    const {
+        noResultsLabel = "No results found.",
+        noResultsDescription,
+        searchPlaceholder = "Search",
+        selectAllButtonLabel = "Select all",
+        clearAllButtonLabel = "Clear all",
+    } = customLabels || {};
     const { focusedIndex, setFocusedIndex } = useContext(
         DropdownListStateContext
     );
@@ -463,7 +466,7 @@ export const DropdownList = <T, V>({
                     </ResultStateContainer>
                     {noResultsDescription && (
                         <NoResultDescContainer data-testid="no-result-desc">
-                            {noResultsDescription}
+                            {noResultsDescription()}
                         </NoResultDescContainer>
                     )}
                 </>

--- a/src/shared/dropdown-list-v2/nested-dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/nested-dropdown-list.tsx
@@ -61,7 +61,9 @@ export const NestedDropdownList = <T,>({
     /* DropdownSearchProps */
     enableSearch,
     hideNoResultsDisplay,
+    noResultsDescription: _noResultsDescription,
     customLabels,
+    searchPlaceholder: _searchPlaceholder,
     onSearch,
 }: NestedDropdownListProps<T>) => {
     // =========================================================================
@@ -69,11 +71,13 @@ export const NestedDropdownList = <T,>({
     // =========================================================================
     const {
         noResultsLabel = "No results found.",
-        noResultsDescription,
-        searchPlaceholder = "Search",
         selectAllButtonLabel = "Select all",
         clearAllButtonLabel = "Clear all",
     } = customLabels || {};
+    const searchPlaceholder =
+        _searchPlaceholder || customLabels?.searchPlaceholder || "Search";
+    const noResultsDescription =
+        _noResultsDescription || customLabels?.noResultsDescription;
     const selectableCategory = multiSelect || _selectableCategory;
     const [searchValue, setSearchValue] = useState<string>("");
     const searchTerm = searchValue.toLowerCase().trim();
@@ -453,7 +457,7 @@ export const NestedDropdownList = <T,>({
                     </ResultStateContainer>
                     {noResultsDescription && (
                         <NoResultDescContainer data-testid="no-result-desc">
-                            {noResultsDescription()}
+                            {noResultsDescription}
                         </NoResultDescContainer>
                     )}
                 </>

--- a/src/shared/dropdown-list-v2/nested-dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/nested-dropdown-list.tsx
@@ -61,6 +61,7 @@ export const NestedDropdownList = <T,>({
     /* DropdownSearchProps */
     enableSearch,
     hideNoResultsDisplay,
+    noResultsLabel = "No results found.",
     noResultsDescription,
     searchPlaceholder = "Search",
     onSearch,
@@ -443,7 +444,7 @@ export const NestedDropdownList = <T,>({
                 <>
                     <ResultStateContainer data-testid="list-no-results">
                         <LabelIcon data-testid="no-result-icon" />
-                        No results found.
+                        {noResultsLabel}
                     </ResultStateContainer>
                     {noResultsDescription && (
                         <NoResultDescContainer data-testid="no-result-desc">

--- a/src/shared/dropdown-list-v2/nested-dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/nested-dropdown-list.tsx
@@ -61,14 +61,19 @@ export const NestedDropdownList = <T,>({
     /* DropdownSearchProps */
     enableSearch,
     hideNoResultsDisplay,
-    noResultsLabel = "No results found.",
-    noResultsDescription,
-    searchPlaceholder = "Search",
+    customLabels,
     onSearch,
 }: NestedDropdownListProps<T>) => {
     // =========================================================================
     // CONST, STATE, REF
     // =========================================================================
+    const {
+        noResultsLabel = "No results found.",
+        noResultsDescription,
+        searchPlaceholder = "Search",
+        selectAllButtonLabel = "Select all",
+        clearAllButtonLabel = "Clear all",
+    } = customLabels || {};
     const selectableCategory = multiSelect || _selectableCategory;
     const [searchValue, setSearchValue] = useState<string>("");
     const searchTerm = searchValue.toLowerCase().trim();
@@ -425,8 +430,8 @@ export const NestedDropdownList = <T,>({
                         $variant={variant}
                     >
                         {selectedKeyPaths.size === 0
-                            ? "Select all"
-                            : "Clear all"}
+                            ? selectAllButtonLabel
+                            : clearAllButtonLabel}
                     </SelectAllButton>
                 </SelectAllContainer>
             );
@@ -448,7 +453,7 @@ export const NestedDropdownList = <T,>({
                     </ResultStateContainer>
                     {noResultsDescription && (
                         <NoResultDescContainer data-testid="no-result-desc">
-                            {noResultsDescription}
+                            {noResultsDescription()}
                         </NoResultDescContainer>
                     )}
                 </>

--- a/src/shared/dropdown-list-v2/nested-dropdown-list.tsx
+++ b/src/shared/dropdown-list-v2/nested-dropdown-list.tsx
@@ -75,9 +75,9 @@ export const NestedDropdownList = <T,>({
         clearAllButtonLabel = "Clear all",
     } = customLabels || {};
     const searchPlaceholder =
-        _searchPlaceholder || customLabels?.searchPlaceholder || "Search";
+        customLabels?.searchPlaceholder || _searchPlaceholder || "Search";
     const noResultsDescription =
-        _noResultsDescription || customLabels?.noResultsDescription;
+        customLabels?.noResultsDescription || _noResultsDescription;
     const selectableCategory = multiSelect || _selectableCategory;
     const [searchValue, setSearchValue] = useState<string>("");
     const searchTerm = searchValue.toLowerCase().trim();

--- a/src/shared/dropdown-list-v2/types.ts
+++ b/src/shared/dropdown-list-v2/types.ts
@@ -15,6 +15,14 @@ export interface ListItemDisplayProps {
     secondaryLabel?: string | undefined;
 }
 
+export interface DropdownCustomLabelProps {
+    searchPlaceholder?: string | undefined;
+    noResultsLabel?: string | undefined;
+    noResultsDescription?: () => React.ReactNode | undefined;
+    selectAllButtonLabel?: string | undefined;
+    clearAllButtonLabel?: string | undefined;
+}
+
 export interface DropdownDisplayProps<T, V> {
     /** Function to derive value from an item */
     valueExtractor?: ((item: T) => V) | undefined;
@@ -40,9 +48,6 @@ export interface DropdownSearchProps<T> {
     enableSearch?: boolean | undefined;
     /** If specified, the default no results display will not be rendered */
     hideNoResultsDisplay?: boolean | undefined;
-    noResultsLabel?: string | undefined;
-    noResultsDescription?: React.ReactNode | undefined;
-    searchPlaceholder?: string | undefined;
     /** Custom function to perform search when a user keys in a value in the search input */
     searchFunction?: ((searchValue: string) => T[]) | undefined;
     onSearch?: (() => void) | undefined;
@@ -51,8 +56,7 @@ export interface DropdownSearchProps<T> {
 export interface DropdownConfigProps {
     multiSelect?: boolean | undefined;
     maxSelectable?: number | undefined;
-    selectAllButtonLabel?: string | undefined;
-    clearAllButtonLabel?: string | undefined;
+    customLabels?: DropdownCustomLabelProps | undefined;
     width?: number | undefined;
     /**
      * Used when items are loaded from an api call.

--- a/src/shared/dropdown-list-v2/types.ts
+++ b/src/shared/dropdown-list-v2/types.ts
@@ -40,6 +40,7 @@ export interface DropdownSearchProps<T> {
     enableSearch?: boolean | undefined;
     /** If specified, the default no results display will not be rendered */
     hideNoResultsDisplay?: boolean | undefined;
+    noResultsLabel?: string | undefined;
     noResultsDescription?: React.ReactNode | undefined;
     searchPlaceholder?: string | undefined;
     /** Custom function to perform search when a user keys in a value in the search input */
@@ -50,6 +51,8 @@ export interface DropdownSearchProps<T> {
 export interface DropdownConfigProps {
     multiSelect?: boolean | undefined;
     maxSelectable?: number | undefined;
+    selectAllButtonLabel?: string | undefined;
+    clearAllButtonLabel?: string | undefined;
     width?: number | undefined;
     /**
      * Used when items are loaded from an api call.

--- a/src/shared/dropdown-list-v2/types.ts
+++ b/src/shared/dropdown-list-v2/types.ts
@@ -18,7 +18,7 @@ export interface ListItemDisplayProps {
 export interface DropdownCustomLabelProps {
     searchPlaceholder?: string | undefined;
     noResultsLabel?: string | undefined;
-    noResultsDescription?: () => React.ReactNode | undefined;
+    noResultsDescription?: React.ReactNode | undefined;
     selectAllButtonLabel?: string | undefined;
     clearAllButtonLabel?: string | undefined;
 }
@@ -48,6 +48,10 @@ export interface DropdownSearchProps<T> {
     enableSearch?: boolean | undefined;
     /** If specified, the default no results display will not be rendered */
     hideNoResultsDisplay?: boolean | undefined;
+    /** @deprecated use `noResultsDescription` inside `customLabels` */
+    noResultsDescription?: React.ReactNode | undefined;
+    /** @deprecated use `searchPlaceholder` inside `customLabels` */
+    searchPlaceholder?: string | undefined;
     /** Custom function to perform search when a user keys in a value in the search input */
     searchFunction?: ((searchValue: string) => T[]) | undefined;
     onSearch?: (() => void) | undefined;

--- a/src/shared/dropdown-list-v2/types.ts
+++ b/src/shared/dropdown-list-v2/types.ts
@@ -21,6 +21,8 @@ export interface DropdownCustomLabelProps {
     noResultsDescription?: React.ReactNode | undefined;
     selectAllButtonLabel?: string | undefined;
     clearAllButtonLabel?: string | undefined;
+    allSelectedLabel?: string | undefined;
+    multiSelectedLabel?: string | undefined;
 }
 
 export interface DropdownDisplayProps<T, V> {

--- a/stories/form/form-multi-select/form-multi-select.stories.tsx
+++ b/stories/form/form-multi-select/form-multi-select.stories.tsx
@@ -90,46 +90,48 @@ export const Default: StoryObj<Component> = {
     decorators: [StoryDecorator({ maxWidth: true })],
 };
 
+// NOTE: SB freezes with nested JSX, workaround is to declare outside of the CSF
+const _WithSearch = (
+    <>
+        <Form.MultiSelect
+            label="This has searchable options"
+            options={OPTIONS_DATA}
+            valueExtractor={(item) => item.value}
+            listExtractor={(item) => item.label}
+            enableSearch
+        />
+        <Form.MultiSelect
+            label="Custom label when no results are found"
+            options={OPTIONS_DATA}
+            valueExtractor={(item) => item.value}
+            listExtractor={(item) => item.label}
+            enableSearch
+            customLabels={{
+                noResultsLabel: "Custom no result found.",
+            }}
+        />
+        <Form.MultiSelect
+            label="Custom description when no results are found"
+            options={OPTIONS_DATA}
+            valueExtractor={(item) => item.value}
+            listExtractor={(item) => item.label}
+            enableSearch
+            customLabels={{
+                noResultsDescription: (
+                    <>
+                        Display additional information here when no results are
+                        found. There is default styling for commonly used markup
+                        such as <strong>bold text</strong> or <a>links</a>.
+                    </>
+                ),
+            }}
+        />
+    </>
+);
+
 export const WithSearch: StoryObj<Component> = {
-    render: () => {
-        return (
-            <>
-                <Form.MultiSelect
-                    label="This has searchable options"
-                    options={OPTIONS_DATA}
-                    valueExtractor={(item) => item.value}
-                    listExtractor={(item) => item.label}
-                    enableSearch
-                />
-                <Form.MultiSelect
-                    label="Custom label when no results are found"
-                    options={OPTIONS_DATA}
-                    valueExtractor={(item) => item.value}
-                    listExtractor={(item) => item.label}
-                    enableSearch
-                    customLabels={{
-                        noResultsLabel: "Custom no result found.",
-                    }}
-                />
-                <Form.MultiSelect
-                    label="Custom description when no results are found"
-                    options={OPTIONS_DATA}
-                    valueExtractor={(item) => item.value}
-                    listExtractor={(item) => item.label}
-                    enableSearch
-                    customLabels={{
-                        noResultsDescription: (
-                            <>
-                                Display additional information here when no
-                                results are found. There is default styling for
-                                commonly used markup such as{" "}
-                                <strong>bold text</strong> or <a>links</a>.
-                            </>
-                        ),
-                    }}
-                />
-            </>
-        );
+    render: (_args) => {
+        return _WithSearch;
     },
     decorators: [StoryDecorator({ maxWidth: true })],
 };

--- a/stories/form/form-multi-select/form-multi-select.stories.tsx
+++ b/stories/form/form-multi-select/form-multi-select.stories.tsx
@@ -69,8 +69,10 @@ export const Default: StoryObj<Component> = {
                     options={OPTIONS_DATA}
                     valueExtractor={(item) => item.value}
                     listExtractor={(item) => item.label}
-                    selectAllButtonLabel="Custom select all"
-                    clearAllButtonLabel="Custom clear all"
+                    customLabels={{
+                        selectAllButtonLabel: "Custom select all",
+                        clearAllButtonLabel: "Custom clear all",
+                    }}
                 />
             </>
         );
@@ -95,7 +97,9 @@ export const WithSearch: StoryObj<Component> = {
                     valueExtractor={(item) => item.value}
                     listExtractor={(item) => item.label}
                     enableSearch
-                    noResultsLabel="Custom no result found."
+                    customLabels={{
+                        noResultsLabel: "Custom no result found.",
+                    }}
                 />
                 <Form.MultiSelect
                     label="Custom description when no results are found"
@@ -103,14 +107,16 @@ export const WithSearch: StoryObj<Component> = {
                     valueExtractor={(item) => item.value}
                     listExtractor={(item) => item.label}
                     enableSearch
-                    noResultsDescription={
-                        <>
-                            Display additional information here when no results
-                            are found. There is default styling for commonly
-                            used markup such as <strong>bold text</strong> or{" "}
-                            <a>links</a>.
-                        </>
-                    }
+                    customLabels={{
+                        noResultsDescription: () => (
+                            <>
+                                Display additional information here when no
+                                results are found. There is default styling for
+                                commonly used markup such as{" "}
+                                <strong>bold text</strong> or <a>links</a>.
+                            </>
+                        ),
+                    }}
                 />
             </>
         );

--- a/stories/form/form-multi-select/form-multi-select.stories.tsx
+++ b/stories/form/form-multi-select/form-multi-select.stories.tsx
@@ -65,6 +65,16 @@ export const Default: StoryObj<Component> = {
                     ]}
                 />
                 <Form.MultiSelect
+                    label="This has custom all selected & multi selected label"
+                    options={OPTIONS_DATA}
+                    valueExtractor={(item) => item.value}
+                    listExtractor={(item) => item.label}
+                    customLabels={{
+                        allSelectedLabel: "Custom all selected",
+                        multiSelectedLabel: "Custom X selected",
+                    }}
+                />
+                <Form.MultiSelect
                     label="This has custom select all & clear all label"
                     options={OPTIONS_DATA}
                     valueExtractor={(item) => item.value}

--- a/stories/form/form-multi-select/form-multi-select.stories.tsx
+++ b/stories/form/form-multi-select/form-multi-select.stories.tsx
@@ -81,7 +81,7 @@ export const Default: StoryObj<Component> = {
 };
 
 export const WithSearch: StoryObj<Component> = {
-    render: (_args) => {
+    render: () => {
         return (
             <>
                 <Form.MultiSelect

--- a/stories/form/form-multi-select/form-multi-select.stories.tsx
+++ b/stories/form/form-multi-select/form-multi-select.stories.tsx
@@ -108,7 +108,7 @@ export const WithSearch: StoryObj<Component> = {
                     listExtractor={(item) => item.label}
                     enableSearch
                     customLabels={{
-                        noResultsDescription: () => (
+                        noResultsDescription: (
                             <>
                                 Display additional information here when no
                                 results are found. There is default styling for

--- a/stories/form/form-multi-select/form-multi-select.stories.tsx
+++ b/stories/form/form-multi-select/form-multi-select.stories.tsx
@@ -64,6 +64,14 @@ export const Default: StoryObj<Component> = {
                         { value: "C", label: "Option C" },
                     ]}
                 />
+                <Form.MultiSelect
+                    label="This has custom select all & clear all label"
+                    options={OPTIONS_DATA}
+                    valueExtractor={(item) => item.value}
+                    listExtractor={(item) => item.label}
+                    selectAllButtonLabel="Custom select all"
+                    clearAllButtonLabel="Custom clear all"
+                />
             </>
         );
     },
@@ -80,6 +88,14 @@ export const WithSearch: StoryObj<Component> = {
                     valueExtractor={(item) => item.value}
                     listExtractor={(item) => item.label}
                     enableSearch
+                />
+                <Form.MultiSelect
+                    label="Custom label when no results are found"
+                    options={OPTIONS_DATA}
+                    valueExtractor={(item) => item.value}
+                    listExtractor={(item) => item.label}
+                    enableSearch
+                    noResultsLabel="Custom no result found."
                 />
                 <Form.MultiSelect
                     label="Custom description when no results are found"

--- a/stories/form/form-multi-select/props-table.tsx
+++ b/stories/form/form-multi-select/props-table.tsx
@@ -233,6 +233,18 @@ const DATA: ApiTableSectionProps[] = [
                     "Specifies to replace the default Clear all button label",
                 propTypes: ["string"],
             },
+            {
+                name: "allSelectedLabel",
+                description:
+                    "Specifies to replace the default All selected label",
+                propTypes: ["string"],
+            },
+            {
+                name: "multiSelectedLabel",
+                description:
+                    "Specifies to replace the default X selected label",
+                propTypes: ["string"],
+            },
         ],
     },
     ...SHARED_FORM_PROPS_DATA,

--- a/stories/form/form-multi-select/props-table.tsx
+++ b/stories/form/form-multi-select/props-table.tsx
@@ -137,6 +137,12 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["boolean"],
             },
             {
+                name: "noResultsLabel",
+                description:
+                    "Specifies to replace the default no results display",
+                propTypes: ["string"],
+            },
+            {
                 name: "noResultsDescription",
                 description:
                     "Additional description rendered after the default no results display",
@@ -167,6 +173,18 @@ const DATA: ApiTableSectionProps[] = [
                 description:
                     "Specifies the maximum number of options that can be selected",
                 propTypes: ["number"],
+            },
+            {
+                name: "selectAllButtonLabel",
+                description:
+                    "Specifies to replace the default Select all button label",
+                propTypes: ["string"],
+            },
+            {
+                name: "clearAllButtonLabel",
+                description:
+                    "Specifies to replace the default Clear all button label",
+                propTypes: ["string"],
             },
             {
                 name: "dropdownRootNode",

--- a/stories/form/form-multi-select/props-table.tsx
+++ b/stories/form/form-multi-select/props-table.tsx
@@ -93,11 +93,6 @@ const DATA: ApiTableSectionProps[] = [
                 defaultValue: "false",
             },
             {
-                name: "searchPlaceholder",
-                description: "The placeholder for the search field",
-                propTypes: ["string"],
-            },
-            {
                 name: "searchFunction",
                 description:
                     "The custom function to perform a search when the user enters a value in the search input",
@@ -137,16 +132,10 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["boolean"],
             },
             {
-                name: "noResultsLabel",
+                name: "customLabels",
                 description:
-                    "Specifies to replace the default no results display",
-                propTypes: ["string"],
-            },
-            {
-                name: "noResultsDescription",
-                description:
-                    "Additional description rendered after the default no results display",
-                propTypes: ["React.ReactNode"],
+                    "Specifies custom labels to replace default labels",
+                propTypes: ["DropdownCustomLabelProps"],
             },
             {
                 name: "variant",
@@ -175,18 +164,6 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["number"],
             },
             {
-                name: "selectAllButtonLabel",
-                description:
-                    "Specifies to replace the default Select all button label",
-                propTypes: ["string"],
-            },
-            {
-                name: "clearAllButtonLabel",
-                description:
-                    "Specifies to replace the default Clear all button label",
-                propTypes: ["string"],
-            },
-            {
                 name: "dropdownRootNode",
                 description: (
                     <>
@@ -210,6 +187,40 @@ const DATA: ApiTableSectionProps[] = [
                         document<code>body</code>
                     </>
                 ),
+            },
+        ],
+    },
+    {
+        name: "DropdownCustomLabelProps",
+        attributes: [
+            {
+                name: "searchPlaceholder",
+                description: "The placeholder for the search field",
+                propTypes: ["string"],
+            },
+            {
+                name: "noResultsLabel",
+                description:
+                    "Specifies to replace the default no results display",
+                propTypes: ["string"],
+            },
+            {
+                name: "noResultsDescription",
+                description:
+                    "Additional description rendered after the default no results display",
+                propTypes: ["() => React.ReactNode"],
+            },
+            {
+                name: "selectAllButtonLabel",
+                description:
+                    "Specifies to replace the default Select all button label",
+                propTypes: ["string"],
+            },
+            {
+                name: "clearAllButtonLabel",
+                description:
+                    "Specifies to replace the default Clear all button label",
+                propTypes: ["string"],
             },
         ],
     },

--- a/stories/form/form-multi-select/props-table.tsx
+++ b/stories/form/form-multi-select/props-table.tsx
@@ -93,6 +93,11 @@ const DATA: ApiTableSectionProps[] = [
                 defaultValue: "false",
             },
             {
+                name: "searchPlaceholder (deprecated)",
+                description: "The placeholder for the search field",
+                propTypes: ["string"],
+            },
+            {
                 name: "searchFunction",
                 description:
                     "The custom function to perform a search when the user enters a value in the search input",
@@ -130,6 +135,12 @@ const DATA: ApiTableSectionProps[] = [
                 description:
                     "If specified, the default no results display will not be rendered",
                 propTypes: ["boolean"],
+            },
+            {
+                name: "noResultsDescription (deprecated)",
+                description:
+                    "Additional description rendered after the default no results display",
+                propTypes: ["React.ReactNode"],
             },
             {
                 name: "customLabels",

--- a/stories/form/form-nested-multi-select/form-nested-multi-select.stories.tsx
+++ b/stories/form/form-nested-multi-select/form-nested-multi-select.stories.tsx
@@ -102,40 +102,42 @@ export const SpecifyingMode: StoryObj<Component> = {
     decorators: [StoryDecorator({ maxWidth: true })],
 };
 
+// NOTE: SB freezes with nested JSX, workaround is to declare outside of the CSF
+const _WithSearch = (
+    <>
+        <Form.NestedMultiSelect
+            label="This has searchable options"
+            options={searchOptions}
+            enableSearch
+        />
+        <Form.NestedMultiSelect
+            label="Custom label when no results are found"
+            options={searchOptions}
+            enableSearch
+            customLabels={{
+                noResultsLabel: "Custom no result found.",
+            }}
+        />
+        <Form.NestedMultiSelect
+            label="Custom description when no results are found"
+            options={searchOptions}
+            enableSearch
+            customLabels={{
+                noResultsDescription: (
+                    <>
+                        Display additional information here when no results are
+                        found. There is default styling for commonly used markup
+                        such as <strong>bold text</strong> or <a>links</a>.
+                    </>
+                ),
+            }}
+        />
+    </>
+);
+
 export const WithSearch: StoryObj<Component> = {
-    render: () => {
-        return (
-            <>
-                <Form.NestedMultiSelect
-                    label="This has searchable options"
-                    options={searchOptions}
-                    enableSearch
-                />
-                <Form.NestedMultiSelect
-                    label="Custom label when no results are found"
-                    options={searchOptions}
-                    enableSearch
-                    customLabels={{
-                        noResultsLabel: "Custom no result found.",
-                    }}
-                />
-                <Form.NestedMultiSelect
-                    label="Custom description when no results are found"
-                    options={searchOptions}
-                    enableSearch
-                    customLabels={{
-                        noResultsDescription: (
-                            <>
-                                Display additional information here when no
-                                results are found. There is default styling for
-                                commonly used markup such as{" "}
-                                <strong>bold text</strong> or <a>links</a>.
-                            </>
-                        ),
-                    }}
-                />
-            </>
-        );
+    render: (_args) => {
+        return _WithSearch;
     },
     decorators: [StoryDecorator({ maxWidth: true })],
 };

--- a/stories/form/form-nested-multi-select/form-nested-multi-select.stories.tsx
+++ b/stories/form/form-nested-multi-select/form-nested-multi-select.stories.tsx
@@ -53,6 +53,13 @@ export const Default: StoryObj<Component> = {
                     errorMessage="Selection is required"
                 />
                 <Form.NestedMultiSelect
+                    label="This has custom multi selected label"
+                    options={options}
+                    customLabels={{
+                        multiSelectedLabel: "Custom X selected",
+                    }}
+                />
+                <Form.NestedMultiSelect
                     label="This has custom select all & clear all label"
                     options={options}
                     customLabels={{

--- a/stories/form/form-nested-multi-select/form-nested-multi-select.stories.tsx
+++ b/stories/form/form-nested-multi-select/form-nested-multi-select.stories.tsx
@@ -97,6 +97,12 @@ export const WithSearch: StoryObj<Component> = {
                     enableSearch
                 />
                 <Form.NestedMultiSelect
+                    label="Custom label when no results are found"
+                    options={searchOptions}
+                    enableSearch
+                    noResultsLabel="Custom no result found."
+                />
+                <Form.NestedMultiSelect
                     label="Custom description when no results are found"
                     options={searchOptions}
                     enableSearch

--- a/stories/form/form-nested-multi-select/form-nested-multi-select.stories.tsx
+++ b/stories/form/form-nested-multi-select/form-nested-multi-select.stories.tsx
@@ -52,6 +52,14 @@ export const Default: StoryObj<Component> = {
                     options={options}
                     errorMessage="Selection is required"
                 />
+                <Form.NestedMultiSelect
+                    label="This has custom select all & clear all label"
+                    options={options}
+                    customLabels={{
+                        selectAllButtonLabel: "Custom select all",
+                        clearAllButtonLabel: "Custom clear all",
+                    }}
+                />
             </>
         );
     },
@@ -100,20 +108,24 @@ export const WithSearch: StoryObj<Component> = {
                     label="Custom label when no results are found"
                     options={searchOptions}
                     enableSearch
-                    noResultsLabel="Custom no result found."
+                    customLabels={{
+                        noResultsLabel: "Custom no result found.",
+                    }}
                 />
                 <Form.NestedMultiSelect
                     label="Custom description when no results are found"
                     options={searchOptions}
                     enableSearch
-                    noResultsDescription={
-                        <>
-                            Display additional information here when no results
-                            are found. There is default styling for commonly
-                            used markup such as <strong>bold text</strong> or{" "}
-                            <a>links</a>.
-                        </>
-                    }
+                    customLabels={{
+                        noResultsDescription: () => (
+                            <>
+                                Display additional information here when no
+                                results are found. There is default styling for
+                                commonly used markup such as{" "}
+                                <strong>bold text</strong> or <a>links</a>.
+                            </>
+                        ),
+                    }}
                 />
             </>
         );

--- a/stories/form/form-nested-multi-select/form-nested-multi-select.stories.tsx
+++ b/stories/form/form-nested-multi-select/form-nested-multi-select.stories.tsx
@@ -117,7 +117,7 @@ export const WithSearch: StoryObj<Component> = {
                     options={searchOptions}
                     enableSearch
                     customLabels={{
-                        noResultsDescription: () => (
+                        noResultsDescription: (
                             <>
                                 Display additional information here when no
                                 results are found. There is default styling for

--- a/stories/form/form-nested-multi-select/form-nested-multi-select.stories.tsx
+++ b/stories/form/form-nested-multi-select/form-nested-multi-select.stories.tsx
@@ -96,7 +96,7 @@ export const SpecifyingMode: StoryObj<Component> = {
 };
 
 export const WithSearch: StoryObj<Component> = {
-    render: (_args) => {
+    render: () => {
         return (
             <>
                 <Form.NestedMultiSelect

--- a/stories/form/form-nested-multi-select/props-table.tsx
+++ b/stories/form/form-nested-multi-select/props-table.tsx
@@ -89,6 +89,12 @@ const DATA: ApiTableSectionProps[] = [
                 defaultValue: "false",
             },
             {
+                name: "noResultsLabel",
+                description:
+                    "Specifies to replace the default no results display",
+                propTypes: ["string"],
+            },
+            {
                 name: "noResultsDescription",
                 description:
                     "Additional description rendered after the default no results display",

--- a/stories/form/form-nested-multi-select/props-table.tsx
+++ b/stories/form/form-nested-multi-select/props-table.tsx
@@ -89,6 +89,12 @@ const DATA: ApiTableSectionProps[] = [
                 defaultValue: "false",
             },
             {
+                name: "noResultsDescription (deprecated)",
+                description:
+                    "Additional description rendered after the default no results display",
+                propTypes: ["React.ReactNode"],
+            },
+            {
                 name: "customLabels",
                 description:
                     "Specifies custom labels to replace default labels",
@@ -112,6 +118,11 @@ const DATA: ApiTableSectionProps[] = [
                     "When specified, it will allow a text base search for the items in the list",
                 propTypes: ["boolean"],
                 defaultValue: "false",
+            },
+            {
+                name: "searchPlaceholder (deprecated)",
+                description: "The placeholder for the search field",
+                propTypes: ["string"],
             },
             {
                 name: "variant",

--- a/stories/form/form-nested-multi-select/props-table.tsx
+++ b/stories/form/form-nested-multi-select/props-table.tsx
@@ -89,16 +89,10 @@ const DATA: ApiTableSectionProps[] = [
                 defaultValue: "false",
             },
             {
-                name: "noResultsLabel",
+                name: "customLabels",
                 description:
-                    "Specifies to replace the default no results display",
-                propTypes: ["string"],
-            },
-            {
-                name: "noResultsDescription",
-                description:
-                    "Additional description rendered after the default no results display",
-                propTypes: ["React.ReactNode"],
+                    "Specifies custom labels to replace default labels",
+                propTypes: ["DropdownCustomLabelProps"],
             },
             {
                 name: "listStyleWidth (deprecated)",
@@ -118,11 +112,6 @@ const DATA: ApiTableSectionProps[] = [
                     "When specified, it will allow a text base search for the items in the list",
                 propTypes: ["boolean"],
                 defaultValue: "false",
-            },
-            {
-                name: "searchPlaceholder",
-                description: "The placeholder for the search field",
-                propTypes: ["string"],
             },
             {
                 name: "variant",
@@ -201,6 +190,40 @@ const DATA: ApiTableSectionProps[] = [
                 name: "onBlur",
                 description: "Called when a defocus on the field is made",
                 propTypes: ["() => void"],
+            },
+        ],
+    },
+    {
+        name: "DropdownCustomLabelProps",
+        attributes: [
+            {
+                name: "searchPlaceholder",
+                description: "The placeholder for the search field",
+                propTypes: ["string"],
+            },
+            {
+                name: "noResultsLabel",
+                description:
+                    "Specifies to replace the default no results display",
+                propTypes: ["string"],
+            },
+            {
+                name: "noResultsDescription",
+                description:
+                    "Additional description rendered after the default no results display",
+                propTypes: ["() => React.ReactNode"],
+            },
+            {
+                name: "selectAllButtonLabel",
+                description:
+                    "Specifies to replace the default Select all button label",
+                propTypes: ["string"],
+            },
+            {
+                name: "clearAllButtonLabel",
+                description:
+                    "Specifies to replace the default Clear all button label",
+                propTypes: ["string"],
             },
         ],
     },

--- a/stories/form/form-nested-multi-select/props-table.tsx
+++ b/stories/form/form-nested-multi-select/props-table.tsx
@@ -236,6 +236,18 @@ const DATA: ApiTableSectionProps[] = [
                     "Specifies to replace the default Clear all button label",
                 propTypes: ["string"],
             },
+            {
+                name: "allSelectedLabel",
+                description:
+                    "Specifies to replace the default All selected label",
+                propTypes: ["string"],
+            },
+            {
+                name: "multiSelectedLabel",
+                description:
+                    "Specifies to replace the default X selected label",
+                propTypes: ["string"],
+            },
         ],
     },
     ...SHARED_FORM_PROPS_DATA,

--- a/stories/form/form-nested-select/form-nested-select.stories.tsx
+++ b/stories/form/form-nested-select/form-nested-select.stories.tsx
@@ -113,20 +113,24 @@ export const WithSearch: StoryObj<Component> = {
                     label="Custom label when no results are found"
                     options={searchOptions}
                     enableSearch
-                    noResultsLabel="Custom no result found."
+                    customLabels={{
+                        noResultsLabel: "Custom no result found.",
+                    }}
                 />
                 <Form.NestedSelect
                     label="Custom description when no results are found"
                     options={searchOptions}
                     enableSearch
-                    noResultsDescription={
-                        <>
-                            Display additional information here when no results
-                            are found. There is default styling for commonly
-                            used markup such as <strong>bold text</strong> or{" "}
-                            <a>links</a>.
-                        </>
-                    }
+                    customLabels={{
+                        noResultsDescription: () => (
+                            <>
+                                Display additional information here when no
+                                results are found. There is default styling for
+                                commonly used markup such as{" "}
+                                <strong>bold text</strong> or <a>links</a>.
+                            </>
+                        ),
+                    }}
                 />
             </>
         );

--- a/stories/form/form-nested-select/form-nested-select.stories.tsx
+++ b/stories/form/form-nested-select/form-nested-select.stories.tsx
@@ -101,7 +101,7 @@ export const SelectableCategory: StoryObj<Component> = {
 };
 
 export const WithSearch: StoryObj<Component> = {
-    render: (_args) => {
+    render: () => {
         return (
             <>
                 <Form.NestedSelect

--- a/stories/form/form-nested-select/form-nested-select.stories.tsx
+++ b/stories/form/form-nested-select/form-nested-select.stories.tsx
@@ -122,7 +122,7 @@ export const WithSearch: StoryObj<Component> = {
                     options={searchOptions}
                     enableSearch
                     customLabels={{
-                        noResultsDescription: () => (
+                        noResultsDescription: (
                             <>
                                 Display additional information here when no
                                 results are found. There is default styling for

--- a/stories/form/form-nested-select/form-nested-select.stories.tsx
+++ b/stories/form/form-nested-select/form-nested-select.stories.tsx
@@ -100,40 +100,42 @@ export const SelectableCategory: StoryObj<Component> = {
     decorators: [StoryDecorator({ maxWidth: true })],
 };
 
+// NOTE: SB freezes with nested JSX, workaround is to declare outside of the CSF
+const _WithSearch = (
+    <>
+        <Form.NestedSelect
+            label="This has searchable options"
+            options={searchOptions}
+            enableSearch
+        />
+        <Form.NestedSelect
+            label="Custom label when no results are found"
+            options={searchOptions}
+            enableSearch
+            customLabels={{
+                noResultsLabel: "Custom no result found.",
+            }}
+        />
+        <Form.NestedSelect
+            label="Custom description when no results are found"
+            options={searchOptions}
+            enableSearch
+            customLabels={{
+                noResultsDescription: (
+                    <>
+                        Display additional information here when no results are
+                        found. There is default styling for commonly used markup
+                        such as <strong>bold text</strong> or <a>links</a>.
+                    </>
+                ),
+            }}
+        />
+    </>
+);
+
 export const WithSearch: StoryObj<Component> = {
-    render: () => {
-        return (
-            <>
-                <Form.NestedSelect
-                    label="This has searchable options"
-                    options={searchOptions}
-                    enableSearch
-                />
-                <Form.NestedSelect
-                    label="Custom label when no results are found"
-                    options={searchOptions}
-                    enableSearch
-                    customLabels={{
-                        noResultsLabel: "Custom no result found.",
-                    }}
-                />
-                <Form.NestedSelect
-                    label="Custom description when no results are found"
-                    options={searchOptions}
-                    enableSearch
-                    customLabels={{
-                        noResultsDescription: (
-                            <>
-                                Display additional information here when no
-                                results are found. There is default styling for
-                                commonly used markup such as{" "}
-                                <strong>bold text</strong> or <a>links</a>.
-                            </>
-                        ),
-                    }}
-                />
-            </>
-        );
+    render: (_args) => {
+        return _WithSearch;
     },
     decorators: [StoryDecorator({ maxWidth: true })],
 };

--- a/stories/form/form-nested-select/form-nested-select.stories.tsx
+++ b/stories/form/form-nested-select/form-nested-select.stories.tsx
@@ -110,6 +110,12 @@ export const WithSearch: StoryObj<Component> = {
                     enableSearch
                 />
                 <Form.NestedSelect
+                    label="Custom label when no results are found"
+                    options={searchOptions}
+                    enableSearch
+                    noResultsLabel="Custom no result found."
+                />
+                <Form.NestedSelect
                     label="Custom description when no results are found"
                     options={searchOptions}
                     enableSearch

--- a/stories/form/form-nested-select/props-table.tsx
+++ b/stories/form/form-nested-select/props-table.tsx
@@ -93,16 +93,10 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["boolean"],
             },
             {
-                name: "noResultsLabel",
+                name: "customLabels",
                 description:
-                    "Specifies to replace the default no results display",
-                propTypes: ["string"],
-            },
-            {
-                name: "noResultsDescription",
-                description:
-                    "Additional description rendered after the default no results display",
-                propTypes: ["React.ReactNode"],
+                    "Specifies custom labels to replace default labels",
+                propTypes: ["DropdownCustomLabelProps"],
             },
             {
                 name: "listStyleWidth (deprecated)",
@@ -121,11 +115,6 @@ const DATA: ApiTableSectionProps[] = [
                 description:
                     "When specified, it will allow a text base search for the items in the list",
                 propTypes: ["boolean"],
-            },
-            {
-                name: "searchPlaceholder",
-                description: "The placeholder for the search field",
-                propTypes: ["string"],
             },
             {
                 name: "variant",
@@ -202,6 +191,40 @@ const DATA: ApiTableSectionProps[] = [
                 name: "onBlur",
                 description: "Called when a defocus on the field is made",
                 propTypes: ["() => void"],
+            },
+        ],
+    },
+    {
+        name: "DropdownCustomLabelProps",
+        attributes: [
+            {
+                name: "searchPlaceholder",
+                description: "The placeholder for the search field",
+                propTypes: ["string"],
+            },
+            {
+                name: "noResultsLabel",
+                description:
+                    "Specifies to replace the default no results display",
+                propTypes: ["string"],
+            },
+            {
+                name: "noResultsDescription",
+                description:
+                    "Additional description rendered after the default no results display",
+                propTypes: ["() => React.ReactNode"],
+            },
+            {
+                name: "selectAllButtonLabel",
+                description:
+                    "Specifies to replace the default Select all button label",
+                propTypes: ["string"],
+            },
+            {
+                name: "clearAllButtonLabel",
+                description:
+                    "Specifies to replace the default Clear all button label",
+                propTypes: ["string"],
             },
         ],
     },

--- a/stories/form/form-nested-select/props-table.tsx
+++ b/stories/form/form-nested-select/props-table.tsx
@@ -237,6 +237,18 @@ const DATA: ApiTableSectionProps[] = [
                     "Specifies to replace the default Clear all button label",
                 propTypes: ["string"],
             },
+            {
+                name: "allSelectedLabel",
+                description:
+                    "Specifies to replace the default All selected label",
+                propTypes: ["string"],
+            },
+            {
+                name: "multiSelectedLabel",
+                description:
+                    "Specifies to replace the default X selected label",
+                propTypes: ["string"],
+            },
         ],
     },
     ...SHARED_FORM_PROPS_DATA,

--- a/stories/form/form-nested-select/props-table.tsx
+++ b/stories/form/form-nested-select/props-table.tsx
@@ -93,6 +93,12 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["boolean"],
             },
             {
+                name: "noResultsDescription (deprecated)",
+                description:
+                    "Additional description rendered after the default no results display",
+                propTypes: ["React.ReactNode"],
+            },
+            {
                 name: "customLabels",
                 description:
                     "Specifies custom labels to replace default labels",
@@ -115,6 +121,11 @@ const DATA: ApiTableSectionProps[] = [
                 description:
                     "When specified, it will allow a text base search for the items in the list",
                 propTypes: ["boolean"],
+            },
+            {
+                name: "searchPlaceholder (deprecated)",
+                description: "The placeholder for the search field",
+                propTypes: ["string"],
             },
             {
                 name: "variant",

--- a/stories/form/form-nested-select/props-table.tsx
+++ b/stories/form/form-nested-select/props-table.tsx
@@ -93,6 +93,12 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["boolean"],
             },
             {
+                name: "noResultsLabel",
+                description:
+                    "Specifies to replace the default no results display",
+                propTypes: ["string"],
+            },
+            {
                 name: "noResultsDescription",
                 description:
                     "Additional description rendered after the default no results display",

--- a/stories/form/form-select/form-select.stories.tsx
+++ b/stories/form/form-select/form-select.stories.tsx
@@ -153,7 +153,9 @@ export const WithSearch: StoryObj<Component> = {
                     listExtractor={(item) => item.label}
                     displayValueExtractor={(item) => item.label}
                     enableSearch
-                    noResultsLabel="Custom no result found."
+                    customLabels={{
+                        noResultsLabel: "Custom no result found.",
+                    }}
                 />
                 <Form.Select
                     label="Custom description when no results are found"
@@ -162,14 +164,16 @@ export const WithSearch: StoryObj<Component> = {
                     listExtractor={(item) => item.label}
                     displayValueExtractor={(item) => item.label}
                     enableSearch
-                    noResultsDescription={
-                        <>
-                            Display additional information here when no results
-                            are found. There is default styling for commonly
-                            used markup such as <strong>bold text</strong> or{" "}
-                            <a>links</a>.
-                        </>
-                    }
+                    customLabels={{
+                        noResultsDescription: () => (
+                            <>
+                                Display additional information here when no
+                                results are found. There is default styling for
+                                commonly used markup such as{" "}
+                                <strong>bold text</strong> or <a>links</a>.
+                            </>
+                        ),
+                    }}
                 />
             </>
         );

--- a/stories/form/form-select/form-select.stories.tsx
+++ b/stories/form/form-select/form-select.stories.tsx
@@ -135,7 +135,7 @@ export const WithCustomListItemDisplay: StoryObj<Component> = {
 };
 
 export const WithSearch: StoryObj<Component> = {
-    render: (_args) => {
+    render: () => {
         return (
             <>
                 <Form.Select

--- a/stories/form/form-select/form-select.stories.tsx
+++ b/stories/form/form-select/form-select.stories.tsx
@@ -165,7 +165,7 @@ export const WithSearch: StoryObj<Component> = {
                     displayValueExtractor={(item) => item.label}
                     enableSearch
                     customLabels={{
-                        noResultsDescription: () => (
+                        noResultsDescription: (
                             <>
                                 Display additional information here when no
                                 results are found. There is default styling for

--- a/stories/form/form-select/form-select.stories.tsx
+++ b/stories/form/form-select/form-select.stories.tsx
@@ -147,6 +147,15 @@ export const WithSearch: StoryObj<Component> = {
                     enableSearch
                 />
                 <Form.Select
+                    label="Custom label when no results are found"
+                    options={OPTIONS_DATA}
+                    valueExtractor={(item) => item.value}
+                    listExtractor={(item) => item.label}
+                    displayValueExtractor={(item) => item.label}
+                    enableSearch
+                    noResultsLabel="Custom no result found."
+                />
+                <Form.Select
                     label="Custom description when no results are found"
                     options={OPTIONS_DATA}
                     valueExtractor={(item) => item.value}

--- a/stories/form/form-select/form-select.stories.tsx
+++ b/stories/form/form-select/form-select.stories.tsx
@@ -134,49 +134,51 @@ export const WithCustomListItemDisplay: StoryObj<Component> = {
     decorators: [StoryDecorator({ maxWidth: true })],
 };
 
+// NOTE: SB freezes with nested JSX, workaround is to declare outside of the CSF
+const _WithSearch = (
+    <>
+        <Form.Select
+            label="This has searchable options"
+            options={OPTIONS_DATA}
+            valueExtractor={(item) => item.value}
+            listExtractor={(item) => item.label}
+            displayValueExtractor={(item) => item.label}
+            enableSearch
+        />
+        <Form.Select
+            label="Custom label when no results are found"
+            options={OPTIONS_DATA}
+            valueExtractor={(item) => item.value}
+            listExtractor={(item) => item.label}
+            displayValueExtractor={(item) => item.label}
+            enableSearch
+            customLabels={{
+                noResultsLabel: "Custom no result found.",
+            }}
+        />
+        <Form.Select
+            label="Custom description when no results are found"
+            options={OPTIONS_DATA}
+            valueExtractor={(item) => item.value}
+            listExtractor={(item) => item.label}
+            displayValueExtractor={(item) => item.label}
+            enableSearch
+            customLabels={{
+                noResultsDescription: (
+                    <>
+                        Display additional information here when no results are
+                        found. There is default styling for commonly used markup
+                        such as <strong>bold text</strong> or <a>links</a>.
+                    </>
+                ),
+            }}
+        />
+    </>
+);
+
 export const WithSearch: StoryObj<Component> = {
-    render: () => {
-        return (
-            <>
-                <Form.Select
-                    label="This has searchable options"
-                    options={OPTIONS_DATA}
-                    valueExtractor={(item) => item.value}
-                    listExtractor={(item) => item.label}
-                    displayValueExtractor={(item) => item.label}
-                    enableSearch
-                />
-                <Form.Select
-                    label="Custom label when no results are found"
-                    options={OPTIONS_DATA}
-                    valueExtractor={(item) => item.value}
-                    listExtractor={(item) => item.label}
-                    displayValueExtractor={(item) => item.label}
-                    enableSearch
-                    customLabels={{
-                        noResultsLabel: "Custom no result found.",
-                    }}
-                />
-                <Form.Select
-                    label="Custom description when no results are found"
-                    options={OPTIONS_DATA}
-                    valueExtractor={(item) => item.value}
-                    listExtractor={(item) => item.label}
-                    displayValueExtractor={(item) => item.label}
-                    enableSearch
-                    customLabels={{
-                        noResultsDescription: (
-                            <>
-                                Display additional information here when no
-                                results are found. There is default styling for
-                                commonly used markup such as{" "}
-                                <strong>bold text</strong> or <a>links</a>.
-                            </>
-                        ),
-                    }}
-                />
-            </>
-        );
+    render: (_args) => {
+        return _WithSearch;
     },
     decorators: [StoryDecorator({ maxWidth: true })],
 };

--- a/stories/form/form-select/props-table.tsx
+++ b/stories/form/form-select/props-table.tsx
@@ -110,11 +110,6 @@ const DATA: ApiTableSectionProps[] = [
                 defaultValue: "false",
             },
             {
-                name: "searchPlaceholder",
-                description: "The placeholder for the search field",
-                propTypes: ["string"],
-            },
-            {
                 name: "searchFunction",
                 description:
                     "The custom function to perform a search when the user enters a value in the search input",
@@ -167,16 +162,9 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["boolean"],
             },
             {
-                name: "noResultsLabel",
-                description:
-                    "Specifies to replace the default no results display",
-                propTypes: ["string"],
-            },
-            {
-                name: "noResultsDescription",
-                description:
-                    "Additional description rendered after the default no results display",
-                propTypes: ["React.ReactNode"],
+                name: "customLabels",
+                description: "Specifies custom label to replace default labels",
+                propTypes: ["DropdownCustomLabelProps"],
             },
             {
                 name: "renderCustomCallToAction",
@@ -240,6 +228,40 @@ const DATA: ApiTableSectionProps[] = [
                 name: "selected",
                 description: "Indicates if the list item is selected",
                 propTypes: ["boolean"],
+            },
+        ],
+    },
+    {
+        name: "DropdownCustomLabelProps",
+        attributes: [
+            {
+                name: "searchPlaceholder",
+                description: "The placeholder for the search field",
+                propTypes: ["string"],
+            },
+            {
+                name: "noResultsLabel",
+                description:
+                    "Specifies to replace the default no results display",
+                propTypes: ["string"],
+            },
+            {
+                name: "noResultsDescription",
+                description:
+                    "Additional description rendered after the default no results display",
+                propTypes: ["() => React.ReactNode"],
+            },
+            {
+                name: "selectAllButtonLabel",
+                description:
+                    "Specifies to replace the default Select all button label",
+                propTypes: ["string"],
+            },
+            {
+                name: "clearAllButtonLabel",
+                description:
+                    "Specifies to replace the default Clear all button label",
+                propTypes: ["string"],
             },
         ],
     },

--- a/stories/form/form-select/props-table.tsx
+++ b/stories/form/form-select/props-table.tsx
@@ -167,6 +167,12 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["boolean"],
             },
             {
+                name: "noResultsLabel",
+                description:
+                    "Specifies to replace the default no results display",
+                propTypes: ["string"],
+            },
+            {
                 name: "noResultsDescription",
                 description:
                     "Additional description rendered after the default no results display",

--- a/stories/form/form-select/props-table.tsx
+++ b/stories/form/form-select/props-table.tsx
@@ -274,6 +274,18 @@ const DATA: ApiTableSectionProps[] = [
                     "Specifies to replace the default Clear all button label",
                 propTypes: ["string"],
             },
+            {
+                name: "allSelectedLabel",
+                description:
+                    "Specifies to replace the default All selected label",
+                propTypes: ["string"],
+            },
+            {
+                name: "multiSelectedLabel",
+                description:
+                    "Specifies to replace the default X selected label",
+                propTypes: ["string"],
+            },
         ],
     },
     ...SHARED_FORM_PROPS_DATA,

--- a/stories/form/form-select/props-table.tsx
+++ b/stories/form/form-select/props-table.tsx
@@ -110,6 +110,11 @@ const DATA: ApiTableSectionProps[] = [
                 defaultValue: "false",
             },
             {
+                name: "searchPlaceholder (deprecated)",
+                description: "The placeholder for the search field",
+                propTypes: ["string"],
+            },
+            {
                 name: "searchFunction",
                 description:
                     "The custom function to perform a search when the user enters a value in the search input",
@@ -160,6 +165,12 @@ const DATA: ApiTableSectionProps[] = [
                 description:
                     "If specified, the default no results display will not be rendered",
                 propTypes: ["boolean"],
+            },
+            {
+                name: "noResultsDescription (deprecated)",
+                description:
+                    "Additional description rendered after the default no results display",
+                propTypes: ["React.ReactNode"],
             },
             {
                 name: "customLabels",

--- a/stories/form/form-select/props-table.tsx
+++ b/stories/form/form-select/props-table.tsx
@@ -174,7 +174,8 @@ const DATA: ApiTableSectionProps[] = [
             },
             {
                 name: "customLabels",
-                description: "Specifies custom label to replace default labels",
+                description:
+                    "Specifies custom labels to replace default labels",
                 propTypes: ["DropdownCustomLabelProps"],
             },
             {


### PR DESCRIPTION
**Changes**
add these 3 new options, to have custom label for select with search to have custom `no result found` label and multi select to have custom `Select All/Clear All` label (mainly for translation)
- noResultsLabel
- selectAllButtonLabel
- clearAllButtonLabel
- delete branch

**Additional information**

- You may refer to this [COMMPORTAL-832](https://sgtechstack.atlassian.net/browse/COMMPORTAL-832)
