### PR TITLE
Align masthead with stretched layouts

### DIFF
--- a/src/masthead/masthead.style.tsx
+++ b/src/masthead/masthead.style.tsx
@@ -13,61 +13,47 @@ interface WrapperStyleProps {
 // =============================================================================
 export const Wrapper = styled.div<WrapperStyleProps>`
     // matches Layout.Container
+    --sgds-mainnav-padding-x: ${Breakpoint["xxl-margin"]}px;
+    --sgds-mainnav-mobile-padding-x: ${Breakpoint["xxl-margin"]}px;
+
+    ${MediaQuery.MaxWidth.xl} {
+        --sgds-mainnav-padding-x: ${Breakpoint["xl-margin"]}px;
+        --sgds-mainnav-mobile-padding-x: ${Breakpoint["xl-margin"]}px;
+    }
+
+    ${MediaQuery.MaxWidth.lg} {
+        --sgds-mainnav-padding-x: ${Breakpoint["lg-margin"]}px;
+        --sgds-mainnav-mobile-padding-x: ${Breakpoint["lg-margin"]}px;
+    }
+
+    ${MediaQuery.MaxWidth.md} {
+        --sgds-mainnav-padding-x: ${Breakpoint["md-margin"]}px;
+        --sgds-mainnav-mobile-padding-x: ${Breakpoint["md-margin"]}px;
+    }
+
+    ${MediaQuery.MaxWidth.sm} {
+        --sgds-mainnav-padding-x: ${Breakpoint["sm-margin"]}px;
+        --sgds-mainnav-mobile-padding-x: ${Breakpoint["sm-margin"]}px;
+    }
+
+    ${MediaQuery.MaxWidth.xs} {
+        --sgds-mainnav-padding-x: ${Breakpoint["xs-margin"]}px;
+        --sgds-mainnav-mobile-padding-x: ${Breakpoint["xs-margin"]}px;
+    }
+
+    ${MediaQuery.MaxWidth.xxs} {
+        --sgds-mainnav-padding-x: ${Breakpoint["xxs-margin"]}px;
+        --sgds-mainnav-mobile-padding-x: ${Breakpoint["xxs-margin"]}px;
+    }
+
     ${(props) => {
         if (props.$stretch) {
             return css`
                 --sgds-mainnav-max-width: calc(infinity * 1px);
-                --sgds-mainnav-padding-x: ${Breakpoint["xxl-margin"]}px;
-                --sgds-mainnav-mobile-padding-x: ${Breakpoint["xxl-margin"]}px;
             `;
         } else {
             return css`
                 --sgds-mainnav-max-width: 1440px;
-
-                --sgds-mainnav-padding-x: ${Breakpoint["xxl-margin"]}px;
-                --sgds-mainnav-mobile-padding-x: ${Breakpoint["xxl-margin"]}px;
-
-                ${MediaQuery.MaxWidth.xl} {
-                    --sgds-mainnav-padding-x: ${Breakpoint["xl-margin"]}px;
-                    --sgds-mainnav-mobile-padding-x: ${Breakpoint[
-                        "xl-margin"
-                    ]}px;
-                }
-
-                ${MediaQuery.MaxWidth.lg} {
-                    --sgds-mainnav-padding-x: ${Breakpoint["lg-margin"]}px;
-                    --sgds-mainnav-mobile-padding-x: ${Breakpoint[
-                        "lg-margin"
-                    ]}px;
-                }
-
-                ${MediaQuery.MaxWidth.md} {
-                    --sgds-mainnav-padding-x: ${Breakpoint["md-margin"]}px;
-                    --sgds-mainnav-mobile-padding-x: ${Breakpoint[
-                        "md-margin"
-                    ]}px;
-                }
-
-                ${MediaQuery.MaxWidth.sm} {
-                    --sgds-mainnav-padding-x: ${Breakpoint["sm-margin"]}px;
-                    --sgds-mainnav-mobile-padding-x: ${Breakpoint[
-                        "sm-margin"
-                    ]}px;
-                }
-
-                ${MediaQuery.MaxWidth.xs} {
-                    --sgds-mainnav-padding-x: ${Breakpoint["xs-margin"]}px;
-                    --sgds-mainnav-mobile-padding-x: ${Breakpoint[
-                        "xs-margin"
-                    ]}px;
-                }
-
-                ${MediaQuery.MaxWidth.xxs} {
-                    --sgds-mainnav-padding-x: ${Breakpoint["xxs-margin"]}px;
-                    --sgds-mainnav-mobile-padding-x: ${Breakpoint[
-                        "xxs-margin"
-                    ]}px;
-                }
             `;
         }
     }}


### PR DESCRIPTION
**Changes**

Missed out applying the same changes to Masthead in https://github.com/LifeSG/react-design-system/pull/932

- [delete] branch

<!-- Remove if not required -->
**Changelog entry**

Style fix

- Apply viewport-specific spacing for `Masthead`'s stretch layout
