### PR TITLE
Fix DateRangeInput selection month reverting to present month for invalid range reselection

### DIFF
--- a/src/date-range-input/date-range-input.tsx
+++ b/src/date-range-input/date-range-input.tsx
@@ -206,7 +206,7 @@ export const DateRangeInput = ({
     useEffect(() => {
         if (currentFocus === "start") {
             setInitialCalendarDate(selectedStart);
-        } else if (currentFocus === "end") {
+        } else if (currentFocus === "end" && selectedEnd) {
             setInitialCalendarDate(selectedEnd);
         }
     }, [currentFocus]);


### PR DESCRIPTION
**Changes**
Steps to reproduce bug:
1. Select a date range outside the existing month and click done
2. Click on start date input and select a start date that comes after the end date, which causes end date to reset
3. Date selection month snaps to present month
<img width="507" height="279" alt="image" src="https://github.com/user-attachments/assets/b7935d49-bdce-4663-9f3c-295357a4f611" />
<img width="506" height="325" alt="image" src="https://github.com/user-attachments/assets/881f9642-2c5a-4b09-9311-2acddc988b94" />




- delete branch

**Additional information**
- You may refer to this [BOOKINGSG-7813](https://sgtechstack.atlassian.net/browse/BOOKINGSG-7813)
