### PR TITLE
Let SGDS masthead stretch full-width

### DIFF
--- a/src/masthead/masthead.style.tsx
+++ b/src/masthead/masthead.style.tsx
@@ -16,6 +16,7 @@ export const Wrapper = styled.div<WrapperStyleProps>`
     ${(props) => {
         if (props.$stretch) {
             return css`
+                --sgds-mainnav-max-width: calc(infinity * 1px);
                 --sgds-mainnav-padding-x: ${Breakpoint["xxl-margin"]}px;
                 --sgds-mainnav-mobile-padding-x: ${Breakpoint["xxl-margin"]}px;
             `;

--- a/stories/navbar/navbar.mdx
+++ b/stories/navbar/navbar.mdx
@@ -91,8 +91,8 @@ In this example, the masthead is hidden.
 
 ## Stretched layout
 
-In this example, the content of the navbar is stretched to the full width of
-the screen with a fixed padding, ignoring the masthead's alignment.
+In this example, the content of the navbar (and masthead, if applicable) is
+stretched to the full width of the screen with a fixed padding.
 
 <Canvas of={NavbarStories.StretchedLayout} />
 


### PR DESCRIPTION
**Changes**

- Set the provided max width variable to a large number
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

Style fix
- Let `Masthead` take up the full width when `stretch` is enabled