### PR TITLE
Gracefully handle missing icon for ButtonWithIcon

### DIFF
--- a/src/button-with-icon/button-with-icon.tsx
+++ b/src/button-with-icon/button-with-icon.tsx
@@ -49,9 +49,9 @@ const DefaultComponent = (
         >
             {loading ? (
                 <ComponentLoadingSpinner />
-            ) : (
+            ) : icon ? (
                 React.cloneElement(icon, { "aria-hidden": true })
-            )}
+            ) : null}
             <span>{children}</span>
         </MainButtonWithIcon>
     );
@@ -92,9 +92,9 @@ const SmallComponent = (props: ButtonWithIconProps, ref: ButtonWithIconRef) => {
         >
             {loading ? (
                 <ComponentLoadingSpinner />
-            ) : (
+            ) : icon ? (
                 React.cloneElement(icon, { "aria-hidden": true })
-            )}
+            ) : null}
             <span>{children}</span>
         </MainButtonWithIcon>
     );


### PR DESCRIPTION
**Changes**

- prevent error thrown with `React.cloneElement` when icon is not specified
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

Bug fix
- Gracefully handle missing icon for ButtonWithIcon