### PR TITLE
[MISC][NT] Fixed overlay with aria-hidden when filters are open

### DIFF
--- a/src/filter/filter.styles.tsx
+++ b/src/filter/filter.styles.tsx
@@ -36,6 +36,10 @@ export const FilterBody = styled.div`
     overflow-y: auto;
 `;
 
+export const FloatingWrapper = styled.div`
+    height: 100%;
+`;
+
 // =============================================================================
 // HEADER STYLES
 // =============================================================================

--- a/src/filter/filter.tsx
+++ b/src/filter/filter.tsx
@@ -18,6 +18,7 @@ import {
     FilterHeader,
     FilterHeaderButton,
     FilterTitle,
+    FloatingWrapper,
     MobileContainer,
     MobileOverlayContainer,
 } from "./filter.styles";
@@ -146,34 +147,36 @@ const FilterBase = ({
                 </FilterButton>
                 <Overlay show={visible} disableTransition>
                     {visible ? (
-                        <FloatingFocusManager
-                            context={context}
-                            initialFocus={-1}
-                        >
-                            <MobileOverlayContainer
-                                data-id="filter-mobile"
-                                data-testid="filter-mobile"
-                                ref={refs.setFloating}
+                        <FloatingWrapper>
+                            <FloatingFocusManager
+                                context={context}
+                                initialFocus={-1}
                             >
-                                <MobileContainer
-                                    ref={mobileNodeRef}
-                                    tabIndex={0}
+                                <MobileOverlayContainer
+                                    data-id="filter-mobile"
+                                    data-testid="filter-mobile"
+                                    ref={refs.setFloating}
                                 >
-                                    {renderHeader("mobile")}
-                                    <FilterBody>
-                                        {renderChildren("mobile")}
-                                    </FilterBody>
-                                    <FilterFooter>
-                                        <FilterDoneButton
-                                            onClick={handleDoneClick}
-                                            type="button"
-                                        >
-                                            {doneButtonLabel}
-                                        </FilterDoneButton>
-                                    </FilterFooter>
-                                </MobileContainer>
-                            </MobileOverlayContainer>
-                        </FloatingFocusManager>
+                                    <MobileContainer
+                                        ref={mobileNodeRef}
+                                        tabIndex={0}
+                                    >
+                                        {renderHeader("mobile")}
+                                        <FilterBody>
+                                            {renderChildren("mobile")}
+                                        </FilterBody>
+                                        <FilterFooter>
+                                            <FilterDoneButton
+                                                onClick={handleDoneClick}
+                                                type="button"
+                                            >
+                                                {doneButtonLabel}
+                                            </FilterDoneButton>
+                                        </FilterFooter>
+                                    </MobileContainer>
+                                </MobileOverlayContainer>
+                            </FloatingFocusManager>
+                        </FloatingWrapper>
                     ) : undefined}
                 </Overlay>
             </>

--- a/src/filter/filter.tsx
+++ b/src/filter/filter.tsx
@@ -145,28 +145,36 @@ const FilterBase = ({
                     {toggleFilterButtonLabel}
                 </FilterButton>
                 <Overlay show={visible} disableTransition>
-                    <FloatingFocusManager context={context} initialFocus={-1}>
-                        <MobileOverlayContainer
-                            data-id="filter-mobile"
-                            data-testid="filter-mobile"
-                            ref={refs.setFloating}
+                    {visible ? (
+                        <FloatingFocusManager
+                            context={context}
+                            initialFocus={-1}
                         >
-                            <MobileContainer ref={mobileNodeRef} tabIndex={0}>
-                                {renderHeader("mobile")}
-                                <FilterBody>
-                                    {renderChildren("mobile")}
-                                </FilterBody>
-                                <FilterFooter>
-                                    <FilterDoneButton
-                                        onClick={handleDoneClick}
-                                        type="button"
-                                    >
-                                        {doneButtonLabel}
-                                    </FilterDoneButton>
-                                </FilterFooter>
-                            </MobileContainer>
-                        </MobileOverlayContainer>
-                    </FloatingFocusManager>
+                            <MobileOverlayContainer
+                                data-id="filter-mobile"
+                                data-testid="filter-mobile"
+                                ref={refs.setFloating}
+                            >
+                                <MobileContainer
+                                    ref={mobileNodeRef}
+                                    tabIndex={0}
+                                >
+                                    {renderHeader("mobile")}
+                                    <FilterBody>
+                                        {renderChildren("mobile")}
+                                    </FilterBody>
+                                    <FilterFooter>
+                                        <FilterDoneButton
+                                            onClick={handleDoneClick}
+                                            type="button"
+                                        >
+                                            {doneButtonLabel}
+                                        </FilterDoneButton>
+                                    </FilterFooter>
+                                </MobileContainer>
+                            </MobileOverlayContainer>
+                        </FloatingFocusManager>
+                    ) : undefined}
                 </Overlay>
             </>
         );


### PR DESCRIPTION
Fixed overlay with aria-hidden when filters are open in mobile view. When more than 1 filter component is rendered, floating focus is set to the last rendered filter, causing the other filters to be appended with `aria-hidden`

**Changes**
Fixed overlay with `aria-hidden` when more than 1 filter is rendered in mobile view

- [delete] branch

**Changelog entry**
- Fixed overlay with `aria-hidden` when more than 1 filter is rendered in mobile view

