### PR TITLE
Fix incorrect text colour for tab item

### DIFF
--- a/src/tab/tab-link-chain.style.tsx
+++ b/src/tab/tab-link-chain.style.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from "styled-components";
 import { FadeWrapper } from "../shared/fade-wrapper";
-import { Border, Colour, MediaQuery, Radius, Spacing } from "../theme";
+import { Border, Colour, Font, MediaQuery, Radius, Spacing } from "../theme";
 
 // =============================================================================
 // STYLE INTERFACES
@@ -116,6 +116,7 @@ const buttonBase = css`
 export const Label = styled.div<LabelStyleProps>`
     ${buttonBase}
     position: absolute;
+    ${Font["body-baseline-regular"]}
     color: ${Colour["text-subtler"]};
     opacity: 1;
 
@@ -130,6 +131,7 @@ export const Label = styled.div<LabelStyleProps>`
 
 export const BoldLabel = styled.button<LabelStyleProps>`
     ${buttonBase}
+    ${Font["body-baseline-semibold"]}
     color: ${Colour["text-primary"]};
     opacity: 0;
     outline: none;

--- a/src/tab/tab-link-chain.tsx
+++ b/src/tab/tab-link-chain.tsx
@@ -3,7 +3,6 @@ import { useMediaQuery } from "react-responsive";
 import { ThemeContext } from "styled-components";
 import { ResizeCallbackParams } from "../shared/fade-wrapper";
 import { Breakpoint } from "../theme";
-import { Typography } from "../typography/typography";
 import { TabContext } from "./tab-context";
 import {
     BoldLabel,
@@ -138,9 +137,7 @@ export const TabLinkChain = ({
                                         onClick={handleChainLinkClick(index)}
                                         aria-hidden="true"
                                     >
-                                        <Typography.BodyBL weight="regular">
-                                            {truncateText(title)}
-                                        </Typography.BodyBL>
+                                        {truncateText(title)}
                                     </Label>
                                     <BoldLabel
                                         role="tab"
@@ -155,9 +152,7 @@ export const TabLinkChain = ({
                                         }
                                         $active={isActive}
                                     >
-                                        <Typography.BodyBL weight="semibold">
-                                            {truncateText(title)}
-                                        </Typography.BodyBL>
+                                        {truncateText(title)}
                                     </BoldLabel>
                                 </LabelContainer>
                                 {titleAddon?.content}


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)

**Description of changes**

-   Link to [Figma](https://www.figma.com/design/tHmHQNszVzvIamtZWixjgR/%F0%9F%8C%B1-Flagship-V3-Component-Kit?node-id=2070-714&p=f&m=dev)
-   Fix text colour not being applied to tab item as the Typography was overriding the colour. Removed the Typography wrapper and applied the font style directly to the element instead

**Checklist**

<!-- Put an `x` in items that apply -->

-   [x] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [x] Looks good on mobile and tablet
-   [ ] ~~Updated documentation~~
-   [ ] ~~Added/updated tests~~

**Screenshots**

Before
<img width="377" height="396" alt="Screenshot 2026-03-19 at 4 50 56 PM" src="https://github.com/user-attachments/assets/4718312a-bc8f-472a-abd7-addb182af2bd" />

After 
<img width="378" height="396" alt="Screenshot 2026-03-19 at 4 49 49 PM" src="https://github.com/user-attachments/assets/dbf84b3c-9b8f-42e8-8fab-87f1c8a27e45" />
