### PR TITLE
[MISC][XY] Add padding to ActionBar floating state

### DIFF
--- a/src/data-table/data-table.styles.tsx
+++ b/src/data-table/data-table.styles.tsx
@@ -1,7 +1,15 @@
 import styled, { css } from "styled-components";
 import { BasicButton } from "../shared/input-wrapper";
 import { lineClampCss } from "../shared/styles";
-import { Border, Colour, Font, Motion, Radius, Shadow } from "../theme";
+import {
+    Border,
+    Colour,
+    Font,
+    Motion,
+    Radius,
+    Shadow,
+    Spacing,
+} from "../theme";
 import { Typography } from "../typography";
 
 // =============================================================================
@@ -145,23 +153,28 @@ export const TextButton = styled(BasicButton)`
 export const ActionBar = styled.div<ActionBarProps>`
     overflow: hidden;
     display: flex;
-    ${(props) =>
-        props.$float &&
-        css`
-            transform: translateX(-0.5%) translateY(-2rem);
-            border-radius: ${Radius["sm"]};
-            box-shadow: ${Shadow["xs-subtle"]};
-            width: 101%;
-            border: ${Border["width-010"]} ${Border["solid"]} ${borderColor};
-        `}
     align-items: center;
     height: 3.5rem;
-    padding: 1rem;
+    padding: ${Spacing["spacing-16"]} ${Spacing["spacing-24"]};
     border-top: ${Border["width-010"]} ${Border["solid"]} ${borderColor};
-    border-radius: ${Radius["none"]} ${Radius["none"]} ${Radius["sm"]}
-        ${Radius["sm"]};
     background-color: ${Colour["bg-selected"]};
     transition: all 300ms ease;
+    ${(props) => {
+        if (props.$float) {
+            return css`
+                transform: translateX(0.5rem) translateY(-2rem);
+                border-radius: ${Radius["sm"]};
+                box-shadow: ${Shadow["xs-subtle"]};
+                width: calc(100% - ${Spacing["spacing-16"]});
+                border: ${Border["width-010"]} ${Border["solid"]} ${borderColor};
+            `;
+        } else {
+            return css`
+                border-radius: ${Radius["none"]} ${Radius["none"]}
+                    ${Radius["sm"]} ${Radius["sm"]};
+            `;
+        }
+    }}
 `;
 
 export const HeaderRow = styled.tr`


### PR DESCRIPTION
**Changes**
- Add padding left and right to floating bulk action bar
- Adjust action bar's inner padding to match figma

- [delete] branch

**Additional information**

- You may refer to this [figma](https://www.figma.com/design/ogjcWG1exm8T3Ns9uB8HV6/%F0%9F%99%8C--PO--BSG-2.0-%E2%80%94-Admin-Portal?node-id=42971-141535&t=KtwNNLILHCwRzrMO-0) for mock up
