### PR TITLE
Accessible label for PhoneNumberInput

### DIFF
--- a/src/form/form-input-group.tsx
+++ b/src/form/form-input-group.tsx
@@ -37,10 +37,11 @@ const Component = <T, V>(
     return (
         <FormWrapper
             id={inputId}
+            data-testid={testId}
             label={label}
             errorMessage={errorMessage}
-            disabled={otherProps.disabled}
             data-error-testid={errorTestId}
+            disabled={otherProps.disabled}
             layoutType={layoutType}
             mobileCols={mobileCols}
             tabletCols={tabletCols}
@@ -57,6 +58,7 @@ const Component = <T, V>(
                 ref={ref}
                 id={`${inputId}-base`}
                 data-testid={testId ? `${testId}-base` : undefined}
+                aria-labelledby={`${inputId}-label`}
                 error={!!errorMessage}
                 {...otherProps}
             />

--- a/src/form/form-phone-number-input.tsx
+++ b/src/form/form-phone-number-input.tsx
@@ -1,11 +1,13 @@
+import { useState } from "react";
 import { PhoneNumberInput } from "../phone-number-input/phone-number-input";
+import { SimpleIdGenerator } from "../util";
 import { FormWrapper } from "./form-wrapper";
 import { FormPhoneNumberInputProps } from "./types";
 
 export const FormPhoneNumberInput = ({
     label,
     errorMessage,
-    id = "form-phone-number-input",
+    id,
     "data-error-testid": errorTestId,
     "data-testid": testId,
     layoutType,
@@ -21,9 +23,15 @@ export const FormPhoneNumberInput = ({
     xxlCols,
     ...otherProps
 }: FormPhoneNumberInputProps): JSX.Element => {
+    const [internalId] = useState(
+        () => `form-phone-number-input-${SimpleIdGenerator.generate()}`
+    );
+    const inputId = id ?? internalId;
+
     return (
         <FormWrapper
-            id={id}
+            id={inputId}
+            data-testid={testId}
             label={label}
             errorMessage={errorMessage}
             data-error-testid={errorTestId}
@@ -41,8 +49,9 @@ export const FormPhoneNumberInput = ({
             xxlCols={xxlCols}
         >
             <PhoneNumberInput
-                id={`${id}-base`}
-                data-testid={testId || id}
+                id={`${inputId}-base`}
+                data-testid={testId ? `${testId}-base` : undefined}
+                aria-labelledby={`${inputId}-label`}
                 error={!!errorMessage}
                 {...otherProps}
             />

--- a/src/input-group/input-group-list-addon.style.tsx
+++ b/src/input-group/input-group-list-addon.style.tsx
@@ -72,6 +72,7 @@ export const SelectorReadOnly = styled.div`
     padding: 0;
     background: transparent;
     margin-right: ${Spacing["spacing-12"]};
+    color: ${Colour["text"]};
 `;
 
 export const Divider = styled.div<DividerStyleProps>`

--- a/src/input-group/input-group-list-addon.tsx
+++ b/src/input-group/input-group-list-addon.tsx
@@ -248,7 +248,17 @@ export const Component = <T, V>(
     const renderSelector = () => {
         if (readOnly) {
             return selected ? (
-                <SelectorReadOnly data-testid="selector-label">
+                <SelectorReadOnly
+                    data-testid="selector-label"
+                    tabIndex={0}
+                    role="combobox"
+                    aria-haspopup="listbox"
+                    aria-readonly
+                    aria-expanded={false}
+                    aria-labelledby={ariaLabelledBy}
+                    aria-describedby={ariaDescribedBy}
+                    aria-invalid={ariaInvalid}
+                >
                     <ValueLabel>{getDisplayValue()}</ValueLabel>
                 </SelectorReadOnly>
             ) : null;

--- a/src/input-group/input-group-list-addon.tsx
+++ b/src/input-group/input-group-list-addon.tsx
@@ -1,5 +1,6 @@
 import { OpenChangeReason } from "@floating-ui/react";
 import React, { useEffect, useRef, useState } from "react";
+import { VisuallyHidden, concatIds } from "../shared/accessibility";
 import {
     DropdownList,
     DropdownListState,
@@ -31,6 +32,9 @@ export const Component = <T, V>(
         className,
         onBlur,
         "data-testid": testId,
+        "aria-labelledby": ariaLabelledBy,
+        "aria-describedby": ariaDescribedBy,
+        "aria-invalid": ariaInvalid,
         ...otherProps
     }: InputGroupProps<T, V>,
     ref: React.Ref<HTMLInputElement>
@@ -71,6 +75,8 @@ export const Component = <T, V>(
     const [showOptions, setShowOptions] = useState<boolean>(false);
     const [focused, setFocused] = useState<boolean>(false);
     const [internalId] = useState<string>(() => SimpleIdGenerator.generate());
+    const listboxId = `${internalId}-listbox`;
+    const instructionId = `${internalId}-instruction`;
 
     const nodeRef = useRef<HTMLDivElement>(null);
     const positionRef = useRef<HTMLDivElement>(null);
@@ -199,12 +205,18 @@ export const Component = <T, V>(
                     ref={selectorRef}
                     disabled={disabled}
                     expanded={showOptions}
-                    listboxId={internalId}
+                    listboxId={listboxId}
                     popupRole="listbox"
                     readOnly={readOnly}
+                    aria-labelledby={ariaLabelledBy}
+                    aria-describedby={concatIds(ariaDescribedBy, instructionId)}
+                    aria-invalid={ariaInvalid}
                 >
                     {renderSelectorContent()}
                 </ExpandableElement>
+                <VisuallyHidden id={instructionId}>
+                    Press space to open options
+                </VisuallyHidden>
             </div>
         );
     };
@@ -212,7 +224,7 @@ export const Component = <T, V>(
     const renderDropdown = () => {
         return (
             <DropdownList
-                listboxId={internalId}
+                listboxId={listboxId}
                 listItems={options}
                 onSelectItem={handleListItemClick}
                 onDismiss={handleListDismiss}
@@ -288,6 +300,9 @@ export const Component = <T, V>(
                     onChange={handleInputChange}
                     data-testid="input"
                     styleType="no-border"
+                    aria-labelledby={ariaLabelledBy}
+                    aria-describedby={ariaDescribedBy}
+                    aria-invalid={ariaInvalid}
                 />
             </FieldWrapper>
         </DropdownListState>

--- a/src/input-group/input-group-list-addon.tsx
+++ b/src/input-group/input-group-list-addon.tsx
@@ -35,6 +35,7 @@ export const Component = <T, V>(
         "aria-labelledby": ariaLabelledBy,
         "aria-describedby": ariaDescribedBy,
         "aria-invalid": ariaInvalid,
+        "aria-label": textboxAriaLabel,
         ...otherProps
     }: InputGroupProps<T, V>,
     ref: React.Ref<HTMLInputElement>
@@ -64,6 +65,7 @@ export const Component = <T, V>(
         onShowOptions,
         dropdownZIndex,
         dropdownRootNode,
+        "aria-label": comboboxAriaLabel,
     } = addon!.attributes as ListAddon<T, V>;
 
     const { position } = addon!;
@@ -77,6 +79,8 @@ export const Component = <T, V>(
     const [internalId] = useState<string>(() => SimpleIdGenerator.generate());
     const listboxId = `${internalId}-listbox`;
     const instructionId = `${internalId}-instruction`;
+    const comboboxLabelId = `${internalId}-combobox-label`;
+    const textboxLabelId = `${internalId}-textbox-label`;
 
     const nodeRef = useRef<HTMLDivElement>(null);
     const positionRef = useRef<HTMLDivElement>(null);
@@ -208,7 +212,7 @@ export const Component = <T, V>(
                     listboxId={listboxId}
                     popupRole="listbox"
                     readOnly={readOnly}
-                    aria-labelledby={ariaLabelledBy}
+                    aria-labelledby={concatIds(ariaLabelledBy, comboboxLabelId)}
                     aria-describedby={concatIds(ariaDescribedBy, instructionId)}
                     aria-invalid={ariaInvalid}
                 >
@@ -296,10 +300,16 @@ export const Component = <T, V>(
                 className={className}
                 data-testid={testId}
             >
+                <VisuallyHidden aria-hidden id={comboboxLabelId}>
+                    {comboboxAriaLabel}
+                </VisuallyHidden>
                 <FieldSelector data-testid={selectorTestId}>
                     {renderSelector()}
                 </FieldSelector>
                 <Divider $readOnly={readOnly} $position={position} />
+                <VisuallyHidden aria-hidden id={textboxLabelId}>
+                    {textboxAriaLabel}
+                </VisuallyHidden>
                 <FieldInput
                     ref={ref}
                     {...otherProps}
@@ -310,7 +320,7 @@ export const Component = <T, V>(
                     onChange={handleInputChange}
                     data-testid="input"
                     styleType="no-border"
-                    aria-labelledby={ariaLabelledBy}
+                    aria-labelledby={concatIds(ariaLabelledBy, textboxLabelId)}
                     aria-describedby={ariaDescribedBy}
                     aria-invalid={ariaInvalid}
                 />

--- a/src/input-group/types.ts
+++ b/src/input-group/types.ts
@@ -24,6 +24,7 @@ export interface ListAddon<T, V>
     placeholder?: string | undefined;
     displayValueExtractor?: ((item: T) => string) | undefined;
     "data-selector-testid"?: string | undefined;
+    "aria-label"?: string | undefined;
 
     // Dropdown props (unable to inherit directly)
     options?: T[] | undefined;

--- a/src/phone-number-input/phone-number-input.tsx
+++ b/src/phone-number-input/phone-number-input.tsx
@@ -132,6 +132,7 @@ export const PhoneNumberInput = ({
             return {
                 type: "list",
                 attributes: {
+                    "aria-label": "Country code",
                     placeholder: optionPlaceholder,
                     options,
                     selectedOption: selectedCountry,
@@ -166,6 +167,7 @@ export const PhoneNumberInput = ({
             addon={getAddonProps()}
             inputMode="numeric"
             autoComplete={autoComplete}
+            aria-label="Enter phone number"
             {...otherProps}
         />
     );

--- a/src/shared/accessibility/index.ts
+++ b/src/shared/accessibility/index.ts
@@ -21,3 +21,7 @@ export const inertValue = (value: boolean | undefined) => {
 
     return value ? "true" : undefined;
 };
+
+export const concatIds = (...selectors: (string | undefined)[]) => {
+    return selectors.filter((selector) => !!selector).join(" ");
+};

--- a/src/shared/dropdown-list-v2/expandable-element.tsx
+++ b/src/shared/dropdown-list-v2/expandable-element.tsx
@@ -3,7 +3,11 @@ import { AriaAttributes, Ref, forwardRef } from "react";
 import { IconContainer, Selector } from "./expandable-element.styles";
 import { DropdownVariantType } from "./types";
 
-interface ExpandableElementProps {
+interface ExpandableElementProps
+    extends Pick<
+        AriaAttributes,
+        "aria-labelledby" | "aria-describedby" | "aria-invalid"
+    > {
     children: React.ReactNode;
     disabled: boolean | undefined;
     expanded: boolean | undefined;
@@ -22,6 +26,7 @@ export const Component = (
         popupRole,
         readOnly,
         variant,
+        ...otherProps
     }: ExpandableElementProps,
     ref: Ref<HTMLButtonElement>
 ) => {
@@ -32,13 +37,15 @@ export const Component = (
         <Selector
             ref={ref}
             type="button"
+            role="combobox"
             aria-expanded={expanded}
             aria-haspopup={popupRole}
+            aria-controls={expanded ? listboxId : undefined} // only apply when dropdown is mounted
             data-testid="selector"
             disabled={disabled}
-            aria-controls={listboxId}
             $variant={variant}
             $readOnly={readOnly}
+            {...otherProps}
         >
             {children}
             {!readOnly && (

--- a/src/shared/dropdown-list-v2/expandable-element.tsx
+++ b/src/shared/dropdown-list-v2/expandable-element.tsx
@@ -42,7 +42,8 @@ export const Component = (
             aria-haspopup={popupRole}
             aria-controls={expanded ? listboxId : undefined} // only apply when dropdown is mounted
             data-testid="selector"
-            disabled={disabled}
+            aria-disabled={disabled}
+            aria-readonly={readOnly}
             $variant={variant}
             $readOnly={readOnly}
             {...otherProps}

--- a/tests/input-group/input-group-list-addon.spec.tsx
+++ b/tests/input-group/input-group-list-addon.spec.tsx
@@ -1,6 +1,7 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { InputGroup } from "../../src/input-group";
+import { Form } from "src/form";
+import { InputGroup } from "src/input-group";
 import { waitForElementToBeRemoved } from "../common/waitForElementRemoved";
 
 const FIELD_TESTID = "test";
@@ -9,6 +10,10 @@ const SELECTOR_TESTID = "selector";
 const SELECTOR_LABEL_TESTID = "selector-label";
 const DROPDOWN_TESTID = "dropdown-list";
 const OPTIONS = ["Option 1", "Option 2", "Option 3"];
+const LABEL = "Test label";
+const DESCRIPTION = "Test subtitle";
+const DROPDOWN_INSTRUCTION = "Press space to open options";
+const ERROR = "Error message";
 
 describe("InputGroup - List addon", () => {
     beforeEach(() => {
@@ -470,6 +475,89 @@ describe("InputGroup - List addon", () => {
             expect(
                 screen.queryByTestId(DROPDOWN_TESTID)
             ).not.toBeInTheDocument();
+        });
+    });
+
+    describe("accessible names", () => {
+        it("should apply the correct label", () => {
+            render(
+                <Form.InputGroup
+                    label={LABEL}
+                    addon={{
+                        type: "list",
+                        attributes: {
+                            options: OPTIONS,
+                        },
+                    }}
+                />
+            );
+
+            expect(
+                screen.getByRole("combobox", {
+                    name: LABEL,
+                    description: DROPDOWN_INSTRUCTION,
+                })
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole("textbox", {
+                    name: LABEL,
+                })
+            ).toBeInTheDocument();
+        });
+
+        it("should apply the correct label and description", () => {
+            render(
+                <Form.InputGroup
+                    label={{ children: LABEL, subtitle: DESCRIPTION }}
+                    addon={{
+                        type: "list",
+                        attributes: {
+                            options: OPTIONS,
+                        },
+                    }}
+                />
+            );
+
+            expect(
+                screen.getByRole("combobox", {
+                    name: LABEL,
+                    description: `${DESCRIPTION} ${DROPDOWN_INSTRUCTION}`,
+                })
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole("textbox", {
+                    name: LABEL,
+                    description: DESCRIPTION,
+                })
+            ).toBeInTheDocument();
+        });
+
+        it("should apply the error state and error description", () => {
+            render(
+                <Form.InputGroup
+                    label={{ children: LABEL, subtitle: DESCRIPTION }}
+                    errorMessage={ERROR}
+                    addon={{
+                        type: "list",
+                        attributes: {
+                            options: OPTIONS,
+                        },
+                    }}
+                />
+            );
+
+            const combobox = screen.getByRole("combobox", {
+                name: LABEL,
+                description: `${ERROR} ${DESCRIPTION} ${DROPDOWN_INSTRUCTION}`,
+            });
+            const textbox = screen.getByRole("textbox", {
+                name: LABEL,
+                description: `${ERROR} ${DESCRIPTION}`,
+            });
+            expect(combobox).toBeInTheDocument();
+            expect(combobox).toBeInvalid();
+            expect(textbox).toBeInTheDocument();
+            expect(textbox).toBeInvalid();
         });
     });
 });

--- a/tests/phone-number-input/phone-number-input.spec.tsx
+++ b/tests/phone-number-input/phone-number-input.spec.tsx
@@ -6,7 +6,9 @@ const INPUT_TESTID = "input";
 const SELECTOR_TESTID = "selector";
 const LABEL = "Test label";
 const DESCRIPTION = "Test subtitle";
+const DROPDOWN_LABEL = `${LABEL} Country code`;
 const DROPDOWN_INSTRUCTION = "Press space to open options";
+const TEXTBOX_LABEL = `${LABEL} Enter phone number`;
 const ERROR = "Error message";
 
 // =============================================================================
@@ -95,13 +97,13 @@ describe("PhoneNumberInput", () => {
 
             expect(
                 screen.getByRole("combobox", {
-                    name: LABEL,
+                    name: DROPDOWN_LABEL,
                     description: DROPDOWN_INSTRUCTION,
                 })
             ).toBeInTheDocument();
             expect(
                 screen.getByRole("textbox", {
-                    name: LABEL,
+                    name: TEXTBOX_LABEL,
                 })
             ).toBeInTheDocument();
         });
@@ -115,13 +117,13 @@ describe("PhoneNumberInput", () => {
 
             expect(
                 screen.getByRole("combobox", {
-                    name: LABEL,
+                    name: DROPDOWN_LABEL,
                     description: `${DESCRIPTION} ${DROPDOWN_INSTRUCTION}`,
                 })
             ).toBeInTheDocument();
             expect(
                 screen.getByRole("textbox", {
-                    name: LABEL,
+                    name: TEXTBOX_LABEL,
                     description: DESCRIPTION,
                 })
             ).toBeInTheDocument();
@@ -136,11 +138,11 @@ describe("PhoneNumberInput", () => {
             );
 
             const combobox = screen.getByRole("combobox", {
-                name: LABEL,
+                name: DROPDOWN_LABEL,
                 description: `${ERROR} ${DESCRIPTION} ${DROPDOWN_INSTRUCTION}`,
             });
             const textbox = screen.getByRole("textbox", {
-                name: LABEL,
+                name: TEXTBOX_LABEL,
                 description: `${ERROR} ${DESCRIPTION}`,
             });
             expect(combobox).toBeInTheDocument();

--- a/tests/phone-number-input/phone-number-input.spec.tsx
+++ b/tests/phone-number-input/phone-number-input.spec.tsx
@@ -1,8 +1,13 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import { Form } from "src/form";
 import { PhoneNumberInput } from "src/phone-number-input";
 
 const INPUT_TESTID = "input";
 const SELECTOR_TESTID = "selector";
+const LABEL = "Test label";
+const DESCRIPTION = "Test subtitle";
+const DROPDOWN_INSTRUCTION = "Press space to open options";
+const ERROR = "Error message";
 
 // =============================================================================
 // UNIT TESTS
@@ -81,6 +86,67 @@ describe("PhoneNumberInput", () => {
 
             expect(input).toHaveValue("(12");
             expect(inputSpy).toHaveBeenCalledWith(2, 2);
+        });
+    });
+
+    describe("accessible names", () => {
+        it("should apply the correct label", () => {
+            render(<Form.PhoneNumberInput label={LABEL} />);
+
+            expect(
+                screen.getByRole("combobox", {
+                    name: LABEL,
+                    description: DROPDOWN_INSTRUCTION,
+                })
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole("textbox", {
+                    name: LABEL,
+                })
+            ).toBeInTheDocument();
+        });
+
+        it("should apply the correct label and description", () => {
+            render(
+                <Form.PhoneNumberInput
+                    label={{ children: LABEL, subtitle: DESCRIPTION }}
+                />
+            );
+
+            expect(
+                screen.getByRole("combobox", {
+                    name: LABEL,
+                    description: `${DESCRIPTION} ${DROPDOWN_INSTRUCTION}`,
+                })
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole("textbox", {
+                    name: LABEL,
+                    description: DESCRIPTION,
+                })
+            ).toBeInTheDocument();
+        });
+
+        it("should apply the error state and error description", () => {
+            render(
+                <Form.PhoneNumberInput
+                    label={{ children: LABEL, subtitle: DESCRIPTION }}
+                    errorMessage={ERROR}
+                />
+            );
+
+            const combobox = screen.getByRole("combobox", {
+                name: LABEL,
+                description: `${ERROR} ${DESCRIPTION} ${DROPDOWN_INSTRUCTION}`,
+            });
+            const textbox = screen.getByRole("textbox", {
+                name: LABEL,
+                description: `${ERROR} ${DESCRIPTION}`,
+            });
+            expect(combobox).toBeInTheDocument();
+            expect(combobox).toBeInvalid();
+            expect(textbox).toBeInTheDocument();
+            expect(textbox).toBeInvalid();
         });
     });
 });


### PR DESCRIPTION
**Changes**

- Update label + description association for PhoneNumberInput (which is dependent on InputGroup list variant)
- Retain the country code's combobox semantics even when readonly, so that it remains exposed to the screen reader in form mode
- Keyboard navigation will be covered separately as it affects a shared component and the requirements are pending confirmation
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

New
- Improve accessibility of `PhoneNumberInput` and `InputGroup` list variant

Style fix
- Fix unreadable text in dark mode for readonly InputGroup and PhoneNumberInput

**Additional info**
- [Figma](https://www.figma.com/design/wDAxbRmlq4xOn4UJ8zPuEF/%F0%9F%A7%91%F0%9F%8F%BB%E2%80%8D%F0%9F%A6%AF-Flagship-A11y-Annotations?node-id=2069-801&p=f&m=dev)