### PR TITLE
[MOL-19434][AT] fix an issue on the accordion that is showing the wro…

### DIFF
--- a/src/accordion/accordion-context.tsx
+++ b/src/accordion/accordion-context.tsx
@@ -2,9 +2,11 @@ import React from "react";
 
 interface IAccordionContext {
     expandAll: boolean;
+    onChildStateChange: (id: string, isExpanded: boolean) => void;
     itemHeadingLevel?: number | undefined;
 }
 
 export const AccordionContext = React.createContext<IAccordionContext>({
     expandAll: false,
+    onChildStateChange: () => {},
 });

--- a/src/accordion/accordion-item.tsx
+++ b/src/accordion/accordion-item.tsx
@@ -1,3 +1,4 @@
+import { useSpring } from "@react-spring/web";
 import React, {
     forwardRef,
     useContext,
@@ -7,7 +8,6 @@ import React, {
     useState,
 } from "react";
 import { useResizeDetector } from "react-resize-detector";
-import { useSpring } from "@react-spring/web";
 import { inertValue } from "../shared/accessibility";
 import { SimpleIdGenerator } from "../util";
 import { AccordionContext } from "./accordion-context";
@@ -43,14 +43,14 @@ function Component(
     // CONST, STATE, REF
     // =========================================================================
     const elementRef = useRef<HTMLDivElement>(null);
-    const { expandAll, itemHeadingLevel } = useContext(AccordionContext);
+    const { expandAll, itemHeadingLevel, onChildStateChange } =
+        useContext(AccordionContext);
     const [expanded, setExpanded] = useState<boolean>(
         collapsible ? expandedControlled ?? expandAll : true
     );
     const [hasFirstLoad, setHasFirstLoad] = useState<boolean>(false);
     const [internalId] = useState(() => SimpleIdGenerator.generate());
     const contentId = `${internalId}-content`;
-
     const resizeDetector = useResizeDetector();
 
     useImperativeHandle(
@@ -79,6 +79,7 @@ function Component(
 
     useEffect(() => {
         setHasFirstLoad(true);
+        onChildStateChange(internalId, expandAll);
     }, []);
 
     useEffect(() => {
@@ -93,7 +94,9 @@ function Component(
 
     const handleExpandCollapseClick = (event: React.MouseEvent) => {
         event.preventDefault();
-        setExpanded((prevExpand) => !prevExpand);
+        const expandedState = !expanded;
+        setExpanded(expandedState);
+        onChildStateChange(internalId, expandedState);
     };
 
     // =========================================================================


### PR DESCRIPTION
**Changes**
This update allows state management between AccordionItem children to feedback changes to the parent container.
This fixes the issue of the expand/collapse all button not responding to changes made on the child.

- delete branch

**Changelog entry**
- Accordion state management now correctly syncs between parent and children
- "Show/Hide all" button now properly reflects the actual state of all items

- You may refer to this [MOL-19434](https://sgtechstack.atlassian.net/browse/MOL-19434)
