### PR TITLE
Resolve callback warning on React 18

### DIFF
--- a/src/shared/accessibility/index.ts
+++ b/src/shared/accessibility/index.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { version } from "react";
+import { isReact19 } from "../../util";
 
 export const VisuallyHidden = styled.div`
     clip-path: inset(50%);
@@ -15,9 +15,7 @@ export const VisuallyHidden = styled.div`
  * 19+ provides official support as a boolean, while it is handled as string in older versions
  */
 export const inertValue = (value: boolean | undefined) => {
-    const pieces = version.split(".");
-    const major = parseInt(pieces[0], 10);
-    if (major >= 19) {
+    if (isReact19()) {
         return value;
     }
 

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -12,3 +12,4 @@ export * from "./use-mount";
 export * from "./use-next-input-state";
 export * from "./use-previous";
 export * from "./use-state-ref";
+export * from "./version";

--- a/src/util/merge-refs.ts
+++ b/src/util/merge-refs.ts
@@ -1,4 +1,5 @@
 import { MutableRefObject, Ref } from "react";
+import { isReact19 } from "./version";
 
 export const mergeRefs = <T>(...refs: Ref<T>[]) => {
     return (value: T | null) => {
@@ -17,8 +18,10 @@ export const mergeRefs = <T>(...refs: Ref<T>[]) => {
             }
         }
 
-        return () => {
-            for (const cleanup of cleanups) cleanup();
-        };
+        if (isReact19()) {
+            return () => {
+                for (const cleanup of cleanups) cleanup();
+            };
+        }
     };
 };

--- a/src/util/version.ts
+++ b/src/util/version.ts
@@ -1,0 +1,8 @@
+import { version } from "react";
+
+export const isReact19 = () => {
+    const pieces = version.split(".");
+    const major = parseInt(pieces[0], 10);
+
+    return major >= 19;
+};


### PR DESCRIPTION
**Changes**

Fix the following warning originating from the dropdown list component's `mergeRefs`:

```
Warning: Unexpected return value from a callback ref in div. A callback ref should not return a function.
```

Since callback cleanup is only available in React 19+, added a version check

Also extracted the version check to a util function

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Resolve "A callback ref should not return a function" warning on React 18
