### PR TITLE
[BOOKINGSG-8688][AN] Add hover color prop to slot

### DIFF
--- a/src/time-slot-bar/time-slot-bar.styles.tsx
+++ b/src/time-slot-bar/time-slot-bar.styles.tsx
@@ -49,6 +49,7 @@ export interface TimeSlotStyleProps {
     $styleType: SlotStyle;
     $bgColor: string | ((props: ThemeStyleProps) => string);
     $bgColor2?: string | ((props: ThemeStyleProps) => string);
+    $hoverBgColor?: string | ((props: ThemeStyleProps) => string);
     $clickable?: boolean;
 }
 
@@ -190,6 +191,14 @@ export const TimeSlot = styled.div<TimeSlotStyleProps>`
     }}
     background-color: ${({ $bgColor }) => $bgColor};
     cursor: ${({ $clickable }) => ($clickable ? "pointer" : "default")};
+    ${({ $hoverBgColor, $clickable }) =>
+        $hoverBgColor &&
+        $clickable &&
+        css`
+            &:hover {
+                background-color: ${$hoverBgColor};
+            }
+        `}
 
     ${(props) =>
         props.$styleType === "stripes" &&

--- a/src/time-slot-bar/time-slot-bar.styles.tsx
+++ b/src/time-slot-bar/time-slot-bar.styles.tsx
@@ -50,6 +50,7 @@ export interface TimeSlotStyleProps {
     $bgColor: string | ((props: ThemeStyleProps) => string);
     $bgColor2?: string | ((props: ThemeStyleProps) => string);
     $hoverBgColor?: string | ((props: ThemeStyleProps) => string);
+    $hoverBgColor2?: string | ((props: ThemeStyleProps) => string);
     $clickable?: boolean;
 }
 
@@ -210,6 +211,31 @@ export const TimeSlot = styled.div<TimeSlotStyleProps>`
                 ${props.$bgColor || Colour["bg-stronger"]} 10px,
                 ${props.$bgColor || Colour["bg-stronger"]} 20px
             );
+            ${(props.$hoverBgColor || props.$hoverBgColor2) &&
+            props.$clickable &&
+            css`
+                &:hover {
+                    background: repeating-linear-gradient(
+                        135deg,
+                        ${props.$hoverBgColor2 ||
+                            props.$bgColor2 ||
+                            Colour["bg-strongest"]}
+                            0px,
+                        ${props.$hoverBgColor2 ||
+                            props.$bgColor2 ||
+                            Colour["bg-strongest"]}
+                            10px,
+                        ${props.$hoverBgColor ||
+                            props.$bgColor ||
+                            Colour["bg-stronger"]}
+                            10px,
+                        ${props.$hoverBgColor ||
+                            props.$bgColor ||
+                            Colour["bg-stronger"]}
+                            20px
+                    );
+                }
+            `}
         `}
 `;
 

--- a/src/time-slot-bar/time-slot-bar.tsx
+++ b/src/time-slot-bar/time-slot-bar.tsx
@@ -258,6 +258,7 @@ const Component = (props: TimeSlotBarProps, ref: React.Ref<TimeSlotBarRef>) => {
             backgroundColor,
             backgroundColor2,
             hoverBackgroundColor,
+            hoverBackgroundColor2,
             styleType = "default",
         } = styleAttributes;
 
