### PR TITLE
[MISC][XY] Accessibility enhancement for Alert

### DIFF
--- a/src/alert/alert.style.tsx
+++ b/src/alert/alert.style.tsx
@@ -152,6 +152,7 @@ export const TextWrapperContainer = styled.div<TextWrapperContainerStyleProps>`
     display: flex;
     flex-direction: column;
     flex: 1;
+    order: 1;
     ${(props) => {
         if (props.$showMore && props.$hasActionLink)
             return css`
@@ -189,6 +190,7 @@ export const ShowMoreButton = styled.button<StyleProps>`
     align-self: flex-start;
     gap: ${Spacing["spacing-4"]};
     margin-top: ${Spacing["spacing-8"]};
+    order: 2;
 
     cursor: pointer;
     user-select: none;

--- a/src/alert/alert.tsx
+++ b/src/alert/alert.tsx
@@ -3,8 +3,9 @@ import { ExclamationCircleFillIcon } from "@lifesg/react-icons/exclamation-circl
 import { ExclamationTriangleFillIcon } from "@lifesg/react-icons/exclamation-triangle-fill";
 import { ICircleFillIcon } from "@lifesg/react-icons/i-circle-fill";
 import { TickCircleFillIcon } from "@lifesg/react-icons/tick-circle-fill";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useResizeDetector } from "react-resize-detector";
+import { inertValue } from "../shared/accessibility";
 import {
     ActionLinkText,
     AlertIconWrapper,
@@ -26,6 +27,7 @@ export const Alert = ({
     showIcon = false,
     customIcon,
     maxCollapsedHeight,
+    role,
     ...otherProps
 }: AlertProps): JSX.Element => {
     // =============================================================================
@@ -37,21 +39,30 @@ export const Alert = ({
         useResizeDetector<HTMLDivElement>();
 
     // =============================================================================
-    // EFFECTS
-    // =============================================================================
-
-    useEffect(() => {
-        setCollapsedState();
-    }, [maxCollapsedHeight, contentHeight]);
-
-    // =============================================================================
     // HELPERS
     // =============================================================================
 
-    const setCollapsedState = () => {
+    const getAlertLabel = () => {
+        switch (type) {
+            case "success":
+                return "Success";
+            case "warning":
+                return "Warning";
+            case "error":
+                return "Error";
+            case "info":
+                return "Information";
+            case "description":
+                return "Description";
+            default:
+                return "Alert";
+        }
+    };
+
+    const setCollapsedState = useCallback(() => {
         setShowHiddenContent(!maxCollapsedHeight);
         setRenderShowMore(isContentOutsideCollapsibleZone());
-    };
+    }, [maxCollapsedHeight, contentHeight]);
 
     const isContentOutsideCollapsibleZone = () => {
         if (contentHeight && maxCollapsedHeight) {
@@ -59,6 +70,18 @@ export const Alert = ({
         }
         return false;
     };
+
+    const isInert = () => {
+        return !!maxCollapsedHeight && !showHiddenContent;
+    };
+
+    // =============================================================================
+    // EFFECTS
+    // =============================================================================
+
+    useEffect(() => {
+        setCollapsedState();
+    }, [maxCollapsedHeight, contentHeight, setCollapsedState]);
 
     // =============================================================================
     // RENDER FUNCTIONS
@@ -69,6 +92,7 @@ export const Alert = ({
             $sizeType={sizeType}
             $type={type}
             type="button"
+            aria-expanded={showHiddenContent}
             onClick={() => setShowHiddenContent(!showHiddenContent)}
         >
             Show {showHiddenContent ? "less" : "more"}
@@ -91,6 +115,7 @@ export const Alert = ({
                 data-testid="action-link"
                 $type={type}
                 $sizeType={sizeType}
+                inert={inertValue(isInert())}
                 {...actionLink}
             >
                 {actionLink.children}
@@ -103,15 +128,15 @@ export const Alert = ({
         if (type && customIcon) return customIcon;
         switch (type) {
             case "success":
-                return <TickCircleFillIcon />;
+                return <TickCircleFillIcon aria-hidden />;
             case "warning":
-                return <ExclamationTriangleFillIcon />;
+                return <ExclamationTriangleFillIcon aria-hidden />;
             case "error":
-                return <ExclamationCircleFillIcon />;
+                return <ExclamationCircleFillIcon aria-hidden />;
             case "info":
-                return <ICircleFillIcon />;
+                return <ICircleFillIcon aria-hidden />;
             case "description":
-                return <ICircleFillIcon />;
+                return <ICircleFillIcon aria-hidden />;
             default:
                 return null;
         }
@@ -126,6 +151,7 @@ export const Alert = ({
             }
             $showMore={showHiddenContent}
             $hasActionLink={!!actionLink}
+            inert={inertValue(isInert())}
         >
             <div ref={contentRef}>{children}</div>
             {renderLink()}
@@ -137,7 +163,9 @@ export const Alert = ({
             className={className}
             $type={type}
             $sizeType={sizeType}
+            aria-label={`${getAlertLabel()}`}
             data-testid={otherProps["data-testid"]}
+            role={role}
         >
             {showIcon && (
                 <AlertIconWrapper $sizeType={sizeType} $type={type}>
@@ -145,8 +173,13 @@ export const Alert = ({
                 </AlertIconWrapper>
             )}
             <ContentContainer>
-                {renderContent()}
+                {/* 
+                    CSS-BASED TAB ORDER IMPLEMENTATION:
+                    - DOM order: button → link → content (natural tab order)
+                    - Visual order: content → button (via CSS order property)
+                */}
                 {renderShowMore && renderShowMoreButton()}
+                {renderContent()}
             </ContentContainer>
         </Wrapper>
     );

--- a/stories/alert/alert.mdx
+++ b/stories/alert/alert.mdx
@@ -49,6 +49,49 @@ desired value in px. This also works with custom content.
 
 <Canvas of={AlertStories.WithMaxCollapsedHeight} />
 
+## Accessibility
+
+By default, the Alert component does not include `role="alert"` to avoid disruptive announcements. You can specify roles explicitly when needed:
+
+```tsx
+// For immediate announcement (use sparingly)
+<Alert type="error" role="alert">
+    Critical error message
+</Alert>
+
+// For status updates
+<Alert type="info" role="status">
+    Information update
+</Alert>
+```
+
+For dynamic alerts that need to be announced to screen readers (e.g. an alert that appears after the rest of the elements on the page), use an external live region pattern:
+
+```tsx
+// Create a visually hidden live region that announces content changes
+<div
+    id="live-region"
+    aria-live="polite"
+    aria-atomic="true"
+    style={{
+        position: "absolute",
+        left: "-10000px",
+        width: "1px",
+        height: "1px",
+        overflow: "hidden",
+    }}
+>
+    {alertMessage}
+</div>
+
+// Display alerts without automatic announcement
+<Alert type="success" showIcon>
+    Your data has been saved!
+</Alert>
+```
+
+<Canvas of={AlertStories.Accessibility} />
+
 ## Component API
 
 <PropsTable />

--- a/stories/alert/alert.stories.tsx
+++ b/stories/alert/alert.stories.tsx
@@ -1,5 +1,6 @@
 import { CalendarEventIcon } from "@lifesg/react-icons/calendar-event";
 import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
 import { Alert } from "src/alert";
 import { StackDecorator, StoryDecorator } from "stories/storybook-common";
 
@@ -266,6 +267,57 @@ export const WithMaxCollapsedHeight: StoryObj<Component> = {
                         Custom content
                     </div>
                 </Alert>
+            </>
+        );
+    },
+};
+
+export const Accessibility: StoryObj<Component> = {
+    render: () => {
+        const [alertMessage, setAlertMessage] = useState("");
+        const [messageId, setMessageId] = useState(0);
+
+        const announceMessage = (message: string) => {
+            setMessageId((prev) => prev + 1);
+            setAlertMessage(message);
+        };
+
+        return (
+            <>
+                <div
+                    id="live-region"
+                    aria-live="polite"
+                    aria-atomic="true"
+                    style={{
+                        position: "absolute",
+                        left: "-10000px",
+                        width: "1px",
+                        height: "1px",
+                        overflow: "hidden",
+                    }}
+                >
+                    {alertMessage && (
+                        <span key={messageId}>{alertMessage}</span>
+                    )}
+                </div>
+
+                <Alert type="error" showIcon role="alert">
+                    This alert uses role=&quot;alert&quot; for immediate
+                    announcement.
+                </Alert>
+
+                <Alert type="info" showIcon role="status">
+                    This alert uses role=&quot;status&quot; for less urgent
+                    updates.
+                </Alert>
+
+                <button
+                    onClick={() =>
+                        announceMessage("Success: Your data has been saved!")
+                    }
+                >
+                    Trigger Live Region Announcement
+                </button>
             </>
         );
     },


### PR DESCRIPTION
**Changes**
- Expose `role` prop for consumer use
- Make content not tab-able in collapsed state (similar to accordion)
- Add accessibility section in stories to explain aria-role & aria-live usage

- [delete] branch

- [WARNING] Restructure component to get intended tab order and use css flex to keep visual order 

**Additional information**

- You may refer to this [Figma](https://www.figma.com/design/wDAxbRmlq4xOn4UJ8zPuEF/%F0%9F%A7%91%F0%9F%8F%BB%E2%80%8D%F0%9F%A6%AF-Flagship-A11y-Annotations?node-id=1-29771)
