### PR TITLE
Prefix scrollbar selectors to fix missing styles

### DIFF
--- a/src/data-table/data-table.styles.tsx
+++ b/src/data-table/data-table.styles.tsx
@@ -66,7 +66,7 @@ export const TableWrapper = styled.div`
     border-radius: ${Radius["md"]};
 
     // Hide scrollbar
-    ::-webkit-scrollbar {
+    &::-webkit-scrollbar {
         display: none;
     }
     * {

--- a/src/popover-v2/popover.styles.tsx
+++ b/src/popover-v2/popover.styles.tsx
@@ -64,7 +64,7 @@ export const MobileModalBox = styled(ModalBox)`
 export const ContentWrapper = styled.div`
     overflow-y: scroll;
 
-    ::-webkit-scrollbar {
+    &::-webkit-scrollbar {
         display: none; /* Chrome/Safari/Webkit */
     }
 

--- a/src/popover/popover.styles.tsx
+++ b/src/popover/popover.styles.tsx
@@ -126,7 +126,7 @@ export const HOCTrigger = styled.button`
 export const ContentWrapper = styled.div`
     overflow-y: scroll;
 
-    ::-webkit-scrollbar {
+    &::-webkit-scrollbar {
         display: none; /* Chrome/Safari/Webkit */
     }
 `;

--- a/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-list.styles.tsx
@@ -76,15 +76,15 @@ export const Container = styled.div<ContainerStyleProps>`
         width: calc(100vw - ${Breakpoint["xxs-margin"]} * 2);
     }
 
-    ::-webkit-scrollbar {
+    &::-webkit-scrollbar {
         width: 14px;
     }
 
-    ::-webkit-scrollbar-track {
+    &::-webkit-scrollbar-track {
         background: transparent;
     }
 
-    ::-webkit-scrollbar-thumb {
+    &::-webkit-scrollbar-thumb {
         background: ${Colour["bg-inverse-subtlest"]};
         border: 5px solid transparent;
         border-radius: ${Radius["full"]};

--- a/src/shared/dropdown-list/dropdown-list.styles.tsx
+++ b/src/shared/dropdown-list/dropdown-list.styles.tsx
@@ -62,15 +62,15 @@ export const List = styled.ul<ListContainerProps>`
     padding: ${Spacing["spacing-8"]};
     list-style-type: none;
 
-    ::-webkit-scrollbar {
+    &::-webkit-scrollbar {
         width: 14px;
     }
 
-    ::-webkit-scrollbar-track {
+    &::-webkit-scrollbar-track {
         background: transparent;
     }
 
-    ::-webkit-scrollbar-thumb {
+    &::-webkit-scrollbar-thumb {
         background: ${Colour["bg-inverse-subtlest"]};
         border: 5px solid transparent;
         border-radius: ${Radius["full"]};

--- a/src/shared/fade-wrapper/fade-wrapper.style.tsx
+++ b/src/shared/fade-wrapper/fade-wrapper.style.tsx
@@ -85,7 +85,7 @@ export const Content = styled.div`
     white-space: nowrap;
     scrollbar-width: none; /* Firefox */
     -ms-overflow-style: none; /* IE 10+ */
-    ::-webkit-scrollbar {
+    &::-webkit-scrollbar {
         display: none; /* Chrome/Safari/Webkit */
     }
 `;


### PR DESCRIPTION
**Changes**

Add missing `&` for scrollbar selectors after styled components 6 upgrade

Only affecting two components, the rest still preview nicely

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Restore scrollbar styles in DataTable and Select pickers
