### PR TITLE
[COMMPORTAL-353][SW] update props for custom labels in Filter

### DIFF
--- a/src/filter/filter.tsx
+++ b/src/filter/filter.tsx
@@ -25,9 +25,9 @@ import { FilterProps, Mode } from "./types";
 
 const FilterBase = ({
     customLabels,
-    toggleFilterButtonLabel,
-    headerTitle,
-    doneButtonLabel,
+    toggleFilterButtonLabel: _toggleFilterButtonLabel,
+    headerTitle: _headerTitle,
+    doneButtonLabel: _doneButtonLabel,
     toggleFilterButtonStyle = "light",
     clearButtonDisabled = false,
     onClear,
@@ -39,13 +39,13 @@ const FilterBase = ({
     // =============================================================================
     // CONST, STATE, REF
     // =============================================================================
-    const _toggleFilterButtonLabel =
+    const toggleFilterButtonLabel =
         customLabels?.toggleFilterButtonLabel ||
-        toggleFilterButtonLabel ||
+        _toggleFilterButtonLabel ||
         "Filters";
-    const _headerTitle = customLabels?.headerTitle || headerTitle || "Filters";
-    const _doneButtonLabel =
-        customLabels?.doneButtonLabel || doneButtonLabel || "Done";
+    const headerTitle = customLabels?.headerTitle || _headerTitle || "Filters";
+    const doneButtonLabel =
+        customLabels?.doneButtonLabel || _doneButtonLabel || "Done";
 
     const [visible, setVisible] = useState(false);
     const mobileNodeRef = useRef<HTMLDivElement>(null);

--- a/src/filter/filter.tsx
+++ b/src/filter/filter.tsx
@@ -24,10 +24,11 @@ import {
 import { FilterProps, Mode } from "./types";
 
 const FilterBase = ({
-    toggleFilterButtonLabel = "Filters",
+    customLabels,
+    toggleFilterButtonLabel,
+    headerTitle,
+    doneButtonLabel,
     toggleFilterButtonStyle = "light",
-    headerTitle = "Filters",
-    doneButtonLabel = "Done",
     clearButtonDisabled = false,
     onClear,
     onDismiss,
@@ -38,6 +39,14 @@ const FilterBase = ({
     // =============================================================================
     // CONST, STATE, REF
     // =============================================================================
+    const _toggleFilterButtonLabel =
+        customLabels?.toggleFilterButtonLabel ||
+        toggleFilterButtonLabel ||
+        "Filters";
+    const _headerTitle = customLabels?.headerTitle || headerTitle || "Filters";
+    const _doneButtonLabel =
+        customLabels?.doneButtonLabel || doneButtonLabel || "Done";
+
     const [visible, setVisible] = useState(false);
     const mobileNodeRef = useRef<HTMLDivElement>(null);
     const desktopNodeRef = useRef<HTMLDivElement>(null);

--- a/src/filter/types.ts
+++ b/src/filter/types.ts
@@ -5,13 +5,32 @@ export type Mode = "default" | "mobile";
 
 export interface FilterProps {
     children: React.ReactNode | ((mode: Mode) => React.ReactNode);
-    clearButtonDisabled?: boolean | undefined;
+    customLabels?:
+        | {
+              headerTitle?: string | undefined;
+              toggleFilterButtonLabel?: string | undefined;
+              doneButtonLabel?: string | undefined;
+          }
+        | undefined;
+    /**
+     * @deprecated
+     * use customLabels instead
+     */
     headerTitle?: string | undefined;
+    /**
+     * @deprecated
+     * use customLabels instead
+     */
     toggleFilterButtonLabel?: string | undefined;
+    /**
+     * @deprecated
+     * use customLabels instead
+     */
+    doneButtonLabel?: string | undefined;
+    clearButtonDisabled?: boolean | undefined;
     toggleFilterButtonStyle?: ButtonStyleType | undefined;
     className?: string | undefined;
     id?: string | undefined;
-    doneButtonLabel?: string | undefined;
     "data-testid"?: string | undefined;
     /** Called when dismiss button is pressed (mobile mode only) */
     onDismiss?: (() => void) | undefined;

--- a/src/link-list/components/link-list-eager.tsx
+++ b/src/link-list/components/link-list-eager.tsx
@@ -23,7 +23,7 @@ export const EagerLinkList = <T,>({
     maxShown,
     style,
     onItemClick,
-    customLabel,
+    customLabels,
 }: Props<T>) => {
     // =============================================================================
     // CONST, STATE, REFS
@@ -77,8 +77,8 @@ export const EagerLinkList = <T,>({
                 data-testid="toggle-button-label"
             >
                 {showMinimised
-                    ? customLabel?.viewLess || "View less"
-                    : customLabel?.viewMore || "View more"}
+                    ? customLabels?.viewLess || "View less"
+                    : customLabels?.viewMore || "View more"}
             </ToggleButtonLabel>
             {showMinimised ? <ViewLessIcon /> : <ViewMoreIcon />}
         </ToggleButton>

--- a/src/link-list/components/link-list-lazy.tsx
+++ b/src/link-list/components/link-list-lazy.tsx
@@ -25,7 +25,7 @@ export const LazyLinkList = <T,>({
     onItemClick,
     loadMore,
     onLoadMore,
-    customLabel,
+    customLabels,
 }: Props<T>) => {
     // =============================================================================
     // CONST, STATE, REFS
@@ -80,7 +80,7 @@ export const LazyLinkList = <T,>({
                 weight="semibold"
                 data-testid="toggle-button-label"
             >
-                {customLabel?.viewMore || "View more"}
+                {customLabels?.viewMore || "View more"}
             </ToggleButtonLabel>
             <ViewMoreIcon />
         </ToggleButton>

--- a/src/link-list/internal-types.ts
+++ b/src/link-list/internal-types.ts
@@ -22,11 +22,11 @@ export type BaseProps<T> = {
               event: React.MouseEvent<HTMLAnchorElement>
           ) => void)
         | undefined;
-    customLabel?:
-        | Partial<{
-              viewMore: string;
-              viewLess: string;
-          }>
+    customLabels?:
+        | {
+              viewMore?: string | undefined;
+              viewLess?: string | undefined;
+          }
         | undefined;
 };
 

--- a/src/link-list/link-list.tsx
+++ b/src/link-list/link-list.tsx
@@ -11,7 +11,7 @@ export const LinkList = <T,>(props: LinkListProps<T>): JSX.Element => {
             style = "default",
             onItemClick,
             maxShown,
-            customLabel,
+            customLabels,
             ...otherProps
         } = props;
 
@@ -22,7 +22,7 @@ export const LinkList = <T,>(props: LinkListProps<T>): JSX.Element => {
                     maxShown={maxShown}
                     style={style}
                     onItemClick={onItemClick}
-                    customLabel={customLabel}
+                    customLabels={customLabels}
                 />
             </Container>
         );
@@ -36,7 +36,7 @@ export const LinkList = <T,>(props: LinkListProps<T>): JSX.Element => {
                 onItemClick,
                 loadMore,
                 onLoadMore,
-                customLabel,
+                customLabels,
                 ...otherProps
             } = props;
 
@@ -48,7 +48,7 @@ export const LinkList = <T,>(props: LinkListProps<T>): JSX.Element => {
                         onItemClick={onItemClick}
                         loadMore={loadMore}
                         onLoadMore={onLoadMore}
-                        customLabel={customLabel}
+                        customLabels={customLabels}
                     />
                 </Container>
             );

--- a/stories/filter/props-table.tsx
+++ b/stories/filter/props-table.tsx
@@ -23,8 +23,7 @@ const FILTER_DATA: ApiTableSectionProps[] = [
             },
             {
                 name: "customLabels",
-                description:
-                    "Specifies custom labels. See the section below for more details",
+                description: `Specifies custom labels. See the "Custom labels" section below for more details`,
                 propTypes: ["object"],
             },
             {
@@ -75,23 +74,26 @@ const FILTER_DATA: ApiTableSectionProps[] = [
         ],
     },
     {
-        name: "customLabels",
+        name: "Custom labels",
         attributes: [
             {
                 name: "headerTitle",
                 description: "The title of the filter header",
                 propTypes: ["string"],
+                defaultValue: `"Filters"`,
             },
             {
                 name: "toggleFilterButtonLabel",
                 description:
                     "The display label of the filter toggle button (in mobile)",
                 propTypes: ["string"],
+                defaultValue: `"Filters"`,
             },
             {
                 name: "doneButtonLabel",
                 description: "The display label of the done button (in mobile)",
                 propTypes: ["string"],
+                defaultValue: `"Done"`,
             },
         ],
     },

--- a/stories/filter/props-table.tsx
+++ b/stories/filter/props-table.tsx
@@ -22,30 +22,17 @@ const FILTER_DATA: ApiTableSectionProps[] = [
                 ],
             },
             {
+                name: "customLabels",
+                description:
+                    "Specifies custom labels. See the section below for more details",
+                propTypes: ["object"],
+            },
+            {
                 name: "clearButtonDisabled",
                 description:
                     "Specifies if the feature to expand/collapse all child items is enabled",
                 propTypes: ["boolean"],
                 defaultValue: "false",
-            },
-            {
-                name: "headerTitle",
-                description: "The title of the filter header",
-                propTypes: ["string"],
-                defaultValue: `"Filters"`,
-            },
-            {
-                name: "toggleFilterButtonLabel",
-                description:
-                    "The display label of the filter toggle button (in mobile)",
-                propTypes: ["string"],
-                defaultValue: `"Filters"`,
-            },
-            {
-                name: "doneButtonLabel",
-                description: "The display label of the done button (in mobile)",
-                propTypes: ["string"],
-                defaultValue: `"Done"`,
             },
             {
                 name: "toggleFilterButtonStyle",
@@ -83,6 +70,27 @@ const FILTER_DATA: ApiTableSectionProps[] = [
             {
                 name: "data-testid",
                 description: "The test identifier for the component",
+                propTypes: ["string"],
+            },
+        ],
+    },
+    {
+        name: "customLabels",
+        attributes: [
+            {
+                name: "headerTitle",
+                description: "The title of the filter header",
+                propTypes: ["string"],
+            },
+            {
+                name: "toggleFilterButtonLabel",
+                description:
+                    "The display label of the filter toggle button (in mobile)",
+                propTypes: ["string"],
+            },
+            {
+                name: "doneButtonLabel",
+                description: "The display label of the done button (in mobile)",
                 propTypes: ["string"],
             },
         ],

--- a/stories/link-list/link-list.stories.tsx
+++ b/stories/link-list/link-list.stories.tsx
@@ -178,7 +178,7 @@ export const CustomLabel: StoryObj<Component> = {
                         rel: "noreferrer",
                     },
                 ]}
-                customLabel={{
+                customLabels={{
                     viewMore: "Custom view more label",
                     viewLess: "Custom view less label",
                 }}

--- a/stories/link-list/props-table.tsx
+++ b/stories/link-list/props-table.tsx
@@ -4,6 +4,12 @@ const DATA: ApiTableSectionProps[] = [
     {
         attributes: [
             {
+                name: "customLabels",
+                description:
+                    "Specifies custom labels. See the section below for more details",
+                propTypes: ["object"],
+            },
+            {
                 name: "loadMode",
                 description: "The loading mode for the data",
                 propTypes: [`"eager"`, `"lazy"`],
@@ -144,6 +150,21 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: [
                     "(event: React.MouseEvent<HTMLAnchorElement>) => void",
                 ],
+            },
+        ],
+    },
+    {
+        name: "customLabels",
+        attributes: [
+            {
+                name: "viewMore",
+                description: "The label of the view more button",
+                propTypes: ["string"],
+            },
+            {
+                name: "viewLess",
+                description: "The label of the view less button",
+                propTypes: ["string"],
             },
         ],
     },

--- a/stories/link-list/props-table.tsx
+++ b/stories/link-list/props-table.tsx
@@ -5,8 +5,7 @@ const DATA: ApiTableSectionProps[] = [
         attributes: [
             {
                 name: "customLabels",
-                description:
-                    "Specifies custom labels. See the section below for more details",
+                description: `Specifies custom labels. See the "Custom labels" section below for more details`,
                 propTypes: ["object"],
             },
             {
@@ -154,17 +153,19 @@ const DATA: ApiTableSectionProps[] = [
         ],
     },
     {
-        name: "customLabels",
+        name: "Custom labels",
         attributes: [
             {
                 name: "viewMore",
                 description: "The label of the view more button",
                 propTypes: ["string"],
+                defaultValue: `"View more"`,
             },
             {
                 name: "viewLess",
                 description: "The label of the view less button",
                 propTypes: ["string"],
+                defaultValue: `"View less"`,
             },
         ],
     },

--- a/tests/link-list/link-list.spec.tsx
+++ b/tests/link-list/link-list.spec.tsx
@@ -18,13 +18,13 @@ describe("LinkList", () => {
         }));
     });
 
-    describe("customLabel", () => {
+    describe("customLabels", () => {
         it("should render with custom labels", () => {
             render(
                 <LinkList
                     items={MOCK_ITEMS}
                     maxShown={2}
-                    customLabel={{
+                    customLabels={{
                         viewMore: "Show more",
                         viewLess: "Show less",
                     }}


### PR DESCRIPTION
**Changes**
combine props for custom labels into `customLabel`

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- [WARNING] Filter: `headerTitle`, `toggleFilterButtonLabel`, and `doneButtonLabel` are now under `customLabel`. The original props have been marked as deprecated.

