### PR TITLE
[MOL-19961][MA] resolve Android touch event causing date-input to become uneditable

### DIFF
--- a/src/date-input/date-input.tsx
+++ b/src/date-input/date-input.tsx
@@ -65,6 +65,8 @@ export const DateInput = ({
         setCalendarOpen(false);
         setFocused(false);
         performOnBlurHandler();
+
+        setHoveredDate(undefined);
     };
 
     const handleDismiss = () => {
@@ -109,9 +111,7 @@ export const DateInput = ({
             }
 
             // clear hover value for mobile when onMouseLeave={handleMouseLeaveCell} is not triggered due to touch input
-            if (hoveredDate) {
-                setHoveredDate(undefined);
-            }
+            setHoveredDate(undefined);
         }
     };
 


### PR DESCRIPTION
**Changes**

- On Android webview, touch events trigger `onMouseEnter` without reliably firing `onMouseLeave`, causing `hoveredDate` to persist. 
- For `DateInput` with `withButton=false`, `handleSelect` checks `hoveredDate` to determine if it should clear the hover state, but captures stale values due to closure issues.
- Removed `hoveredDate` check, ensuring `handleSelect` always properly clears hover state on date selection.
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Resolve Android webview date input becoming uneditable due to stale hover state in touch events in `DateInput`

**Additional information**

- You may refer to this [MOL-19961](https://sgtechstack.atlassian.net/browse/MOL-19961)
