### PR TITLE
[MOL-19265][JC] add expandCollapseClickCallback to Accordion

### DIFF
--- a/src/accordion/accordion.tsx
+++ b/src/accordion/accordion.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { AccordionContext } from "./accordion-context";
 import { AccordionItem } from "./accordion-item";
 import {
@@ -19,23 +19,34 @@ const AccordionBase = ({
     "data-testid": testId,
     className,
     headingLevel = 2,
-    expandCollapseClickCallback,
+    onExpandCollapseChange,
 }: AccordionProps): JSX.Element => {
     const [expandAll, setExpandAll] = useState<boolean>(
         initialDisplay === "expand-all"
     );
+    const [hasFirstLoad, setHasFirstLoad] = useState<boolean>(false);
 
-    const handleExpandCollapseClick = (event: React.MouseEvent, callback?: () => void) => {
+    useEffect(() => {
+        setHasFirstLoad(true);
+    }, []);
+
+    useEffect(() => {
+        if (hasFirstLoad) {
+            onExpandCollapseChange?.(expandAll);
+        }
+    }, [expandAll, hasFirstLoad]);
+
+
+    const handleExpandCollapseClick = (event: React.MouseEvent) => {
         event.preventDefault();
         setExpandAll((prevExpandValue) => !prevExpandValue);
-        callback?.();
     };
 
     const renderCollapseExpandAll = () => {
         return (
             <ExpandCollapseLink
                 data-testid="accordion-expand-collapse-button"
-                onClick={(event) => handleExpandCollapseClick(event, expandCollapseClickCallback)}
+                onClick={handleExpandCollapseClick}
                 styleType="link"
                 type="button"
             >

--- a/src/accordion/accordion.tsx
+++ b/src/accordion/accordion.tsx
@@ -19,21 +19,23 @@ const AccordionBase = ({
     "data-testid": testId,
     className,
     headingLevel = 2,
+    expandCollapseClickCallback,
 }: AccordionProps): JSX.Element => {
     const [expandAll, setExpandAll] = useState<boolean>(
         initialDisplay === "expand-all"
     );
 
-    const handleExpandCollapseClick = (event: React.MouseEvent) => {
+    const handleExpandCollapseClick = (event: React.MouseEvent, callback?: () => void) => {
         event.preventDefault();
         setExpandAll((prevExpandValue) => !prevExpandValue);
+        callback?.();
     };
 
     const renderCollapseExpandAll = () => {
         return (
             <ExpandCollapseLink
                 data-testid="accordion-expand-collapse-button"
-                onClick={handleExpandCollapseClick}
+                onClick={(event) => handleExpandCollapseClick(event, expandCollapseClickCallback)}
                 styleType="link"
                 type="button"
             >

--- a/src/accordion/types.ts
+++ b/src/accordion/types.ts
@@ -8,6 +8,7 @@ export interface AccordionProps {
     "data-testid"?: string | undefined;
     className?: string | undefined;
     headingLevel?: number | undefined;
+    expandCollapseClickCallback?: () => void,
 }
 
 export type AccordionItemType = "default" | "small";

--- a/src/accordion/types.ts
+++ b/src/accordion/types.ts
@@ -8,7 +8,7 @@ export interface AccordionProps {
     "data-testid"?: string | undefined;
     className?: string | undefined;
     headingLevel?: number | undefined;
-    expandCollapseClickCallback?: () => void,
+    onExpandCollapseChange?: ((expanded: boolean) => void) | undefined,
 }
 
 export type AccordionItemType = "default" | "small";

--- a/stories/accordion/props-table.tsx
+++ b/stories/accordion/props-table.tsx
@@ -63,6 +63,11 @@ const ACCORDION_DATA: ApiTableSectionProps[] = [
                 propTypes: ["number"],
                 defaultValue: "2",
             },
+            {
+                name: "onExpandCollapseChange",
+                description: `The callback invoked with the latest expanded state when the "Show all"/"Hide all" button is toggled`,
+                propTypes: ["(expanded: boolean) => void"],
+            },
         ],
     },
 ];


### PR DESCRIPTION
**Changes**
Add new optional props in Accordion - a callback func to be triggered when user click on show all/hide all

- delete branch

<!-- Remove if not required -->
**Changelog entry**

- Add expandCollapseClickCallback in `Accordion`

**Additional information**

- It's to solve issue 2 in [MOL-19265](https://sgtechstack.atlassian.net/browse/MOL-19265)
