### PR TITLE
Migrate shared/styles to Linaria

### DIFF
--- a/src/shared/dropdown-list-v2/dropdown-label.styles.tsx
+++ b/src/shared/dropdown-list-v2/dropdown-label.styles.tsx
@@ -6,7 +6,16 @@ import type {
     LabelDisplayType,
     TruncateType,
 } from "../dropdown-list/types";
-import { lineClampCss } from "../styles";
+import { lineClampDynamicCss } from "../styles";
+
+const tokens = {
+    primaryText: {
+        maxLines: "--fds-dropdownLabel-primaryText-maxLines",
+    },
+    secondaryText: {
+        maxLines: "--fds-dropdownLabel-secondaryText-maxLines",
+    },
+};
 
 // =============================================================================
 // STYLE INTERFACE
@@ -55,19 +64,23 @@ export const PrimaryText = styled.div<LabelTextStyleProps>`
         }
     }}
     width: 100%;
+    overflow-wrap: break-word;
 
     ${(props) =>
-        props.$truncateType === "end" && lineClampCss(props.$maxLines || 2)}
-    overflow-wrap: break-word;
+        props.$truncateType === "end" &&
+        lineClampDynamicCss(tokens.primaryText.maxLines)}
+    ${tokens.primaryText.maxLines}: ${(props) => props.$maxLines || 2};
 `;
 
 export const SecondaryText = styled.div<LabelTextStyleProps>`
     color: ${V3_Colour["text-subtlest"]};
     width: 100%;
+    overflow-wrap: break-word;
 
     ${(props) =>
-        props.$truncateType === "end" && lineClampCss(props.$maxLines || 2)}
-    overflow-wrap: break-word;
+        props.$truncateType === "end" &&
+        lineClampDynamicCss(tokens.secondaryText.maxLines)}
+    ${tokens.secondaryText.maxLines}: ${(props) => props.$maxLines || 2};
 
     ${(props) => {
         switch (props.$labelDisplayType) {

--- a/src/shared/styles/index.ts
+++ b/src/shared/styles/index.ts
@@ -1,10 +1,31 @@
 /**
  * Generates CSS for limiting text to a specified number of lines after which it
- * is truncated with an ellipsis
+ * is truncated with an ellipsis.
  */
 export const lineClampCss = (lines: number) => `
     display: -webkit-box;
     -webkit-line-clamp: ${lines};
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+`;
+
+/**
+ * Generates CSS for limiting text to a number of lines (specified via a CSS
+ * variable) after which it is truncated with an ellipsis.
+ *
+ * @example
+ * ```
+ * css`
+ *   ${lineClampDynamicCss("--my-variable")}
+ *   --my-variable: 3;
+ * `
+ * ```
+ */
+export const lineClampDynamicCss = (variableName: string) => `
+    /* reset variable to prevent leaking to child components */
+    ${variableName}: initial;
+    display: -webkit-box;
+    -webkit-line-clamp: var(${variableName});
     -webkit-box-orient: vertical;
     overflow: hidden;
 `;

--- a/src/typography/helper.ts
+++ b/src/typography/helper.ts
@@ -1,9 +1,13 @@
 import { css } from "styled-components";
 
-import { lineClampCss } from "../shared/styles";
+import { lineClampDynamicCss } from "../shared/styles";
 import { V3_Colour, V3_Font } from "../v3_theme";
 import type { V3_FontSet, V3_TypographySizeType } from "../v3_theme/font/types";
 import type { TypographyWeight } from "./types";
+
+const tokens = {
+    maxLines: "--fds-typography-maxLines",
+};
 
 export const getTextStyle = (
     type: V3_TypographySizeType,
@@ -21,7 +25,8 @@ export const getTextStyle = (
 const getMaxLinesStyle = (maxLines: number | undefined) => {
     if (maxLines) {
         return css`
-            ${lineClampCss(maxLines)}
+            ${lineClampDynamicCss(tokens.maxLines)}
+            ${tokens.maxLines}: ${maxLines};
         `;
     }
 };


### PR DESCRIPTION
**Checklist**

<!-- Put an `x` in all the items that apply, ~~strikethrough~~ items that are not applicable -->

-   [x] Migrated the component styles
    -   [ ] ~~`className` is chained correctly with `clsx`~~
    -   [x] User style prop is set as CSS variable
-   [x] Changes follow the project guidelines in [CONVENTIONS_V4.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS_V4.md)
-   [ ] ~~Updated Storybook documentation~~
-   [ ] ~~Added/updated unit tests~~
-   [ ] ~~Added visual tests~~
-   [ ] ~~Listed breaking changes~~

**Additional information**

Introduced a variant that takes in a variable name instead of a number, to support max lines set dynamically from props. Used by DropdownListV2 and Typography.

Suggestions for naming the new variant appreciated. Considered overloading the arg to support `number | string` or options but felt that made the function unnecessarily complicated