### PR TITLE
[MISC][NT] Fix sidenav item hover highlight

### DIFF
--- a/src/sidenav/sidenav-item.tsx
+++ b/src/sidenav/sidenav-item.tsx
@@ -163,6 +163,10 @@ export const SidenavItem = ({
         setCurrentItem({ itemId: id, content: children });
     };
 
+    const handleMouseLeave = () => {
+        !isOpen && setCurrentItem(undefined);
+    };
+
     const handleDismiss = () => {
         setCurrentItem((current) => {
             if (current?.itemId === id) {
@@ -195,6 +199,7 @@ export const SidenavItem = ({
                 {...otherProps}
                 $highlight={isSelected || isCurrent}
                 {...getReferenceProps()}
+                onMouseLeave={handleMouseLeave}
             >
                 <IconContainer aria-hidden>{icon}</IconContainer>
                 <TitleText inline>{title}</TitleText>


### PR DESCRIPTION
**Changes**
Fix sidenav hover highlight persisting even after cursor leaves the sidenav item. highlight will persist if there is a drawer on that item.

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Fix `Sidenav` hover highlight persisting even after cursor leaves the sidenav item

