### PR TITLE
Ensure iOS scroll lock is cleaned up on forced unmount

### DIFF
--- a/src/overlay/overlay.tsx
+++ b/src/overlay/overlay.tsx
@@ -53,6 +53,8 @@ const OverlayComponent = ({
         return () => {
             removeOverlay();
             if (getOverlayOrder().length < 1) {
+                applyScrollLockClass("remove");
+                scrollToLastScrollPosition();
                 applyBodyStyleClass("remove");
             }
         };
@@ -236,7 +238,7 @@ const OverlayComponent = ({
     // =============================================================================
     const handleWrapperClick = (event: React.MouseEvent<HTMLDivElement>) => {
         const modal = childRef.current?.firstChild;
-        if (modal && (modal as any).contains(event.target)) {
+        if (modal && (modal as Node).contains(event.target as Node)) {
             return;
         } else if (onOverlayClick && enableOverlayClick) {
             event.preventDefault();

--- a/tests/overlay/overlay.spec.tsx
+++ b/tests/overlay/overlay.spec.tsx
@@ -1,0 +1,256 @@
+import { render, waitFor } from "@testing-library/react";
+import { Overlay } from "../../src/overlay";
+import { SimpleIdGenerator } from "../../src/util";
+
+// =============================================================================
+// UNIT TESTS
+// =============================================================================
+describe("Overlay", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        Object.defineProperty(window, "scrollTo", {
+            value: jest.fn(),
+            writable: true,
+        });
+        jest.spyOn(window.navigator, "userAgent", "get").mockReturnValue(
+            "Android"
+        );
+        jest.spyOn(SimpleIdGenerator, "generate").mockReturnValue("id");
+    });
+
+    describe("scroll lock for non-iOS devices", () => {
+        it("should apply scroll lock when overlay is visible", async () => {
+            render(
+                <Overlay show>
+                    <div data-testid="test-content" />
+                </Overlay>
+            );
+
+            await waitFor(async () => {
+                // assert overlay style is rendered
+                expect([...document.body.classList.values()]).toEqual([
+                    "lifesg-ds-overlay-open",
+                ]);
+
+                // assert overlay is tracked
+                expect(document.body.dataset.lifesgDsOverlayOrder).toEqual(
+                    "id"
+                );
+            });
+        });
+
+        it("should clean up scroll lock on show=false", async () => {
+            const { rerender } = render(
+                <Overlay show>
+                    <div data-testid="test-content" />
+                </Overlay>
+            );
+
+            await waitFor(async () => {
+                // assert overlay style is rendered
+                expect([...document.body.classList.values()]).toEqual([
+                    "lifesg-ds-overlay-open",
+                ]);
+
+                // assert overlay is tracked
+                expect(document.body.dataset.lifesgDsOverlayOrder).toEqual(
+                    "id"
+                );
+            });
+
+            rerender(
+                <Overlay show={false}>
+                    <div data-testid="test-content" />
+                </Overlay>
+            );
+
+            await waitFor(async () => {
+                expect([...document.body.classList.values()]).toEqual([]);
+                expect(document.body.dataset.lifesgDsOverlayOrder).toEqual("");
+            });
+        });
+
+        it("should clean up scroll lock on unmount", async () => {
+            const { rerender } = render(
+                <Overlay show>
+                    <div data-testid="test-content" />
+                </Overlay>
+            );
+
+            await waitFor(async () => {
+                // assert overlay style is rendered
+                expect([...document.body.classList.values()]).toEqual([
+                    "lifesg-ds-overlay-open",
+                ]);
+
+                // assert overlay is tracked
+                expect(document.body.dataset.lifesgDsOverlayOrder).toEqual(
+                    "id"
+                );
+            });
+
+            rerender(<></>);
+
+            await waitFor(async () => {
+                expect([...document.body.classList.values()]).toEqual([]);
+                expect(document.body.dataset.lifesgDsOverlayOrder).toEqual("");
+            });
+        });
+    });
+
+    describe("scroll lock for iOS devices", () => {
+        beforeEach(() => {
+            jest.spyOn(window.navigator, "userAgent", "get").mockReturnValue(
+                "iPhone"
+            );
+        });
+
+        it("should apply advanced scroll lock for iOS devices when overlay is visible", async () => {
+            render(
+                <Overlay show>
+                    <div data-testid="test-content" />
+                </Overlay>
+            );
+
+            await waitFor(async () => {
+                // assert overlay style is rendered
+                expect([...document.body.classList.values()]).toEqual([
+                    "lifesg-ds-overlay-scroll-lock",
+                    "lifesg-ds-overlay-open",
+                ]);
+
+                // assert overlay is tracked
+                expect(document.body.dataset.lifesgDsOverlayOrder).toEqual(
+                    "id"
+                );
+            });
+        });
+
+        it("should clean up scroll lock on show=false", async () => {
+            const { rerender } = render(
+                <Overlay show>
+                    <div data-testid="test-content" />
+                </Overlay>
+            );
+
+            await waitFor(async () => {
+                // assert overlay style is rendered
+                expect([...document.body.classList.values()]).toEqual([
+                    "lifesg-ds-overlay-scroll-lock",
+                    "lifesg-ds-overlay-open",
+                ]);
+
+                // assert overlay is tracked
+                expect(document.body.dataset.lifesgDsOverlayOrder).toEqual(
+                    "id"
+                );
+            });
+
+            rerender(
+                <Overlay show={false}>
+                    <div data-testid="test-content" />
+                </Overlay>
+            );
+
+            await waitFor(async () => {
+                expect([...document.body.classList.values()]).toEqual([]);
+                expect(document.body.dataset.lifesgDsOverlayOrder).toEqual("");
+            });
+        });
+
+        it("should clean up scroll lock on unmount", async () => {
+            const { rerender } = render(
+                <Overlay show>
+                    <div data-testid="test-content" />
+                </Overlay>
+            );
+
+            await waitFor(async () => {
+                // assert overlay style is rendered
+                expect([...document.body.classList.values()]).toEqual([
+                    "lifesg-ds-overlay-scroll-lock",
+                    "lifesg-ds-overlay-open",
+                ]);
+
+                // assert overlay is tracked
+                expect(document.body.dataset.lifesgDsOverlayOrder).toEqual(
+                    "id"
+                );
+            });
+
+            rerender(<></>);
+
+            await waitFor(async () => {
+                expect([...document.body.classList.values()]).toEqual([]);
+                expect(document.body.dataset.lifesgDsOverlayOrder).toEqual("");
+            });
+        });
+    });
+
+    it("should manage multiple overlays", async () => {
+        jest.spyOn(SimpleIdGenerator, "generate")
+            .mockReturnValueOnce("id-1")
+            .mockReturnValueOnce("id-2");
+
+        const { rerender } = render(
+            <>
+                <Overlay show={false}>
+                    <div data-testid="test-content" />
+                </Overlay>
+                <Overlay show={false}>
+                    <div data-testid="test-content" />
+                </Overlay>
+            </>
+        );
+
+        rerender(
+            <>
+                <Overlay show={true}>
+                    <div data-testid="test-content" />
+                </Overlay>
+                <Overlay show={false}>
+                    <div data-testid="test-content" />
+                </Overlay>
+            </>
+        );
+
+        await waitFor(async () => {
+            expect([...document.body.classList.values()]).toEqual([
+                "lifesg-ds-overlay-open",
+            ]);
+            expect(document.body.dataset.lifesgDsOverlayOrder).toEqual("id-1");
+        });
+
+        rerender(
+            <>
+                <Overlay show={true}>
+                    <div data-testid="test-content" />
+                </Overlay>
+                <Overlay show={true}>
+                    <div data-testid="test-content" />
+                </Overlay>
+            </>
+        );
+
+        await waitFor(async () => {
+            expect(document.body.dataset.lifesgDsOverlayOrder).toEqual(
+                "id-1,id-2"
+            );
+        });
+
+        rerender(
+            <>
+                <Overlay show={false}>
+                    <div data-testid="test-content" />
+                </Overlay>
+                <Overlay show={true}>
+                    <div data-testid="test-content" />
+                </Overlay>
+            </>
+        );
+
+        await waitFor(async () => {
+            expect(document.body.dataset.lifesgDsOverlayOrder).toEqual("id-2");
+        });
+    });
+});


### PR DESCRIPTION
**Changes**

- a11y playground team reported that the iOS scroll lock was being applied on some pages even though the overlay is not being displayed
- reason is that the page was conditionally rendering a `Overlay`-backed component rather than toggling the `show` flag
- to be safe, we should also clean up the scroll lock for any unmounts
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Fix persistent iOS scroll lock when modal is forcefully unmounted