### PR TITLE
Trigger blur only when entire `InputGroup` list addon is unfocused

### DIFF
--- a/src/input-group/input-group-list-addon.tsx
+++ b/src/input-group/input-group-list-addon.tsx
@@ -83,7 +83,6 @@ export const Component = <T, V>(
     const textboxLabelId = `${internalId}-textbox-label`;
 
     const nodeRef = useRef<HTMLDivElement>(null);
-    const positionRef = useRef<HTMLDivElement>(null);
     const selectorRef = useRef<HTMLButtonElement>(null);
 
     // =============================================================================
@@ -199,12 +198,7 @@ export const Component = <T, V>(
 
     const renderElement = () => {
         return (
-            <div
-                ref={nodeRef}
-                tabIndex={-1}
-                onFocus={handleNodeFocus}
-                onBlur={handleNodeBlur}
-            >
+            <div>
                 <ExpandableElement
                     ref={selectorRef}
                     disabled={disabled}
@@ -282,7 +276,7 @@ export const Component = <T, V>(
                     fitAvailableHeight
                     customZIndex={dropdownZIndex}
                     rootNode={dropdownRootNode}
-                    positionRef={positionRef}
+                    positionRef={nodeRef}
                 />
             );
         }
@@ -296,9 +290,12 @@ export const Component = <T, V>(
                 $readOnly={readOnly}
                 $error={error}
                 $position={position}
-                ref={positionRef}
+                ref={nodeRef}
                 className={className}
                 data-testid={testId}
+                tabIndex={-1}
+                onFocus={handleNodeFocus}
+                onBlur={handleNodeBlur}
             >
                 <VisuallyHidden aria-hidden id={comboboxLabelId}>
                     {comboboxAriaLabel}

--- a/tests/input-group/input-group-list-addon.spec.tsx
+++ b/tests/input-group/input-group-list-addon.spec.tsx
@@ -306,6 +306,32 @@ describe("InputGroup - List addon", () => {
             expect(mockOnBlur).toHaveBeenCalledTimes(1);
         });
 
+        it("should call onBlur from input", async () => {
+            const user = userEvent.setup();
+            const mockOnBlur = jest.fn();
+
+            render(
+                <InputGroup
+                    data-testid={FIELD_TESTID}
+                    addon={{
+                        type: "list",
+                        attributes: {
+                            options: OPTIONS,
+                        },
+                    }}
+                    onBlur={mockOnBlur}
+                />
+            );
+
+            await user.click(screen.getByTestId(INPUT_TESTID));
+
+            expect(mockOnBlur).toHaveBeenCalledTimes(0);
+
+            await user.click(document.body);
+
+            expect(mockOnBlur).toHaveBeenCalledTimes(1);
+        });
+
         it("should call onFocus and onBlur when cycling through the tab sequence", async () => {
             const user = userEvent.setup();
             const mockOnBlur = jest.fn();


### PR DESCRIPTION
**Changes**

- blur event is not firing correctly
- expected behaviour:
  - when user is still within the InputGroup e.g. moving between the selector and input, onBlur should not be triggered
  - when user moves out of the InputGroup, onBlur should be triggered regardless of whether focus on selector or input
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

- Fix `onBlur` event trigger for `InputGroup` list addon