@@ -282,6 +283,7 @@ const Component = (props: TimeSlotBarProps, ref: React.Ref<TimeSlotBarRef>) => {
                     $bgColor={backgroundColor}
                     $bgColor2={backgroundColor2}
                     $hoverBgColor={hoverBackgroundColor}
+                    $hoverBgColor2={hoverBackgroundColor2}
                     $clickable={isClickable}
                     onClick={isClickable ? onClick : undefined}
                 />
@@ -308,6 +310,7 @@ const Component = (props: TimeSlotBarProps, ref: React.Ref<TimeSlotBarRef>) => {
                 backgroundColor,
                 backgroundColor2,
                 hoverBackgroundColor,
+                hoverBackgroundColor2,
             } = styleAttributes;
 
             const slotWidth = TimeSlotBarHelper.calculateWidth(
@@ -350,6 +353,7 @@ const Component = (props: TimeSlotBarProps, ref: React.Ref<TimeSlotBarRef>) => {
                         $bgColor={backgroundColor}
                         $bgColor2={backgroundColor2}
                         $hoverBgColor={hoverBackgroundColor}
+                        $hoverBgColor2={hoverBackgroundColor2}
                         $clickable={isClickable}
                         onClick={handleSlotClick(slot)}
                     >

--- a/src/time-slot-bar/time-slot-bar.tsx
+++ b/src/time-slot-bar/time-slot-bar.tsx
@@ -257,6 +257,7 @@ const Component = (props: TimeSlotBarProps, ref: React.Ref<TimeSlotBarRef>) => {
         const {
             backgroundColor,
             backgroundColor2,
+            hoverBackgroundColor,
             styleType = "default",
         } = styleAttributes;
 
@@ -280,6 +281,7 @@ const Component = (props: TimeSlotBarProps, ref: React.Ref<TimeSlotBarRef>) => {
                     $styleType={styleType}
                     $bgColor={backgroundColor}
                     $bgColor2={backgroundColor2}
+                    $hoverBgColor={hoverBackgroundColor}
                     $clickable={isClickable}
                     onClick={isClickable ? onClick : undefined}
                 />
@@ -305,6 +307,7 @@ const Component = (props: TimeSlotBarProps, ref: React.Ref<TimeSlotBarRef>) => {
                 styleType = "default",
                 backgroundColor,
                 backgroundColor2,
+                hoverBackgroundColor,
             } = styleAttributes;
 
             const slotWidth = TimeSlotBarHelper.calculateWidth(
@@ -346,6 +349,7 @@ const Component = (props: TimeSlotBarProps, ref: React.Ref<TimeSlotBarRef>) => {
                         $variant={variant}
                         $bgColor={backgroundColor}
                         $bgColor2={backgroundColor2}
+                        $hoverBgColor={hoverBackgroundColor}
                         $clickable={isClickable}
                         onClick={handleSlotClick(slot)}
                     >

--- a/src/time-slot-bar/time-slot-bar.tsx
+++ b/src/time-slot-bar/time-slot-bar.tsx
@@ -454,25 +454,23 @@ const Component = (props: TimeSlotBarProps, ref: React.Ref<TimeSlotBarRef>) => {
                 data-testid={testId}
                 ref={barRef}
                 $variant={variant}
-                role="grid"
-                aria-label={slotsSummary}
-                tabIndex={0}
             >
                 <TimeMarkerWrapper
                     data-testid={getDataTestId("time-marker-wrapper")}
                     data-id="marker-wrapper"
-                    role="row"
                 >
                     {renderTimeMarkers()}
                 </TimeMarkerWrapper>
-                <TimeSlotWrapper
-                    data-testid={getDataTestId("time-slot-wrapper")}
-                    data-id="slot-wrapper"
-                    role="row"
-                >
-                    {renderDefaultTimeSlots()}
-                    {renderTimeSlots()}
-                </TimeSlotWrapper>
+                <div role="grid" aria-label={slotsSummary} tabIndex={0}>
+                    <TimeSlotWrapper
+                        data-testid={getDataTestId("time-slot-wrapper")}
+                        data-id="slot-wrapper"
+                        role="row"
+                    >
+                        {renderDefaultTimeSlots()}
+                        {renderTimeSlots()}
+                    </TimeSlotWrapper>
+                </div>
             </TimeSlotBarContainer>
             {renderArrowButtonLeft()}
             {renderArrowButtonRight()}

--- a/src/time-slot-bar/types.ts
+++ b/src/time-slot-bar/types.ts
@@ -28,6 +28,11 @@ interface TimeSlotBarStyleAttributes {
         | string
         | ((props: ThemeStyleProps) => string)
         | undefined;
+    /** The secondary background color on hover. Used in conjunction if styleType is "stripes" */
+    hoverBackgroundColor2?:
+        | string
+        | ((props: ThemeStyleProps) => string)
+        | undefined;
 }
 
 export interface TimeSlotBarProps {

--- a/src/time-slot-bar/types.ts
+++ b/src/time-slot-bar/types.ts
@@ -23,6 +23,11 @@ interface TimeSlotBarStyleAttributes {
         | string
         | ((props: ThemeStyleProps) => string)
         | undefined;
+    /** The background color on hover */
+    hoverBackgroundColor?:
+        | string
+        | ((props: ThemeStyleProps) => string)
+        | undefined;
 }
 
 export interface TimeSlotBarProps {

--- a/stories/time-slot-bar/props-table.tsx
+++ b/stories/time-slot-bar/props-table.tsx
@@ -191,6 +191,16 @@ const DATA: ApiTableSectionProps[] = [
                 ),
                 propTypes: ["string"],
             },
+            {
+                name: "hoverBackgroundColor",
+                description: (
+                    <>
+                        The background color of the slot on hover. Only applies
+                        when the slot is <code>clickable</code>
+                    </>
+                ),
+                propTypes: ["string"],
+            },
         ],
     },
 ];

--- a/stories/time-slot-bar/props-table.tsx
+++ b/stories/time-slot-bar/props-table.tsx
@@ -201,6 +201,18 @@ const DATA: ApiTableSectionProps[] = [
                 ),
                 propTypes: ["string"],
             },
+            {
+                name: "hoverBackgroundColor2",
+                description: (
+                    <>
+                        The secondary color of the slot on hover. Used in
+                        conjuction with <code>styleType</code> of{" "}
+                        <code>{`"stripes"`}</code>. Only applies when the slot
+                        is <code>clickable</code>
+                    </>
+                ),
+                propTypes: ["string"],
+            },
         ],
     },
 ];

--- a/stories/time-slot-bar/time-slot-bar.stories.tsx
+++ b/stories/time-slot-bar/time-slot-bar.stories.tsx
@@ -131,7 +131,7 @@ export const DifferentIndicators: StoryObj<Component> = {
         return (
             <TimeSlotBar
                 startTime="08:00"
-                endTime="17:00"
+                endTime="19:00"
                 onSlotClick={() => {
                     /* empty arrow function */
                 }}
@@ -153,9 +153,9 @@ export const DifferentIndicators: StoryObj<Component> = {
                         startTime: "09:00",
                         endTime: "10:00",
                         styleAttributes: {
-                            backgroundColor: "#EF413D",
+                            backgroundColor: "#CB2213",
                             color: "#FFFFFF",
-                            hoverBackgroundColor: "#00f746",
+                            hoverBackgroundColor: "#9E130F",
                         },
                         label: "Event 1",
                     },
@@ -178,6 +178,18 @@ export const DifferentIndicators: StoryObj<Component> = {
                         endTime: "16:45",
                         styleAttributes: {
                             backgroundColor: Colour["bg-available"],
+                        },
+                    },
+                    {
+                        id: "4",
+                        startTime: "17:00",
+                        endTime: "18:15",
+                        styleAttributes: {
+                            styleType: "stripes",
+                            backgroundColor: "#f2df16",
+                            backgroundColor2: "#f8ef88",
+                            hoverBackgroundColor: "#fe8f17",
+                            hoverBackgroundColor2: "#f8b975",
                         },
                     },
                 ]}

--- a/stories/time-slot-bar/time-slot-bar.stories.tsx
+++ b/stories/time-slot-bar/time-slot-bar.stories.tsx
@@ -155,6 +155,7 @@ export const DifferentIndicators: StoryObj<Component> = {
                         styleAttributes: {
                             backgroundColor: "#EF413D",
                             color: "#FFFFFF",
+                            hoverBackgroundColor: "#00f746",
                         },
                         label: "Event 1",
                     },

--- a/stories/time-slot-bar/time-slot-bar.stories.tsx
+++ b/stories/time-slot-bar/time-slot-bar.stories.tsx
@@ -186,10 +186,10 @@ export const DifferentIndicators: StoryObj<Component> = {
                         endTime: "18:15",
                         styleAttributes: {
                             styleType: "stripes",
-                            backgroundColor: "#f2df16",
-                            backgroundColor2: "#f8ef88",
-                            hoverBackgroundColor: "#fe8f17",
-                            hoverBackgroundColor2: "#f8b975",
+                            backgroundColor: "#F2DF16",
+                            backgroundColor2: "#F8EF88",
+                            hoverBackgroundColor: "#FE8F17",
+                            hoverBackgroundColor2: "#F8B975",
                         },
                     },
                 ]}

