### PR TITLE
[CCUBE-2011][XY] Add slash variant to Breadcrumb

### DIFF
--- a/src/breadcrumb/breadcrumb.style.tsx
+++ b/src/breadcrumb/breadcrumb.style.tsx
@@ -107,10 +107,14 @@ export const Item = styled.li<ItemStyleProps>`
 `;
 
 export const Caret = styled(ChevronRightIcon)`
-    margin: ${Spacing["spacing-8"]};
     height: 1em;
     width: 1em;
     color: ${Colour["icon-subtle"]};
+`;
+
+export const Slash = styled(Typography.BodyMD)`
+    display: inline-block;
+    color: ${Colour["text-subtlest"]};
 `;
 
 export const CurrentLabel = styled(Typography.BodyMD)`

--- a/src/breadcrumb/breadcrumb.tsx
+++ b/src/breadcrumb/breadcrumb.tsx
@@ -8,6 +8,7 @@ import {
     Fade,
     Item,
     PreviousLink,
+    Slash,
     Wrapper,
 } from "./breadcrumb.style";
 import { BreadcrumbProps, FadeColorSet } from "./types";
@@ -20,6 +21,7 @@ export const Breadcrumb = ({
     fadePosition = "both",
     itemStyle,
     id,
+    separatorStyle = "chevron",
     ...otherProps
 }: BreadcrumbProps) => {
     // =========================================================================
@@ -137,7 +139,14 @@ export const Breadcrumb = ({
                     })}
                 >
                     {element}
-                    {index < links.length - 1 && <Caret aria-hidden />}
+                    {index < links.length - 1 &&
+                        (separatorStyle === "chevron" ? (
+                            <Caret aria-hidden />
+                        ) : (
+                            <Slash inline aria-hidden>
+                                /
+                            </Slash>
+                        ))}
                 </Item>
             );
         });

--- a/src/breadcrumb/types.ts
+++ b/src/breadcrumb/types.ts
@@ -1,5 +1,7 @@
 export type FadePosition = "left" | "right" | "both";
 
+export type SeparatorStyle = "chevron" | "slash";
+
 export interface FadeColorSet {
     left?: string[] | undefined;
     right?: string[] | undefined;
@@ -10,6 +12,7 @@ export interface BreadcrumbProps {
     fadeColor?: string[] | FadeColorSet | undefined;
     fadePosition?: FadePosition | undefined;
     itemStyle?: string | undefined;
+    separatorStyle?: SeparatorStyle | undefined;
     className?: string | undefined;
     id?: string | undefined;
     "data-testid"?: string | undefined;

--- a/stories/breadcrumb/breadcrumb.mdx
+++ b/stories/breadcrumb/breadcrumb.mdx
@@ -19,6 +19,12 @@ import { Breadcrumb } from "@lifesg/react-design-system/breadcrumb";
 
 <Canvas of={BreadcrumbStories.Default} />
 
+## Variations
+
+The `Breadcrumb` component comes with 2 `separatorStyle` options, with `chevron` as the default.
+
+<Canvas of={BreadcrumbStories.Variations} />
+
 ## Customising the fade color
 
 > Note that the fade effect appears only if the `Breadcrumbs` are compressed and

--- a/stories/breadcrumb/breadcrumb.stories.tsx
+++ b/stories/breadcrumb/breadcrumb.stories.tsx
@@ -53,6 +53,45 @@ export const Default: StoryObj<Component> = {
     },
 };
 
+export const Variations: StoryObj<Component> = {
+    render: (_args) => {
+        return (
+            <>
+                <Breadcrumb
+                    links={[
+                        { children: "Home", href: "https://life.gov.sg" },
+                        {
+                            children: "Link 1",
+                            href: "https://life.gov.sg",
+                        },
+                        {
+                            children: "Link 2",
+                            href: "https://life.gov.sg",
+                        },
+                        { children: "Current page" },
+                    ]}
+                    separatorStyle="chevron"
+                />
+                <Breadcrumb
+                    links={[
+                        { children: "Home", href: "https://life.gov.sg" },
+                        {
+                            children: "Link 1",
+                            href: "https://life.gov.sg",
+                        },
+                        {
+                            children: "Link 2",
+                            href: "https://life.gov.sg",
+                        },
+                        { children: "Current page" },
+                    ]}
+                    separatorStyle="slash"
+                />
+            </>
+        );
+    },
+    decorators: [],
+};
 export const DifferentFadeColors: StoryObj<Component> = {
     render: (_args) => {
         return (

--- a/stories/breadcrumb/props-table.tsx
+++ b/stories/breadcrumb/props-table.tsx
@@ -51,6 +51,12 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["CSS-JS string"],
             },
             {
+                name: "separatorStyle",
+                description: <>Separator style between breadcrumb items</>,
+                propTypes: [`"chevron"`, `"slash"`],
+                defaultValue: `"chevron"`,
+            },
+            {
                 name: "id",
                 description: "The unique id of the component",
                 propTypes: ["string"],


### PR DESCRIPTION
**Changes**
- Add `separatorStyle` prop to allow consumers to choose whether they want to use / or >
- Aligned margin with Figma specs
- Add `Variations` section in stories

- [delete] branch

**Additional information**

- You may refer to this [Figma](https://www.figma.com/design/tHmHQNszVzvIamtZWixjgR/%F0%9F%8C%B1-Flagship-V3-Component-Kit?node-id=2065-529)
