### PR TITLE
Fix invalid css from solid border util

### DIFF
--- a/src/theme/border-util/utils.ts
+++ b/src/theme/border-util/utils.ts
@@ -13,10 +13,11 @@ export const solidBorderStyle =
         const { thickness, radius, colour } = options || {};
         // Resolve design tokens to their underlying value
         const resolvedThickness =
-            (typeof thickness === "function" ? thickness(props) : thickness) ??
-            BorderValues["width-010"](props);
+            (typeof thickness === "function"
+                ? thickness(props)
+                : thickness + "px") ?? BorderValues["width-010"](props);
         const resolvedRadius =
-            (typeof radius === "function" ? radius(props) : radius) ?? 0;
+            (typeof radius === "function" ? radius(props) : radius + "px") ?? 0;
         const resolvedColor =
             (typeof colour === "function" ? colour(props) : colour) ??
             ColourSemantic.border(props);

--- a/tests/theme/theme-border.spec.tsx
+++ b/tests/theme/theme-border.spec.tsx
@@ -5,64 +5,22 @@ import { ThemeSpec } from "src/theme/types";
 import styled, { ThemeProvider } from "styled-components";
 import { MOCK_THEME } from "./mock-theme-data";
 
-const StyledBorderComponent = styled.div`
-    border: ${Border["width-010"]} ${Border.solid};
-    ${Border.Util["dashed-default"]};
-`;
-
 describe("Border Theming Test", () => {
-    it("should apply correct border styles based on the theme", () => {
-        const expectedSvg = encodeURIComponent(
-            `<svg width='100%' height='100%' xmlns='http://www.w3.org/2000/svg'><rect width='100%' height='100%' fill='none' rx='0' ry='0' stroke='#DDE1E2' stroke-width='1px' stroke-dasharray='4, 8' stroke-dashoffset='0' stroke-linecap='square'/></svg>`
-        );
-
-        const { container } = render(
-            <ThemeProvider theme={MOCK_THEME}>
-                <StyledBorderComponent />
-            </ThemeProvider>
-        );
-
-        const receivedBorderStyle = getComputedStyle(
-            container.firstElementChild!
-        ).border;
-
-        expect(receivedBorderStyle).toBe("1px solid");
-        expect(container.firstChild).toHaveStyleRule(
-            "background-image",
-            `url("data:image/svg+xml,${expectedSvg}")`
-        );
-    });
-
-    it("should apply correct border styles when setting options for dashed-default", () => {
-        const colour = "red";
-        const strokeWidth = 2;
-        const radius = 4;
-
-        const StyledBorderComponentDash = styled.div`
-            ${Border.Util["dashed-default"]({
-                thickness: strokeWidth,
-                colour,
-                radius,
-            })};
+    it("should apply correct solid border styles based on the theme", () => {
+        const SolidBorderComponent = styled.div`
+            border: ${Border["width-010"]} ${Border.solid};
         `;
 
-        const expectedSvg = encodeURIComponent(
-            `<svg width='100%' height='100%' xmlns='http://www.w3.org/2000/svg'><rect width='100%' height='100%' fill='none' rx='${radius}' ry='${radius}' stroke='${colour}' stroke-width='${strokeWidth}' stroke-dasharray='4, 8' stroke-dashoffset='0' stroke-linecap='square'/></svg>`
-        );
-
         const { container } = render(
             <ThemeProvider theme={MOCK_THEME}>
-                <StyledBorderComponentDash />
+                <SolidBorderComponent />
             </ThemeProvider>
         );
 
-        expect(container.firstChild).toHaveStyleRule(
-            "background-image",
-            `url("data:image/svg+xml,${expectedSvg}")`
-        );
+        expect(container.firstChild).toHaveStyleRule("border", "1px solid");
     });
 
-    it("should apply correct border styles based on the override for the border", () => {
+    it("should apply correct solid border styles based on theme overrides", () => {
         const mockTheme: ThemeSpec = {
             ...MOCK_THEME,
             overrides: {
@@ -72,21 +30,107 @@ describe("Border Theming Test", () => {
             },
         };
 
-        const expectedSvg = encodeURIComponent(
-            `<svg width='100%' height='100%' xmlns='http://www.w3.org/2000/svg'><rect width='100%' height='100%' fill='none' rx='0' ry='0' stroke='#DDE1E2' stroke-width='3px' stroke-dasharray='4, 8' stroke-dashoffset='0' stroke-linecap='square'/></svg>`
-        );
-
+        const SolidBorderComponent = styled.div`
+            border: ${Border["width-010"]} ${Border.solid};
+        `;
         const { container } = render(
             <ThemeProvider theme={mockTheme}>
-                <StyledBorderComponent />
+                <SolidBorderComponent />
             </ThemeProvider>
         );
 
-        const receivedBorderStyle = getComputedStyle(
-            container.firstElementChild!
-        ).border;
+        expect(container.firstChild).toHaveStyleRule("border", "3px solid");
+    });
 
-        expect(receivedBorderStyle).toBe("3px solid");
+    it("should apply correct solid border util styles when setting options", () => {
+        const SolidBorderComponent = styled.div`
+            ${Border.Util["solid"]({
+                thickness: 10,
+                radius: 11,
+                colour: "red",
+            })};
+        `;
+
+        const { container } = render(
+            <ThemeProvider theme={MOCK_THEME}>
+                <SolidBorderComponent />
+            </ThemeProvider>
+        );
+
+        expect(container.firstChild).toHaveStyleRule(
+            "border",
+            "10px solid red"
+        );
+        expect(container.firstChild).toHaveStyleRule("border-radius", "11px");
+    });
+
+    it("should apply correct dashed border util styles based on the theme", () => {
+        const DashedBorderUtilComponent = styled.div`
+            ${Border.Util["dashed-default"]};
+        `;
+
+        const { container } = render(
+            <ThemeProvider theme={MOCK_THEME}>
+                <DashedBorderUtilComponent />
+            </ThemeProvider>
+        );
+
+        const expectedSvg = encodeURIComponent(
+            `<svg width='100%' height='100%' xmlns='http://www.w3.org/2000/svg'><rect width='100%' height='100%' fill='none' rx='0' ry='0' stroke='#DDE1E2' stroke-width='1px' stroke-dasharray='4, 8' stroke-dashoffset='0' stroke-linecap='square'/></svg>`
+        );
+        expect(container.firstChild).toHaveStyleRule(
+            "background-image",
+            `url("data:image/svg+xml,${expectedSvg}")`
+        );
+    });
+
+    it("should apply correct dashed border util styles when setting options", () => {
+        const DashedBorderUtilComponent = styled.div`
+            ${Border.Util["dashed-default"]({
+                thickness: 10,
+                radius: 11,
+                colour: "red",
+            })};
+        `;
+
+        const { container } = render(
+            <ThemeProvider theme={MOCK_THEME}>
+                <DashedBorderUtilComponent />
+            </ThemeProvider>
+        );
+
+        const expectedSvg = encodeURIComponent(
+            "<svg width='100%' height='100%' xmlns='http://www.w3.org/2000/svg'><rect width='100%' height='100%' fill='none' rx='11' ry='11' stroke='red' stroke-width='10' stroke-dasharray='4, 8' stroke-dashoffset='0' stroke-linecap='square'/></svg>"
+        );
+        expect(container.firstChild).toHaveStyleRule(
+            "background-image",
+            `url("data:image/svg+xml,${expectedSvg}")`
+        );
+    });
+
+    fit("should apply correct dashed border util styles based on theme overrides", () => {
+        const mockTheme: ThemeSpec = {
+            ...MOCK_THEME,
+            overrides: {
+                border: {
+                    "width-010": 3,
+                },
+            },
+        };
+
+        const DashedBorderUtilComponent = styled.div`
+            ${Border.Util["dashed-default"]};
+        `;
+
+        const { container } = render(
+            <ThemeProvider theme={mockTheme}>
+                <DashedBorderUtilComponent />
+            </ThemeProvider>
+        );
+
+        const expectedSvg = encodeURIComponent(
+            "<svg width='100%' height='100%' xmlns='http://www.w3.org/2000/svg'><rect width='100%' height='100%' fill='none' rx='0' ry='0' stroke='#DDE1E2' stroke-width='3px' stroke-dasharray='4, 8' stroke-dashoffset='0' stroke-linecap='square'/></svg>"
+        );
         expect(container.firstChild).toHaveStyleRule(
             "background-image",
             `url("data:image/svg+xml,${expectedSvg}")`


### PR DESCRIPTION
**Changes**

- fixes #824 
- append missing `px` for border width and radius
- [delete] branch

**Changelog entry**

- Fix invalid css from `Border.Util.solid`