--- a/tests/time-slot-bar/time-slot-bar.spec.tsx
+++ b/tests/time-slot-bar/time-slot-bar.spec.tsx
@@ -102,6 +102,7 @@ describe("TimeSlotBar", () => {
         const styleAttributes = {
             backgroundColor: "#CCCCCC",
             styleType: "default" as const,
+            hoverBackgroundColor: "#AAAAAA",
         };
 
         render(
@@ -114,6 +115,34 @@ describe("TimeSlotBar", () => {
 
         expect(
             screen.getByTestId("time-slot-bar-default-timeslot")
+        ).toBeInTheDocument();
+    });
+
+    it("should render clickable slot with hoverBackgroundColor", () => {
+        const slotsWithHover: TimeSlot[] = [
+            {
+                id: "slot-hover",
+                startTime: "09:00",
+                endTime: "10:00",
+                label: "Hoverable Slot",
+                clickable: true,
+                styleAttributes: {
+                    backgroundColor: "#EF413D",
+                    hoverBackgroundColor: "#ff00e1fb",
+                },
+            },
+        ];
+
+        render(
+            <TimeSlotBar
+                {...defaultProps}
+                slots={slotsWithHover}
+                data-testid="time-slot-bar"
+            />
+        );
+
+        expect(
+            screen.getByTestId("time-slot-bar-slot-hover-timeslot")
         ).toBeInTheDocument();
     });
 

--- a/tests/time-slot-bar/time-slot-bar.spec.tsx
+++ b/tests/time-slot-bar/time-slot-bar.spec.tsx
@@ -101,8 +101,10 @@ describe("TimeSlotBar", () => {
     it("should render default time slot when styleAttributes provided", () => {
         const styleAttributes = {
             backgroundColor: "#CCCCCC",
-            styleType: "default" as const,
+            backgroundColor2: "#BBBBBB",
+            styleType: "stripes" as const,
             hoverBackgroundColor: "#AAAAAA",
+            hoverBackgroundColor2: "#999999",
         };
 
         render(
@@ -115,34 +117,6 @@ describe("TimeSlotBar", () => {
 
         expect(
             screen.getByTestId("time-slot-bar-default-timeslot")
-        ).toBeInTheDocument();
-    });
-
-    it("should render clickable slot with hoverBackgroundColor", () => {
-        const slotsWithHover: TimeSlot[] = [
-            {
-                id: "slot-hover",
-                startTime: "09:00",
-                endTime: "10:00",
-                label: "Hoverable Slot",
-                clickable: true,
-                styleAttributes: {
-                    backgroundColor: "#EF413D",
-                    hoverBackgroundColor: "#ff00e1fb",
-                },
-            },
-        ];
-
-        render(
-            <TimeSlotBar
-                {...defaultProps}
-                slots={slotsWithHover}
-                data-testid="time-slot-bar"
-            />
-        );
-
-        expect(
-            screen.getByTestId("time-slot-bar-slot-hover-timeslot")
         ).toBeInTheDocument();
     });
 


### PR DESCRIPTION
**Type of changes**

-   [x] New feature (non-breaking change which adds functionality)

**Description of changes**

-  Adds a new optional hoverBackgroundColor prop to TimeSlotBar slot style attributes, allowing consumers to specify a custom background color when hovering over a clickable time slot

**Checklist**

-   [x] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [x] Looks good on mobile and tablet
-   [x] Updated documentation
-   [x] Added/updated tests

** Screenshots**

-  Test on mobile
<img width="857" height="856" alt="image" src="https://github.com/user-attachments/assets/f5a69681-42f1-479e-9a20-9978c8ff0a40" />
<img width="951" height="916" alt="image" src="https://github.com/user-attachments/assets/4d32be06-9230-4c39-8c35-e75a12020b06" />

-  Test on tablet
<img width="1489" height="937" alt="image" src="https://github.com/user-attachments/assets/63bbf185-60ba-42cb-911a-484d4ac76ec9" />
<img width="1433" height="925" alt="image" src="https://github.com/user-attachments/assets/c6001fc3-1412-49cd-8674-e4b2ded7464c" />