### PR TITLE
Fix unintended scroll jump after forced modal dismissal on non-iOS devices

### DIFF
--- a/src/overlay/overlay.tsx
+++ b/src/overlay/overlay.tsx
@@ -55,8 +55,8 @@ const OverlayComponent = ({
 
             if (getOverlayOrder().length < 1) {
                 if (isIOS()) {
-                    applyScrollLockClass("remove");
-                    scrollToLastScrollPosition();
+                    applyScrollLockClassForIOS("remove");
+                    scrollToLastScrollPositionForIOS();
                 }
 
                 applyBodyStyleClass("remove");
@@ -73,7 +73,7 @@ const OverlayComponent = ({
 
             if (isIOS() && getOverlayOrder().length === 1) {
                 saveScrollPosition();
-                applyScrollLockClass("add");
+                applyScrollLockClassForIOS("add");
             }
 
             const timerId = setTimeout(() => {
@@ -85,8 +85,8 @@ const OverlayComponent = ({
             removeOverlay();
 
             if (isIOS() && getOverlayOrder().length < 1) {
-                applyScrollLockClass("remove");
-                scrollToLastScrollPosition();
+                applyScrollLockClassForIOS("remove");
+                scrollToLastScrollPositionForIOS();
             }
 
             const timerId = setTimeout(() => {
@@ -204,7 +204,7 @@ const OverlayComponent = ({
      * as a side effect this causes the scroll position to reset, so additional
      * logic to restore the scroll on close is required
      */
-    const applyScrollLockClass = (action: "add" | "remove") => {
+    const applyScrollLockClassForIOS = (action: "add" | "remove") => {
         if (!isIOS()) {
             return;
         }
@@ -227,7 +227,11 @@ const OverlayComponent = ({
         document.body.style.setProperty(SCROLL_POSITION_VAR, scrollY);
     };
 
-    const scrollToLastScrollPosition = () => {
+    const scrollToLastScrollPositionForIOS = () => {
+        if (!isIOS()) {
+            return;
+        }
+
         const scrollY =
             document.body.style.getPropertyValue(SCROLL_POSITION_VAR);
         requestAnimationFrame(() => {


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)

**Description of changes**

-   Fixes a bug where the page jumps to the top when a modal is forcibly unmounted
- Cause: reset scroll was being called on non-iOS devices where the last scroll position is not tracked, leading to an invalid position

**Checklist**

<!-- Put an `x` in items that apply -->

-   [x] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [ ] ~~Looks good on mobile and tablet~~
-   [ ] ~~Updated documentation~~
-   [ ] ~~Added/updated tests~~

**Screenshots**

Before

https://github.com/user-attachments/assets/c28fff44-543f-4789-8d69-1d6d79f0fe67

After

https://github.com/user-attachments/assets/0ae65f4f-ac60-400a-8fc2-4d4cd0273b9f
