### PR TITLE
[BOOKINGSG-8904][LS] Add props to time range picker for initial start and end scroll time

### DIFF
--- a/src/time-range-picker/combobox-picker/combobox-picker.tsx
+++ b/src/time-range-picker/combobox-picker/combobox-picker.tsx
@@ -38,8 +38,8 @@ export const ComboboxPicker = ({
     dropdownZIndex,
     startLimit,
     endLimit,
-    initialStartTime,
-    initialEndTime,
+    initialScrollStartTime,
+    initialScrollEndTime,
     interval = 15,
     dropdownRootNode,
     "aria-labelledby": ariaLabelledBy,
@@ -97,14 +97,14 @@ export const ComboboxPicker = ({
         [format]
     );
 
-    const initialStartScrollTime = useMemo(
-        () => parseInput(initialStartTime) ?? "",
-        [initialStartTime, parseInput]
+    const parsedInitialStartScrollTime = useMemo(
+        () => parseInput(initialScrollStartTime) ?? "",
+        [initialScrollStartTime, parseInput]
     );
 
-    const initialEndScrollTime = useMemo(
-        () => parseInput(initialEndTime) ?? "",
-        [initialEndTime, parseInput]
+    const parsedInitialEndScrollTime = useMemo(
+        () => parseInput(initialScrollEndTime) ?? "",
+        [initialScrollEndTime, parseInput]
     );
 
     useEffect(() => {
@@ -352,9 +352,9 @@ export const ComboboxPicker = ({
     const renderDropdown = () => {
         if (activeTimeSelector === "start") {
             // Prioritise start time value. If non existent, use initial scroll time
-            // If both is non existent, DropdownList will default to first option
+            // If both are non existent, DropdownList will default to first option
             const startScrollTime =
-                parseInput(startTimeVal) || initialStartScrollTime;
+                parseInput(startTimeVal) || parsedInitialStartScrollTime;
 
             return (
                 <DropdownList
@@ -373,7 +373,7 @@ export const ComboboxPicker = ({
             );
         } else {
             const endScrollTime =
-                parseInput(endTimeVal) || initialEndScrollTime;
+                parseInput(endTimeVal) || parsedInitialEndScrollTime;
 
             return (
                 <DropdownList

--- a/src/time-range-picker/combobox-picker/combobox-picker.tsx
+++ b/src/time-range-picker/combobox-picker/combobox-picker.tsx
@@ -38,6 +38,8 @@ export const ComboboxPicker = ({
     dropdownZIndex,
     startLimit,
     endLimit,
+    initialStartTime,
+    initialEndTime,
     interval = 15,
     dropdownRootNode,
     "aria-labelledby": ariaLabelledBy,
@@ -89,10 +91,20 @@ export const ComboboxPicker = ({
     // EFFECTS
     // =========================================================================
     const parseInput = useCallback(
-        (input: string): string | undefined => {
+        (input: string | undefined): string | undefined => {
             return TimeHelper.parseInput(input, format);
         },
         [format]
+    );
+
+    const initialStartScrollTime = useMemo(
+        () => parseInput(initialStartTime) ?? "",
+        [initialStartTime, parseInput]
+    );
+
+    const initialEndScrollTime = useMemo(
+        () => parseInput(initialEndTime) ?? "",
+        [initialEndTime, parseInput]
     );
 
     useEffect(() => {
@@ -339,13 +351,18 @@ export const ComboboxPicker = ({
 
     const renderDropdown = () => {
         if (activeTimeSelector === "start") {
+            // Prioritise start time value. If non existent, use initial scroll time
+            // If both is non existent, DropdownList will default to first option
+            const startScrollTime =
+                parseInput(startTimeVal) || initialStartScrollTime;
+
             return (
                 <DropdownList
                     listItems={startOptions}
                     onSelectItem={handleStartTime}
                     selectedItems={[startTimeVal]}
                     topScrollItem={TimeHelper.findClosestFlooredTime(
-                        parseInput(startTimeVal),
+                        startScrollTime,
                         startOptions
                     )}
                     listboxId={listboxId}
@@ -355,13 +372,16 @@ export const ComboboxPicker = ({
                 />
             );
         } else {
+            const endScrollTime =
+                parseInput(endTimeVal) || initialEndScrollTime;
+
             return (
                 <DropdownList
                     listItems={endOptions}
                     onSelectItem={handleEndTime}
                     selectedItems={[endTimeVal]}
                     topScrollItem={TimeHelper.findClosestFlooredTime(
-                        parseInput(endTimeVal),
+                        endScrollTime,
                         endOptions
                     )}
                     listboxId={listboxId}

--- a/src/time-range-picker/types.ts
+++ b/src/time-range-picker/types.ts
@@ -52,9 +52,9 @@ export interface TimeRangePickerProps {
     /** Specifies the ending time for the dropdown options */
     endLimit?: string | undefined;
     /** Specifies the initial start time to scroll to when the start dropdown opens */
-    initialStartTime?: string | undefined;
+    initialScrollStartTime?: string | undefined;
     /** Specifies the initial end time to scroll to when the end dropdown opens */
-    initialEndTime?: string | undefined;
+    initialScrollEndTime?: string | undefined;
     /** Specifies the alignment of the dropdown to the left or right of the reference element */
     alignment?: DropdownAlignmentType | undefined;
     /** Specifies the z-index of the dropdown element */

--- a/src/time-range-picker/types.ts
+++ b/src/time-range-picker/types.ts
@@ -51,6 +51,10 @@ export interface TimeRangePickerProps {
     startLimit?: string | undefined;
     /** Specifies the ending time for the dropdown options */
     endLimit?: string | undefined;
+    /** Specifies the initial start time to scroll to when the start dropdown opens */
+    initialStartTime?: string | undefined;
+    /** Specifies the initial end time to scroll to when the end dropdown opens */
+    initialEndTime?: string | undefined;
     /** Specifies the alignment of the dropdown to the left or right of the reference element */
     alignment?: DropdownAlignmentType | undefined;
     /** Specifies the z-index of the dropdown element */

--- a/src/util/time-helper.ts
+++ b/src/util/time-helper.ts
@@ -342,7 +342,7 @@ export namespace TimeHelper {
 
     // Return undefined = invalid field, "" = empty field, else returns h:mma
     export const parseInput = (
-        input: string,
+        input: string | undefined,
         format: TimeFormat = "12hr" // Returned format
     ): string | undefined => {
         if (input === "" || input === undefined) return input;

--- a/stories/form/form-time-range-picker/form-time-range-picker.mdx
+++ b/stories/form/form-time-range-picker/form-time-range-picker.mdx
@@ -47,6 +47,11 @@ hh:mm for `24hr`).
 This variant comes in built-in validation for unrecognised time format or
 invalid time range (start is greater than end).
 
+Use `initialStartTime` and `initialEndTime` when you want each combobox
+dropdown to open at a specific time before the user has made a selection. This
+does not prefill the input values. It only controls the initial dropdown scroll
+position while the corresponding field is empty.
+
 <Canvas of={FormTimeRangePickerStories.ComboboxVariant} />
 
 ## Component API

--- a/stories/form/form-time-range-picker/form-time-range-picker.mdx
+++ b/stories/form/form-time-range-picker/form-time-range-picker.mdx
@@ -47,12 +47,16 @@ hh:mm for `24hr`).
 This variant comes in built-in validation for unrecognised time format or
 invalid time range (start is greater than end).
 
-Use `initialStartTime` and `initialEndTime` when you want each combobox
+<Canvas of={FormTimeRangePickerStories.ComboboxVariant} />
+
+### Initial scroll position
+
+Use `initialScrollStartTime` and `initialScrollEndTime` when you want each combobox
 dropdown to open at a specific time before the user has made a selection. This
 does not prefill the input values. It only controls the initial dropdown scroll
 position while the corresponding field is empty.
 
-<Canvas of={FormTimeRangePickerStories.ComboboxVariant} />
+<Canvas of={FormTimeRangePickerStories.ComboboxScrollTime} />
 
 ## Component API
 

--- a/stories/form/form-time-range-picker/form-time-range-picker.stories.tsx
+++ b/stories/form/form-time-range-picker/form-time-range-picker.stories.tsx
@@ -115,6 +115,10 @@ export const ComboboxVariant: StoryObj<Component> = {
         const [time3, setTime3] = useState({ start: "00:00", end: "" });
         const [time4, setTime4] = useState(emptyTime);
         const [time5, setTime5] = useState({ start: "2:00pm", end: "1:00pm" });
+        const [time6, setTime6] = useState({
+            start: "",
+            end: "",
+        });
 
         return (
             <>
@@ -161,6 +165,14 @@ export const ComboboxVariant: StoryObj<Component> = {
                     label="This is the readonly state"
                     variant="combobox"
                     readOnly
+                />
+                <Form.TimeRangePicker
+                    label="With initial dropdown time of 9:00am to 3:00pm"
+                    value={time6}
+                    onChange={(value) => setTime6(value)}
+                    variant="combobox"
+                    initialStartTime="9:00am"
+                    initialEndTime="3:00pm"
                 />
             </>
         );

--- a/stories/form/form-time-range-picker/form-time-range-picker.stories.tsx
+++ b/stories/form/form-time-range-picker/form-time-range-picker.stories.tsx
@@ -115,10 +115,6 @@ export const ComboboxVariant: StoryObj<Component> = {
         const [time3, setTime3] = useState({ start: "00:00", end: "" });
         const [time4, setTime4] = useState(emptyTime);
         const [time5, setTime5] = useState({ start: "2:00pm", end: "1:00pm" });
-        const [time6, setTime6] = useState({
-            start: "",
-            end: "",
-        });
 
         return (
             <>
@@ -166,15 +162,21 @@ export const ComboboxVariant: StoryObj<Component> = {
                     variant="combobox"
                     readOnly
                 />
-                <Form.TimeRangePicker
-                    label="With initial dropdown time of 9:00am to 3:00pm"
-                    value={time6}
-                    onChange={(value) => setTime6(value)}
-                    variant="combobox"
-                    initialStartTime="9:00am"
-                    initialEndTime="3:00pm"
-                />
             </>
+        );
+    },
+    decorators: [StoryDecorator({ maxWidth: true })],
+};
+
+export const ComboboxScrollTime: StoryObj<Component> = {
+    render: (_args) => {
+        return (
+            <Form.TimeRangePicker
+                label="With initial dropdown time of 9:00am to 3:00pm"
+                variant="combobox"
+                initialScrollStartTime="9:00am"
+                initialScrollEndTime="3:00pm"
+            />
         );
     },
     decorators: [StoryDecorator({ maxWidth: true })],

--- a/stories/form/form-time-range-picker/props-table.tsx
+++ b/stories/form/form-time-range-picker/props-table.tsx
@@ -162,13 +162,13 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["string"],
             },
             {
-                name: "initialStartTime",
+                name: "initialScrollStartTime",
                 description:
                     "The initial time that the start dropdown scrolls to when the start field is empty",
                 propTypes: ["string"],
             },
             {
-                name: "initialEndTime",
+                name: "initialScrollEndTime",
                 description:
                     "The initial time that the end dropdown scrolls to when the end field is empty",
                 propTypes: ["string"],

--- a/stories/form/form-time-range-picker/props-table.tsx
+++ b/stories/form/form-time-range-picker/props-table.tsx
@@ -161,6 +161,18 @@ const DATA: ApiTableSectionProps[] = [
                 description: "The ending time for the dropdown options",
                 propTypes: ["string"],
             },
+            {
+                name: "initialStartTime",
+                description:
+                    "The initial time that the start dropdown scrolls to when the start field is empty",
+                propTypes: ["string"],
+            },
+            {
+                name: "initialEndTime",
+                description:
+                    "The initial time that the end dropdown scrolls to when the end field is empty",
+                propTypes: ["string"],
+            },
         ],
     },
     {

--- a/tests/time-range-picker/time-range-picker.spec.tsx
+++ b/tests/time-range-picker/time-range-picker.spec.tsx
@@ -83,7 +83,7 @@ describe("TimeRangePicker", () => {
                 render(
                     <TimeRangePicker
                         variant={"combobox"}
-                        initialStartTime="9:00am"
+                        initialScrollStartTime="9:00am"
                         startLimit="8:00am"
                         endLimit="10:00am"
                         interval={60}
@@ -110,7 +110,7 @@ describe("TimeRangePicker", () => {
                 render(
                     <TimeRangePicker
                         variant={"combobox"}
-                        initialEndTime="3:00pm"
+                        initialScrollEndTime="3:00pm"
                         startLimit="1:00pm"
                         endLimit="5:00pm"
                         interval={60}
@@ -134,6 +134,47 @@ describe("TimeRangePicker", () => {
                         "4:00pm",
                         "5:00pm",
                     ]);
+                });
+            });
+
+            it("should scroll the start dropdown to the selected value instead of the initial start time", async () => {
+                const user = userEvent.setup();
+
+                render(
+                    <TimeRangePicker
+                        variant={"combobox"}
+                        initialScrollStartTime="9:00am"
+                        startLimit="8:00am"
+                        endLimit="11:00am"
+                        interval={60}
+                    />
+                );
+
+                await user.click(screen.getByLabelText(START_LABEL));
+
+                await waitFor(() => {
+                    expect(
+                        screen.getByRole("option", { name: "9:00am" })
+                    ).toHaveAttribute("tabindex", "0");
+                });
+
+                await user.click(
+                    screen.getByRole("option", { name: "10:00am" })
+                );
+
+                expect(screen.getByLabelText(START_LABEL)).toHaveValue(
+                    "10:00am"
+                );
+
+                await user.click(screen.getByLabelText(START_LABEL));
+
+                await waitFor(() => {
+                    expect(
+                        screen.getByRole("option", { name: "10:00am" })
+                    ).toHaveAttribute("tabindex", "0");
+                    expect(
+                        screen.getByRole("option", { name: "9:00am" })
+                    ).toHaveAttribute("tabindex", "-1");
                 });
             });
 

--- a/tests/time-range-picker/time-range-picker.spec.tsx
+++ b/tests/time-range-picker/time-range-picker.spec.tsx
@@ -77,6 +77,66 @@ describe("TimeRangePicker", () => {
         });
 
         describe("generated dropdown options", () => {
+            it("should scroll the start dropdown to the initial start time", async () => {
+                const user = userEvent.setup();
+
+                render(
+                    <TimeRangePicker
+                        variant={"combobox"}
+                        initialStartTime="9:00am"
+                        startLimit="8:00am"
+                        endLimit="10:00am"
+                        interval={60}
+                    />
+                );
+
+                await user.click(screen.getByLabelText(START_LABEL));
+
+                await waitFor(() => {
+                    expect(
+                        screen.getByRole("option", { name: "9:00am" })
+                    ).toHaveAttribute("tabindex", "0");
+                    expect(
+                        screen.queryAllByRole("option").map((option) => {
+                            return option.textContent;
+                        })
+                    ).toEqual(["8:00am", "9:00am", "10:00am"]);
+                });
+            });
+
+            it("should scroll the end dropdown to the initial end time", async () => {
+                const user = userEvent.setup();
+
+                render(
+                    <TimeRangePicker
+                        variant={"combobox"}
+                        initialEndTime="3:00pm"
+                        startLimit="1:00pm"
+                        endLimit="5:00pm"
+                        interval={60}
+                    />
+                );
+
+                await user.click(screen.getByLabelText(END_LABEL));
+
+                await waitFor(() => {
+                    expect(
+                        screen.getByRole("option", { name: "3:00pm" })
+                    ).toHaveAttribute("tabindex", "0");
+                    expect(
+                        screen.queryAllByRole("option").map((option) => {
+                            return option.textContent;
+                        })
+                    ).toEqual([
+                        "1:00pm",
+                        "2:00pm",
+                        "3:00pm",
+                        "4:00pm",
+                        "5:00pm",
+                    ]);
+                });
+            });
+
             it("should have end first option be after start time", async () => {
                 render(
                     <TimeRangePicker

--- a/tests/time-range-picker/time-range-picker.spec.tsx
+++ b/tests/time-range-picker/time-range-picker.spec.tsx
@@ -137,9 +137,42 @@ describe("TimeRangePicker", () => {
                 });
             });
 
+            it("should scroll the start dropdown to the initialised value instead of the initial start time", async () => {
+                const user = userEvent.setup();
+
+                // Time range picker with start value of 10:00am
+                render(
+                    <TimeRangePicker
+                        variant={"combobox"}
+                        initialScrollStartTime="9:00am"
+                        startLimit="8:00am"
+                        value={{ start: "10:00am", end: "11:00am" }}
+                        endLimit="11:00am"
+                        interval={60}
+                    />
+                );
+
+                expect(screen.getByLabelText(START_LABEL)).toHaveValue(
+                    "10:00am"
+                );
+
+                await user.click(screen.getByLabelText(START_LABEL));
+
+                // Scroll start should be 10:00am (from the initialised value)
+                await waitFor(() => {
+                    expect(
+                        screen.getByRole("option", { name: "10:00am" })
+                    ).toHaveAttribute("tabindex", "0");
+                    expect(
+                        screen.getByRole("option", { name: "9:00am" })
+                    ).toHaveAttribute("tabindex", "-1");
+                });
+            });
+
             it("should scroll the start dropdown to the selected value instead of the initial start time", async () => {
                 const user = userEvent.setup();
 
+                // Time range picker without start value
                 render(
                     <TimeRangePicker
                         variant={"combobox"}
@@ -152,12 +185,14 @@ describe("TimeRangePicker", () => {
 
                 await user.click(screen.getByLabelText(START_LABEL));
 
+                // Assert that scroll time is as expected (from initialScrollStartTime)
                 await waitFor(() => {
                     expect(
                         screen.getByRole("option", { name: "9:00am" })
                     ).toHaveAttribute("tabindex", "0");
                 });
 
+                // After clicking on 10:00am selection and reopening the dropdown, first option should be 10:00am instead
                 await user.click(
                     screen.getByRole("option", { name: "10:00am" })
                 );


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)

**Description of changes**
- Added `initialStartTime` and `initialEndTime` props to TimeRangePicker combobox variant so each dropdown can open scrolled to a specified time before the user makes a selection.
- Updated the combobox dropdown logic to prioritize the current selected value, and fall back to the configured initial scroll time when the field is empty.

**Checklist**

<!-- Put an `x` in items that apply -->

-   [x] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [x] Looks good on mobile and tablet
-   [x] Updated documentation
-   [x] Added/updated tests

**Screenshots**

<!-- Include a screenshot or video recording of visual changes -->

https://github.com/user-attachments/assets/2a16beb6-24c0-4618-b803-f3a962f6d930


https://github.com/user-attachments/assets/1e7ff21f-947a-4c1d-836d-13758225452b

