### PR TITLE
Bookingsg 7877

### DIFF
--- a/src/file-upload/file-item-edit.tsx
+++ b/src/file-upload/file-item-edit.tsx
@@ -133,6 +133,7 @@ export const FileItemEdit = ({
                         onChange={handleChange}
                         onBlur={handleBlur}
                         rows={3}
+                        aria-label={`Photo description for ${name}`}
                         label={{
                             children: "Photo description",
                             subtitle:

--- a/src/file-upload/file-list-item/file-list-item.tsx
+++ b/src/file-upload/file-list-item/file-list-item.tsx
@@ -225,7 +225,7 @@ const Component = ({
                 <ErrorIconButton
                     onClick={handleDelete}
                     data-testid={`${id}-error-delete-button`}
-                    aria-label={`delete-${name}`}
+                    aria-label={`delete ${name}, error: ${errorMessage}`}
                 >
                     <CrossIcon aria-hidden />
                 </ErrorIconButton>

--- a/src/file-upload/file-list.tsx
+++ b/src/file-upload/file-list.tsx
@@ -275,6 +275,9 @@ function Component(
 
     const handleDelete = (item: FileItemProps) => () => {
         onItemDelete(item);
+        if (wrapperRef.current) {
+            wrapperRef.current.focus();
+        }
     };
 
     const handleDragEnd = (event: DragEndEvent) => {
@@ -511,7 +514,6 @@ function Component(
     const renderProgressStatus = () => (
         <VisuallyHidden
             ref={visuallyHiddenRef}
-            tabIndex={-1}
             aria-live="polite"
             aria-atomic="true"
         >
@@ -524,7 +526,7 @@ function Component(
             <>
                 {renderProgressStatus()}
                 <ListWrapper
-                    tabIndex={0}
+                    tabIndex={-1}
                     $readOnly={readOnly}
                     ref={wrapperRef}
                     aria-label={getWrapperAriaLabel()}

--- a/src/file-upload/file-upload.tsx
+++ b/src/file-upload/file-upload.tsx
@@ -169,7 +169,6 @@ export const FileUpload = ({
                                 !!activeId || disabled || reachedMaxFiles()
                             }
                             onClick={handleUploadButtonClick}
-                            aria-label="Upload files button"
                         >
                             Upload files
                         </UploadButton>

--- a/src/file-upload/file-upload.tsx
+++ b/src/file-upload/file-upload.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from "react";
 import { FileUploadContext } from "./context";
 import { DropzoneElement, FileUploadDropzone } from "./dropzone";
-import { FileList } from "./file-list";
+import { FileList, FileListRef } from "./file-list";
 import {
     Description,
     DescriptionContainer,
@@ -45,6 +45,7 @@ export const FileUpload = ({
     // CONST, STATE, REFS
     // =========================================================================
     const dropzoneRef = useRef<DropzoneElement>(null);
+    const fileListRef = useRef<FileListRef>(null);
     const [activeId, setActiveId] = useState<string>();
 
     // =========================================================================
@@ -53,6 +54,7 @@ export const FileUpload = ({
     const handleChange = (files: File[]) => {
         if (!disabled && onChange) {
             onChange(files);
+            fileListRef.current?.focus();
         }
     };
 
@@ -144,6 +146,7 @@ export const FileUpload = ({
                     <WarningAlert type="warning">{warning}</WarningAlert>
                 )}
                 <FileList
+                    ref={fileListRef}
                     fileItems={fileItems}
                     editableFileItems={editableFileItems}
                     fileDescriptionMaxLength={fileDescriptionMaxLength}
@@ -166,6 +169,7 @@ export const FileUpload = ({
                                 !!activeId || disabled || reachedMaxFiles()
                             }
                             onClick={handleUploadButtonClick}
+                            aria-label="Upload files button"
                         >
                             Upload files
                         </UploadButton>

--- a/src/file-upload/file-upload.tsx
+++ b/src/file-upload/file-upload.tsx
@@ -61,6 +61,7 @@ export const FileUpload = ({
     const handleItemDelete = (item: FileItemProps) => {
         if (onDelete) {
             onDelete(item);
+            fileListRef.current?.focus();
         }
     };
 

--- a/stories/file-upload/file-upload.stories.tsx
+++ b/stories/file-upload/file-upload.stories.tsx
@@ -109,6 +109,7 @@ export const WithLoadingIndicator: StoryObj<Component> = {
                     name: file.name,
                     size: file.size,
                     type: file.type,
+                    progress: 0, 
                 };
             });
             setFileItems((prevItems) => {

--- a/tests/file-upload/file-upload.spec.tsx
+++ b/tests/file-upload/file-upload.spec.tsx
@@ -364,6 +364,98 @@ describe("FileUpload", () => {
             expect(uploadButton).not.toBeInTheDocument();
         });
     });
+
+    describe("Progress Announcements", () => {
+        it("should announce the start of file upload when progress begins", () => {
+            const fileItems: FileItemProps[] = [
+                {
+                    ...MOCK_NON_IMAGE_FILE,
+                    progress: 0.1,
+                },
+            ];
+
+            render(<FileUpload fileItems={fileItems} />);
+
+            const announcement = screen.getByText(
+                "Starting upload of bugs-bunny.pdf"
+            );
+            expect(announcement).toBeInTheDocument();
+            expect(
+                announcement.closest('[aria-live="polite"]')
+            ).toBeInTheDocument();
+        });
+
+        it("should announce when file upload is complete", () => {
+            const fileItems: FileItemProps[] = [
+                {
+                    ...MOCK_NON_IMAGE_FILE,
+                    progress: 1,
+                },
+            ];
+
+            render(<FileUpload fileItems={fileItems} />);
+
+            const announcement = screen.getByText(
+                "bugs-bunny.pdf upload is complete"
+            );
+            expect(announcement).toBeInTheDocument();
+            expect(
+                announcement.closest('[aria-live="polite"]')
+            ).toBeInTheDocument();
+        });
+
+        it("should announce errors when file upload fails", () => {
+            const errorMessage = "File size too large";
+            const fileItems: FileItemProps[] = [
+                {
+                    ...MOCK_NON_IMAGE_FILE,
+                    errorMessage,
+                },
+            ];
+
+            render(<FileUpload fileItems={fileItems} />);
+
+            const announcement = screen.getByText(
+                `Error uploading bugs-bunny.pdf: ${errorMessage}`
+            );
+            expect(announcement).toBeInTheDocument();
+            expect(
+                announcement.closest('[aria-live="polite"]')
+            ).toBeInTheDocument();
+        });
+
+        it("should announce multiple file uploads correctly", () => {
+            const fileItems: FileItemProps[] = [
+                {
+                    ...MOCK_NON_IMAGE_FILE,
+                    id: "file1",
+                    name: "document1.pdf",
+                    progress: 0.2,
+                },
+                {
+                    ...MOCK_IMAGE_ITEM,
+                    id: "file2",
+                    name: "image1.png",
+                    progress: 1,
+                },
+                {
+                    id: "file3",
+                    name: "document2.pdf",
+                    type: "application/pdf",
+                    size: 5000,
+                    errorMessage: "Network error",
+                },
+            ];
+
+            render(<FileUpload fileItems={fileItems} />);
+
+            // Should announce all three states in one message
+            const announcementText = screen.getByText(
+                /Starting upload of document1.pdf, image1.png upload is complete, Error uploading document2.pdf: Network error/
+            );
+            expect(announcementText).toBeInTheDocument();
+        });
+    });
 });
 
 // =============================================================================


### PR DESCRIPTION
**Changes**
Add accessibility for FileUpload
- Expose `FileList` to be focusable via `tabIndex={0}`
- Wrap `FileList` with `forwardRef` to expose its `wrapperRef.focus()`
- Use `getWrapperAriaLabel` to provide announcements on the status of the array of Files that reannounces if the user brings focus to the FileList
- Use `VisuallyHidden` to announce download progress of files via `renderProgressStatus`
- Throttle downloadProgress announcement in case the download progress is updated very often, causing the announcements to spam and be unlistenable
- Fix Storybook WithLoadingIndicator to show download progress with loading indicator
- [BREAKING] Update aria-label in file delete button to include error message if file failed to download

- [delete] branch


**Additional information**
- You may refer to this [Figma](https://www.figma.com/design/wDAxbRmlq4xOn4UJ8zPuEF/%F0%9F%A7%91%F0%9F%8F%BB%E2%80%8D%F0%9F%A6%AF-Flagship-A11y-Annotations?node-id=1964-2404&m=dev)
