### PR TITLE
[COMMPORTAL-805][SW] disable active/hover states for button, checkbox…

### DIFF
--- a/src/button/button.style.tsx
+++ b/src/button/button.style.tsx
@@ -47,7 +47,9 @@ export const Main = styled.button<MainStyleProps>`
 
                     &:hover,
                     &:active {
-                        background-color: ${Colour["bg-hover-neutral"]};
+                        @media (pointer: fine) {
+                            background-color: ${Colour["bg-hover-neutral"]};
+                        }
                     }
                 `;
             case "light":
@@ -61,7 +63,9 @@ export const Main = styled.button<MainStyleProps>`
 
                     &:hover,
                     &:active {
-                        background-color: ${Colour["bg-hover-neutral"]};
+                        @media (pointer: fine) {
+                            background-color: ${Colour["bg-hover-neutral"]};
+                        }
                     }
                 `;
 
@@ -74,7 +78,9 @@ export const Main = styled.button<MainStyleProps>`
                         : ThemeButton["button-link-colour-text"]};
                     &:hover,
                     &:active {
-                        background-color: ${Colour["bg-hover-neutral"]};
+                        @media (pointer: fine) {
+                            background-color: ${Colour["bg-hover-neutral"]};
+                        }
                     }
                 `;
             case "disabled":
@@ -103,9 +109,13 @@ export const Main = styled.button<MainStyleProps>`
 
                     &:hover,
                     &:active {
-                        background-color: ${props.$buttonIsDanger
-                            ? Colour["bg-error-strong-hover"]
-                            : ThemeButton["button-default-colour-bg-hover"]};
+                        @media (pointer: fine) {
+                            background-color: ${props.$buttonIsDanger
+                                ? Colour["bg-error-strong-hover"]
+                                : ThemeButton[
+                                      "button-default-colour-bg-hover"
+                                  ]};
+                        }
                     }
                 `;
         }

--- a/src/checkbox/checkbox.style.tsx
+++ b/src/checkbox/checkbox.style.tsx
@@ -95,6 +95,8 @@ export const Input = styled.input<CheckboxProps>`
         + ${StyledCheckedIcon},
         &:hover
         + ${StyledInteremediateIcon} {
-        color: ${(props) => !props.disabled && Colour["icon-hover"](props)};
+        @media (pointer: fine) {
+            color: ${(props) => !props.disabled && Colour["icon-hover"](props)};
+        }
     }
 `;

--- a/src/toggle/toggle.styles.tsx
+++ b/src/toggle/toggle.styles.tsx
@@ -91,7 +91,9 @@ export const Container = styled.div<ContainerStyleProps>`
                             border-color: ${Colour["border-error"]};
 
                             &:has(${HeaderContainer}:hover) {
-                                background: ${Colour["bg-hover-subtle"]};
+                                @media (pointer: fine) {
+                                    background: ${Colour["bg-hover-subtle"]};
+                                }
                             }
                         `;
                     }
@@ -116,14 +118,16 @@ export const Container = styled.div<ContainerStyleProps>`
                         background: ${Colour["bg-selected"]};
 
                         &:has(${HeaderContainer}:hover) {
-                            background: ${Colour["bg-selected-hover"]};
+                            @media (pointer: fine) {
+                                background: ${Colour["bg-selected-hover"]};
 
-                            & ${TextContainer} {
-                                color: ${Colour["text-selected-hover"]};
-                            }
+                                & ${TextContainer} {
+                                    color: ${Colour["text-selected-hover"]};
+                                }
 
-                            & ${StyledToggleIcon} {
-                                color: ${Colour["icon-selected-hover"]};
+                                & ${StyledToggleIcon} {
+                                    color: ${Colour["icon-selected-hover"]};
+                                }
                             }
                         }
                     `;
@@ -133,7 +137,9 @@ export const Container = styled.div<ContainerStyleProps>`
                     border: none;
 
                     &:has(${HeaderContainer}:hover) {
-                        background: ${Colour["bg-hover-subtle"]};
+                        @media (pointer: fine) {
+                            background: ${Colour["bg-hover-subtle"]};
+                        }
                     }
                 `;
             }
@@ -149,7 +155,9 @@ export const Container = styled.div<ContainerStyleProps>`
                             border-color: ${Colour["border-error"]};
 
                             &:has(${HeaderContainer}:hover) {
-                                background: ${Colour["bg-hover-subtle"]};
+                                @media (pointer: fine) {
+                                    background: ${Colour["bg-hover-subtle"]};
+                                }
                             }
                         `;
                     }
@@ -175,14 +183,16 @@ export const Container = styled.div<ContainerStyleProps>`
                         background: ${Colour["bg-selected"]};
 
                         &:has(${HeaderContainer}:hover) {
-                            background: ${Colour["bg-selected-hover"]};
+                            @media (pointer: fine) {
+                                background: ${Colour["bg-selected-hover"]};
 
-                            & ${TextContainer} {
-                                color: ${Colour["text-selected-hover"]};
-                            }
+                                & ${TextContainer} {
+                                    color: ${Colour["text-selected-hover"]};
+                                }
 
-                            & ${StyledToggleIcon} {
-                                color: ${Colour["icon-selected-hover"]};
+                                & ${StyledToggleIcon} {
+                                    color: ${Colour["icon-selected-hover"]};
+                                }
                             }
                         }
                     `;
@@ -192,7 +202,9 @@ export const Container = styled.div<ContainerStyleProps>`
                     border-color: ${Colour.border};
 
                     &:has(${HeaderContainer}:hover) {
-                        background: ${Colour["bg-hover-subtle"]};
+                        @media (pointer: fine) {
+                            background: ${Colour["bg-hover-subtle"]};
+                        }
                     }
                 `;
             }


### PR DESCRIPTION
**Changes**
disable active/hover states for button, checkbox, and toggle

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- [WARNING] active/hover state for button, checkbox, and toggle are only applicable for mouse events, and not touch (ie applicable on desktop but not on mobile with touch)
