### PR TITLE
Apply viewport-specific spacing for stretch layouts

### DIFF
--- a/src/layout/container.styles.tsx
+++ b/src/layout/container.styles.tsx
@@ -14,39 +14,36 @@ export const StyledContainer = styled.div<StyleProps>`
     width: auto;
     height: auto;
 
+    padding: 0 ${Breakpoint["xxl-margin"]}px;
+
+    ${MediaQuery.MaxWidth.xl} {
+        padding: 0 ${Breakpoint["xl-margin"]}px;
+    }
+
+    ${MediaQuery.MaxWidth.lg} {
+        padding: 0 ${Breakpoint["lg-margin"]}px;
+    }
+
+    ${MediaQuery.MaxWidth.md} {
+        padding: 0 ${Breakpoint["md-margin"]}px;
+    }
+
+    ${MediaQuery.MaxWidth.sm} {
+        padding: 0 ${Breakpoint["sm-margin"]}px;
+    }
+
+    ${MediaQuery.MaxWidth.xs} {
+        padding: 0 ${Breakpoint["xs-margin"]}px;
+    }
+
+    ${MediaQuery.MaxWidth.xxs} {
+        padding: 0 ${Breakpoint["xxs-margin"]}px;
+    }
+
     ${(props) => {
-        if (props.$stretch) {
+        if (!props.$stretch) {
             return css`
-                padding: 0 ${Breakpoint["xxl-margin"]}px;
-            `;
-        } else {
-            return css`
-                padding: 0 ${Breakpoint["xxl-margin"]}px;
                 max-width: 1440px;
-
-                ${MediaQuery.MaxWidth.xl} {
-                    padding: 0 ${Breakpoint["xl-margin"]}px;
-                }
-
-                ${MediaQuery.MaxWidth.lg} {
-                    padding: 0 ${Breakpoint["lg-margin"]}px;
-                }
-
-                ${MediaQuery.MaxWidth.md} {
-                    padding: 0 ${Breakpoint["md-margin"]}px;
-                }
-
-                ${MediaQuery.MaxWidth.sm} {
-                    padding: 0 ${Breakpoint["sm-margin"]}px;
-                }
-
-                ${MediaQuery.MaxWidth.xs} {
-                    padding: 0 ${Breakpoint["xs-margin"]}px;
-                }
-
-                ${MediaQuery.MaxWidth.xxs} {
-                    padding: 0 ${Breakpoint["xxs-margin"]}px;
-                }
             `;
         }
     }}


### PR DESCRIPTION
**Changes**

- Fix incorrect padding applied on tablet/mobile, instead of being hardcoded to `xxl` margins, it should take the breakpoint specific values
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

Style fix
- Apply viewport-specific spacing for stretch layouts