### PR TITLE
Add alt scroll lock method for iOS

### DIFF
--- a/src/overlay/overlay.tsx
+++ b/src/overlay/overlay.tsx
@@ -145,11 +145,11 @@ const OverlayComponent = ({
 					display: none;
 				}
 
-                .${OVERLAY_SCROLL_LOCK_CLASSNAME} {
-                    position: fixed;
-                    top: var(${SCROLL_POSITION_VAR}, 0);
-                    bottom: 0;
-                }
+				.${OVERLAY_SCROLL_LOCK_CLASSNAME} {
+					position: fixed;
+					top: var(${SCROLL_POSITION_VAR}, 0);
+					bottom: 0;
+				}
 			`;
 
             document.body.appendChild(overlayStyleSheet);


### PR DESCRIPTION
**Changes**

- [delete] branch

The existing scroll lock method was not working for iOS. This solution works by setting the content to `position: fixed`. As a side effect this causes the scroll position to reset, so additional logic to restore the scroll position on close is required.

As a bonus, this causes page content that was visible in the bottom tab bar to be hidden as well (after the iOS 26 Safari UI changes)

Other alternative solutions tested:
- `overscroll-behaviour`: works only if container is scrollable
- `touchmove`: referencing react-aria's [usePreventScroll](https://github.com/adobe/react-spectrum/blob/main/packages/%40react-aria/overlays/src/usePreventScroll.ts) - too complex

<!-- Remove if not required -->
**Changelog entry**

- **[WARNING]** Add alternative scroll lock method on iOS for `Overlay` and `Modal`