### PR TITLE
Fix issue where `PredictiveTextInput` does not allow space input

### DIFF
--- a/src/shared/dropdown-wrapper/element-with-dropdown.tsx
+++ b/src/shared/dropdown-wrapper/element-with-dropdown.tsx
@@ -210,7 +210,11 @@ export const ElementWithDropdown = ({
         duration: 300,
     });
 
-    const click = useClick(context, { enabled, toggle: clickToToggle });
+    const click = useClick(context, {
+        enabled,
+        toggle: clickToToggle,
+        keyboardHandlers: clickToToggle,
+    });
     const dismiss = useDismiss(context, { enabled });
 
     const { getReferenceProps, getFloatingProps } = useInteractions([

--- a/tests/predictive-text-input/predictive-text-input.spec.tsx
+++ b/tests/predictive-text-input/predictive-text-input.spec.tsx
@@ -186,6 +186,48 @@ describe("PredictiveTextInput", () => {
         expect(mockOnSelectOption).toHaveBeenCalledWith(undefined, undefined);
     });
 
+    it("should fetch and display options correctly when input contains space", async () => {
+        const user = userEvent.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+        const mockFetchOptions = jest.fn().mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    setTimeout(() => {
+                        resolve(OPTIONS);
+                    }, FETCH_DELAY);
+                })
+        );
+
+        render(
+            <PredictiveTextInput
+                data-testid={FIELD_TESTID}
+                fetchOptions={mockFetchOptions}
+            />
+        );
+
+        await user.type(
+            screen.getByPlaceholderText("Enter here..."),
+            "hello world"
+        );
+        jest.advanceTimersByTime(INPUT_DEBOUNCE_DELAY);
+
+        expect(mockFetchOptions).toHaveBeenCalledWith("hello world");
+
+        await waitFor(() => {
+            expect(screen.queryByTestId(DROPDOWN_TESTID)).toBeVisible();
+            expect(screen.getByText("Loading...")).toBeVisible();
+        });
+
+        await act(async () => {
+            jest.advanceTimersByTime(FETCH_DELAY);
+        });
+
+        expect(screen.getByText("Option 1")).toBeVisible();
+        expect(screen.getByText("Option 2")).toBeVisible();
+        expect(screen.getByText("Option 3")).toBeVisible();
+    });
+
     it("readOnly", async () => {
         const user = userEvent.setup({
             advanceTimers: jest.advanceTimersByTime,


### PR DESCRIPTION
**Changes**

Resolves #939 

- the user's space key was being swallowed by the dropdown interaction handler that detects whether it should toggle the dropdown on space/enter
- if the dropdown is not toggle-able by click (`clickToToggle`), as in the case of the `PredictiveTextInput`, it doesn't need the click/keyboard handler
- so far only the select dropdowns need `clickToToggle`
- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

Bug fix
- Fix issue where `PredictiveTextInput` does not allow space input
