### PR TITLE
Add delete action to fullscreen image carousel

### DIFF
--- a/src/fullscreen-image-carousel/fullscreen-image-carousel.style.tsx
+++ b/src/fullscreen-image-carousel/fullscreen-image-carousel.style.tsx
@@ -60,7 +60,7 @@ export const CloseButton = styled(IconButton)<InsetStyleProps>`
     }
 `;
 
-export const MagnifierButton = styled(IconButton)<InsetStyleProps>`
+export const DeleteButton = styled(IconButton)<InsetStyleProps>`
     position: absolute;
     top: ${(props) =>
         css`calc(${Spacing["spacing-48"]} + ${props.$insetTop || 0}px)`};
@@ -69,7 +69,8 @@ export const MagnifierButton = styled(IconButton)<InsetStyleProps>`
             Spacing["spacing-16"]
         } + ${
             props.$insetRight || 0
-        }px)`}; // close button + space from screen + gap between buttons
+        }px)`}; // close button + gap + space from screen
+    color: ${Colour["icon-error"]};
 
     z-index: 5;
 
@@ -81,7 +82,32 @@ export const MagnifierButton = styled(IconButton)<InsetStyleProps>`
                 Spacing["spacing-16"]
             } + ${
                 props.$insetRight || 0
-            }px)`}; // close button + space from screen + gap between buttons
+            }px)`}; // close button + gap + space from screen
+    }
+`;
+
+export const MagnifierButton = styled(IconButton)<InsetStyleProps>`
+    position: absolute;
+    top: ${(props) =>
+        css`calc(${Spacing["spacing-48"]} + ${props.$insetTop || 0}px)`};
+    right: ${(props) =>
+        css`calc(5rem + ${Spacing["spacing-48"]} + ${
+            Spacing["spacing-16"]
+        } * 2 + ${
+            props.$insetRight || 0
+        }px)`}; // close button + delete button + gaps + space from screen
+
+    z-index: 5;
+
+    ${MediaQuery.MaxWidth.sm} {
+        top: ${(props) =>
+            css`calc(${Spacing["spacing-20"]} + ${props.$insetTop || 0}px)`};
+        right: ${(props) =>
+            css`calc(5rem + ${Spacing["spacing-20"]} + ${
+                Spacing["spacing-16"]
+            } * 2 + ${
+                props.$insetRight || 0
+            }px)`}; // close button + delete button + gaps + space from screen
     }
 `;
 

--- a/src/fullscreen-image-carousel/fullscreen-image-carousel.style.tsx
+++ b/src/fullscreen-image-carousel/fullscreen-image-carousel.style.tsx
@@ -17,10 +17,6 @@ interface ThumbnailItemStyleProps {
     $active?: boolean;
 }
 
-interface TopActionButtonStyleProps extends InsetStyleProps {
-    $hasDeleteAction?: boolean;
-}
-
 // =============================================================================
 // STYLING
 // =============================================================================
@@ -48,13 +44,16 @@ const IconButton = styled(ClickableIcon)`
     }
 `;
 
-export const CloseButton = styled(IconButton)<InsetStyleProps>`
+export const TopActionButtons = styled.div<InsetStyleProps>`
     position: absolute;
     top: ${(props) =>
         css`calc(${Spacing["spacing-48"]} + ${props.$insetTop || 0}px)`};
     right: ${(props) =>
         css`calc(${Spacing["spacing-48"]} + ${props.$insetRight || 0}px)`};
     z-index: 5;
+    display: flex;
+    align-items: center;
+    gap: ${Spacing["spacing-16"]};
 
     ${MediaQuery.MaxWidth.sm} {
         top: ${(props) =>
@@ -64,64 +63,13 @@ export const CloseButton = styled(IconButton)<InsetStyleProps>`
     }
 `;
 
-export const DeleteButton = styled(IconButton)<InsetStyleProps>`
-    position: absolute;
-    top: ${(props) =>
-        css`calc(${Spacing["spacing-48"]} + ${props.$insetTop || 0}px)`};
-    right: ${(props) =>
-        css`calc(2.5rem + ${Spacing["spacing-48"]} + ${
-            Spacing["spacing-16"]
-        } + ${
-            props.$insetRight || 0
-        }px)`}; // close button + gap + space from screen
+export const CloseButton = styled(IconButton)``;
+
+export const DeleteButton = styled(IconButton)`
     color: ${Colour["icon-error"]};
-
-    z-index: 5;
-
-    ${MediaQuery.MaxWidth.sm} {
-        top: ${(props) =>
-            css`calc(${Spacing["spacing-20"]} + ${props.$insetTop || 0}px)`};
-        right: ${(props) =>
-            css`calc(2.5rem + ${Spacing["spacing-20"]} + ${
-                Spacing["spacing-16"]
-            } + ${
-                props.$insetRight || 0
-            }px)`}; // close button + gap + space from screen
-    }
 `;
 
-export const MagnifierButton = styled(IconButton)<TopActionButtonStyleProps>`
-    position: absolute;
-    top: ${(props) =>
-        css`calc(${Spacing["spacing-48"]} + ${props.$insetTop || 0}px)`};
-    right: ${(props) =>
-        props.$hasDeleteAction
-            ? css`calc(5rem + ${Spacing["spacing-48"]} + ${
-                  Spacing["spacing-16"]
-              } * 2 + ${props.$insetRight || 0}px)`
-            : css`calc(2.5rem + ${Spacing["spacing-48"]} + ${
-                  Spacing["spacing-16"]
-              } + ${
-                  props.$insetRight || 0
-              }px)`}; // close button + optional delete button + gaps + space from screen
-
-    z-index: 5;
-
-    ${MediaQuery.MaxWidth.sm} {
-        top: ${(props) =>
-            css`calc(${Spacing["spacing-20"]} + ${props.$insetTop || 0}px)`};
-        right: ${(props) =>
-            props.$hasDeleteAction
-                ? css`calc(5rem + ${Spacing["spacing-20"]} + ${
-                      Spacing["spacing-16"]
-                  } * 2 + ${props.$insetRight || 0}px)`
-                : css`calc(2.5rem + ${Spacing["spacing-20"]} + ${
-                      Spacing["spacing-16"]
-                  } + ${
-                      props.$insetRight || 0
-                  }px)`}; // close button + optional delete button + gaps + space from screen
-    }
-`;
+export const MagnifierButton = styled(IconButton)``;
 
 export const ArrowButton = styled(IconButton)<ArrowButtonStyleProps>`
     z-index: 4;

--- a/src/fullscreen-image-carousel/fullscreen-image-carousel.style.tsx
+++ b/src/fullscreen-image-carousel/fullscreen-image-carousel.style.tsx
@@ -17,6 +17,10 @@ interface ThumbnailItemStyleProps {
     $active?: boolean;
 }
 
+interface TopActionButtonStyleProps extends InsetStyleProps {
+    $hasDeleteAction?: boolean;
+}
+
 // =============================================================================
 // STYLING
 // =============================================================================
@@ -86,16 +90,20 @@ export const DeleteButton = styled(IconButton)<InsetStyleProps>`
     }
 `;
 
-export const MagnifierButton = styled(IconButton)<InsetStyleProps>`
+export const MagnifierButton = styled(IconButton)<TopActionButtonStyleProps>`
     position: absolute;
     top: ${(props) =>
         css`calc(${Spacing["spacing-48"]} + ${props.$insetTop || 0}px)`};
     right: ${(props) =>
-        css`calc(5rem + ${Spacing["spacing-48"]} + ${
-            Spacing["spacing-16"]
-        } * 2 + ${
-            props.$insetRight || 0
-        }px)`}; // close button + delete button + gaps + space from screen
+        props.$hasDeleteAction
+            ? css`calc(5rem + ${Spacing["spacing-48"]} + ${
+                  Spacing["spacing-16"]
+              } * 2 + ${props.$insetRight || 0}px)`
+            : css`calc(2.5rem + ${Spacing["spacing-48"]} + ${
+                  Spacing["spacing-16"]
+              } + ${
+                  props.$insetRight || 0
+              }px)`}; // close button + optional delete button + gaps + space from screen
 
     z-index: 5;
 
@@ -103,11 +111,15 @@ export const MagnifierButton = styled(IconButton)<InsetStyleProps>`
         top: ${(props) =>
             css`calc(${Spacing["spacing-20"]} + ${props.$insetTop || 0}px)`};
         right: ${(props) =>
-            css`calc(5rem + ${Spacing["spacing-20"]} + ${
-                Spacing["spacing-16"]
-            } * 2 + ${
-                props.$insetRight || 0
-            }px)`}; // close button + delete button + gaps + space from screen
+            props.$hasDeleteAction
+                ? css`calc(5rem + ${Spacing["spacing-20"]} + ${
+                      Spacing["spacing-16"]
+                  } * 2 + ${props.$insetRight || 0}px)`
+                : css`calc(2.5rem + ${Spacing["spacing-20"]} + ${
+                      Spacing["spacing-16"]
+                  } + ${
+                      props.$insetRight || 0
+                  }px)`}; // close button + optional delete button + gaps + space from screen
     }
 `;
 

--- a/src/fullscreen-image-carousel/fullscreen-image-carousel.tsx
+++ b/src/fullscreen-image-carousel/fullscreen-image-carousel.tsx
@@ -409,6 +409,7 @@ export const Component = (
                     <MagnifierButton
                         aria-label={zoom === 1 ? "Zoom in" : "Zoom out"}
                         onClick={handleMagnifier}
+                        $hasDeleteAction={!!onDelete}
                         $insetTop={insets?.top}
                         $insetRight={insets?.right}
                     >

--- a/src/fullscreen-image-carousel/fullscreen-image-carousel.tsx
+++ b/src/fullscreen-image-carousel/fullscreen-image-carousel.tsx
@@ -45,6 +45,7 @@ import {
     ThumbnailItem,
     ThumbnailItemContainer,
     ThumbnailWrapper,
+    TopActionButtons,
 } from "./fullscreen-image-carousel.style";
 import {
     FullscreenImageCarouselProps,
@@ -405,42 +406,40 @@ export const Component = (
                     {!hideThumbnail && renderThumbnails()}
                 </ImageGalleryContainer>
 
-                {!hideMagnifier && (
-                    <MagnifierButton
-                        aria-label={zoom === 1 ? "Zoom in" : "Zoom out"}
-                        onClick={handleMagnifier}
-                        $hasDeleteAction={!!onDelete}
-                        $insetTop={insets?.top}
-                        $insetRight={insets?.right}
-                    >
-                        {zoom === 1 ? (
-                            <MagnifierPlusIcon aria-hidden />
-                        ) : (
-                            <MagnifierMinusIcon aria-hidden />
-                        )}
-                    </MagnifierButton>
-                )}
-
-                {onDelete && currentItem && (
-                    <DeleteButton
-                        aria-label="Delete image"
-                        data-testid="delete-btn"
-                        onClick={handleDelete}
-                        $insetTop={insets?.top}
-                        $insetRight={insets?.right}
-                    >
-                        <BinIcon aria-hidden />
-                    </DeleteButton>
-                )}
-
-                <CloseButton
-                    aria-label="Close image carousel"
-                    onClick={onClose}
+                <TopActionButtons
                     $insetTop={insets?.top}
                     $insetRight={insets?.right}
                 >
-                    <CrossIcon aria-hidden />
-                </CloseButton>
+                    {!hideMagnifier && (
+                        <MagnifierButton
+                            aria-label={zoom === 1 ? "Zoom in" : "Zoom out"}
+                            onClick={handleMagnifier}
+                        >
+                            {zoom === 1 ? (
+                                <MagnifierPlusIcon aria-hidden />
+                            ) : (
+                                <MagnifierMinusIcon aria-hidden />
+                            )}
+                        </MagnifierButton>
+                    )}
+
+                    {onDelete && currentItem && (
+                        <DeleteButton
+                            aria-label="Delete image"
+                            data-testid="delete-btn"
+                            onClick={handleDelete}
+                        >
+                            <BinIcon aria-hidden />
+                        </DeleteButton>
+                    )}
+
+                    <CloseButton
+                        aria-label="Close image carousel"
+                        onClick={onClose}
+                    >
+                        <CrossIcon aria-hidden />
+                    </CloseButton>
+                </TopActionButtons>
             </CarouselModalContent>
         </ModalV2>
     );

--- a/src/fullscreen-image-carousel/fullscreen-image-carousel.tsx
+++ b/src/fullscreen-image-carousel/fullscreen-image-carousel.tsx
@@ -5,6 +5,7 @@ import {
     MagnifierMinusIcon,
     MagnifierPlusIcon,
 } from "@lifesg/react-icons";
+import { BinIcon } from "@lifesg/react-icons/bin";
 import { announce, clearAnnouncer } from "@react-aria/live-announcer";
 import {
     forwardRef,
@@ -21,6 +22,7 @@ import {
     TransformWrapper,
 } from "react-zoom-pan-pinch";
 import { ModalV2 } from "../modal-v2";
+import { useStateCallback } from "../shared/hooks";
 import { useEventListener } from "../util";
 import {
     ArrowButton,
@@ -28,6 +30,7 @@ import {
     CarouselModalContent,
     Chip,
     CloseButton,
+    DeleteButton,
     FocusableImageRegion,
     ImageGalleryContainer,
     ImageGallerySlide,
@@ -48,7 +51,6 @@ import {
     FullscreenImageCarouselRef,
     ImageDimension,
 } from "./types";
-import { useStateCallback } from "../shared/hooks";
 
 export const Component = (
     {
@@ -58,6 +60,7 @@ export const Component = (
         hideNavigation = false,
         hideCounter = false,
         hideMagnifier = false,
+        onDelete,
         onClose,
         insets,
         show,
@@ -82,6 +85,7 @@ export const Component = (
     const zoomRefs = useRef<(ReactZoomPanPinchContentRef | null)[]>([]);
     const imageRef = useRef<HTMLDivElement>(null);
     const diff = startX && endX ? startX - endX : 0;
+    const currentItem = items[currentSlide];
 
     const getImageAriaLabel = useCallback(
         (index: number) => {
@@ -112,6 +116,17 @@ export const Component = (
             imageRef.current?.focus();
         }
     }, [show]);
+
+    useEffect(() => {
+        if (items.length === 0) {
+            setCurrentSlide(0);
+            return;
+        }
+
+        if (currentSlide > items.length - 1) {
+            setCurrentSlide(items.length - 1);
+        }
+    }, [currentSlide, items.length, setCurrentSlide]);
 
     useEffect(() => {
         thumbnailRefs.current?.[currentSlide]?.scrollIntoView({
@@ -150,6 +165,12 @@ export const Component = (
         setZoom(e.state.scale);
     };
 
+    const handleDelete = () => {
+        if (currentItem && onDelete) {
+            onDelete(currentItem, currentSlide);
+        }
+    };
+
     function handleKeyDown(e: KeyboardEvent) {
         if (e.key === "ArrowRight") {
             goToNextSlide();
@@ -186,7 +207,11 @@ export const Component = (
     };
 
     const getZoomRatio = () => {
-        const imageDimension = imagesDimension[items[currentSlide].src];
+        if (!currentItem) {
+            return;
+        }
+
+        const imageDimension = imagesDimension[currentItem.src];
 
         if (containerRef.current && !!imageDimension) {
             const { clientHeight, clientWidth } = containerRef.current;
@@ -393,6 +418,18 @@ export const Component = (
                             <MagnifierMinusIcon aria-hidden />
                         )}
                     </MagnifierButton>
+                )}
+
+                {onDelete && currentItem && (
+                    <DeleteButton
+                        aria-label="Delete image"
+                        data-testid="delete-btn"
+                        onClick={handleDelete}
+                        $insetTop={insets?.top}
+                        $insetRight={insets?.right}
+                    >
+                        <BinIcon aria-hidden />
+                    </DeleteButton>
                 )}
 
                 <CloseButton

--- a/src/fullscreen-image-carousel/fullscreen-image-carousel.tsx
+++ b/src/fullscreen-image-carousel/fullscreen-image-carousel.tsx
@@ -423,7 +423,7 @@ export const Component = (
                         </MagnifierButton>
                     )}
 
-                    {onDelete && currentItem && (
+                    {onDelete && (
                         <DeleteButton
                             aria-label="Delete image"
                             data-testid="delete-btn"

--- a/src/fullscreen-image-carousel/types.ts
+++ b/src/fullscreen-image-carousel/types.ts
@@ -20,6 +20,9 @@ export interface FullscreenImageCarouselProps
     hideNavigation?: boolean | undefined;
     hideCounter?: boolean | undefined;
     hideMagnifier?: boolean | undefined;
+    onDelete?:
+        | ((item: FullscreenCarouselItemProps, index: number) => void)
+        | undefined;
     onClose?: (() => void) | undefined;
     insets?: Insets | undefined;
 }

--- a/stories/fullscreen-image-carousel/fullscreen-image-carousel.mdx
+++ b/stories/fullscreen-image-carousel/fullscreen-image-carousel.mdx
@@ -24,6 +24,10 @@ import { FullscreenImageCarousel } from "@lifesg/react-design-system/fullscreen-
 
 <Canvas of={FullscreenImageCarouselStories.WithManyImages} />
 
+## With delete button
+
+<Canvas of={FullscreenImageCarouselStories.WithDeleteButton} />
+
 ## Configurable
 
 <Canvas of={FullscreenImageCarouselStories.Configurable} />

--- a/stories/fullscreen-image-carousel/fullscreen-image-carousel.stories.tsx
+++ b/stories/fullscreen-image-carousel/fullscreen-image-carousel.stories.tsx
@@ -87,6 +87,29 @@ export const WithManyImages: StoryObj<Component> = {
     },
 };
 
+export const WithDeleteButton: StoryObj<Component> = {
+    render: (_args) => {
+        const [show, setShow] = useState(false);
+        return (
+            <>
+                <Button.Default
+                    onClick={() => {
+                        setShow((old) => !old);
+                    }}
+                >
+                    Show carousel
+                </Button.Default>
+                <FullscreenImageCarousel
+                    items={getImages(4)}
+                    show={show}
+                    onDelete={() => undefined}
+                    onClose={() => setShow(false)}
+                />
+            </>
+        );
+    },
+};
+
 export const Configurable: StoryObj<Component> = {
     render: (_args) => {
         const [show, setShow] = useState(false);

--- a/stories/fullscreen-image-carousel/props-table.tsx
+++ b/stories/fullscreen-image-carousel/props-table.tsx
@@ -79,6 +79,14 @@ const DATA: ApiTableSectionProps[] = [
                 propTypes: ["boolean"],
             },
             {
+                name: "onDelete",
+                description:
+                    "Called when the current image delete button is clicked. When provided, the delete button will be shown. If called, do not reorder the items array while a delete is in flight.",
+                propTypes: [
+                    "(item: FullscreenCarouselItemProps, index: number) => void",
+                ],
+            },
+            {
                 name: "onClose",
                 description:
                     "The callback when the carousel overlay is dimissed via the close button or Esc key",

--- a/tests/fullscreen-image-carousel/fullscreen-image-carousel.spec.tsx
+++ b/tests/fullscreen-image-carousel/fullscreen-image-carousel.spec.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import "jest-styled-components";
 import { FullscreenImageCarousel } from "../../src/fullscreen-image-carousel";
 
 // =============================================================================
@@ -41,30 +40,6 @@ describe("Fullscreen Image Carousel", () => {
         );
 
         expect(screen.getByTestId("delete-btn")).toBeInTheDocument();
-    });
-
-    it("should only reserve delete button spacing when onDelete is provided", () => {
-        const { rerender } = render(
-            <FullscreenImageCarousel items={IMAGES} show={true} />
-        );
-
-        expect(screen.getByLabelText("Zoom in")).toHaveStyleRule(
-            "right",
-            "calc(2.5rem + 48px + 16px + 0px)"
-        );
-
-        rerender(
-            <FullscreenImageCarousel
-                items={IMAGES}
-                show={true}
-                onDelete={jest.fn()}
-            />
-        );
-
-        expect(screen.getByLabelText("Zoom in")).toHaveStyleRule(
-            "right",
-            "calc(5rem + 48px + 16px * 2 + 0px)"
-        );
     });
 
     it("should call onDelete with the current item and index", () => {

--- a/tests/fullscreen-image-carousel/fullscreen-image-carousel.spec.tsx
+++ b/tests/fullscreen-image-carousel/fullscreen-image-carousel.spec.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "jest-styled-components";
 import { FullscreenImageCarousel } from "../../src/fullscreen-image-carousel";
 
 // =============================================================================
@@ -40,6 +41,30 @@ describe("Fullscreen Image Carousel", () => {
         );
 
         expect(screen.getByTestId("delete-btn")).toBeInTheDocument();
+    });
+
+    it("should only reserve delete button spacing when onDelete is provided", () => {
+        const { rerender } = render(
+            <FullscreenImageCarousel items={IMAGES} show={true} />
+        );
+
+        expect(screen.getByLabelText("Zoom in")).toHaveStyleRule(
+            "right",
+            "calc(2.5rem + 48px + 16px + 0px)"
+        );
+
+        rerender(
+            <FullscreenImageCarousel
+                items={IMAGES}
+                show={true}
+                onDelete={jest.fn()}
+            />
+        );
+
+        expect(screen.getByLabelText("Zoom in")).toHaveStyleRule(
+            "right",
+            "calc(5rem + 48px + 16px * 2 + 0px)"
+        );
     });
 
     it("should call onDelete with the current item and index", () => {

--- a/tests/fullscreen-image-carousel/fullscreen-image-carousel.spec.tsx
+++ b/tests/fullscreen-image-carousel/fullscreen-image-carousel.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { FullscreenImageCarousel } from "../../src/fullscreen-image-carousel";
 
 // =============================================================================
@@ -22,11 +22,43 @@ describe("Fullscreen Image Carousel", () => {
         render(<FullscreenImageCarousel items={IMAGES} show={true} />);
 
         expect(screen.getByTestId("image-carousel-modal")).toBeInTheDocument();
+        expect(screen.queryByTestId("delete-btn")).not.toBeInTheDocument();
 
         const slides = screen.getAllByTestId("slide-item");
         expect(slides.length).toBe(4);
         const thumbnails = screen.getAllByTestId("thumbnail-item");
         expect(thumbnails.length).toBe(4);
+    });
+
+    it("should render the delete button when onDelete is provided", () => {
+        render(
+            <FullscreenImageCarousel
+                items={IMAGES}
+                show={true}
+                onDelete={jest.fn()}
+            />
+        );
+
+        expect(screen.getByTestId("delete-btn")).toBeInTheDocument();
+    });
+
+    it("should call onDelete with the current item and index", () => {
+        const onDelete = jest.fn();
+
+        render(
+            <FullscreenImageCarousel
+                items={IMAGES}
+                show={true}
+                onDelete={onDelete}
+            />
+        );
+
+        fireEvent.click(screen.getByTestId("forward-btn"));
+        expect(screen.getByText("2/4")).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId("delete-btn"));
+
+        expect(onDelete).toHaveBeenCalledWith(IMAGES[1], 1);
     });
 
     it("should display the correct slide current based on the initialIndex", () => {
@@ -39,6 +71,30 @@ describe("Fullscreen Image Carousel", () => {
         );
 
         expect(screen.getByText("2/4")).toBeInTheDocument();
+    });
+
+    it("should clamp the current slide when items shrink", async () => {
+        const { rerender } = render(
+            <FullscreenImageCarousel
+                items={IMAGES}
+                show={true}
+                initialActiveItemIndex={3}
+            />
+        );
+
+        expect(screen.getByText("4/4")).toBeInTheDocument();
+
+        rerender(
+            <FullscreenImageCarousel
+                items={IMAGES.slice(0, 3)}
+                show={true}
+                initialActiveItemIndex={3}
+            />
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText("3/3")).toBeInTheDocument();
+        });
     });
 
     describe("Navigation", () => {

--- a/tests/fullscreen-image-carousel/fullscreen-image-carousel.spec.tsx
+++ b/tests/fullscreen-image-carousel/fullscreen-image-carousel.spec.tsx
@@ -30,19 +30,7 @@ describe("Fullscreen Image Carousel", () => {
         expect(thumbnails.length).toBe(4);
     });
 
-    it("should render the delete button when onDelete is provided", () => {
-        render(
-            <FullscreenImageCarousel
-                items={IMAGES}
-                show={true}
-                onDelete={jest.fn()}
-            />
-        );
-
-        expect(screen.getByTestId("delete-btn")).toBeInTheDocument();
-    });
-
-    it("should call onDelete with the current item and index", () => {
+    it("should render the delete button and call onDelete with the current item and index", () => {
         const onDelete = jest.fn();
 
         render(
@@ -52,6 +40,8 @@ describe("Fullscreen Image Carousel", () => {
                 onDelete={onDelete}
             />
         );
+
+        expect(screen.getByTestId("delete-btn")).toBeInTheDocument();
 
         fireEvent.click(screen.getByTestId("forward-btn"));
         expect(screen.getByText("2/4")).toBeInTheDocument();


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)

**Description of changes**

-   Link to [ticket](https://sgtechstack.atlassian.net/browse/DCUBESDQLR-2356)
-   Link to [Figma](https://www.figma.com/design/tHmHQNszVzvIamtZWixjgR/%F0%9F%8C%B1-Flagship-V3-Component-Kit?node-id=2875-26479&p=f&t=t1l5viitrMN2VlNU-0)
-   Added an optional delete action to FullscreenImageCarousel that shows a delete button when `onDelete` is provided.
-   Updated the carousel to keep the active slide index in range when the items array shrinks after deletion.
-   Added Storybook documentation for the delete button variant and updated the props table.
-   Added tests covering delete button rendering, delete callback behavior, and slide clamping after item removal.

**Checklist**

<!-- Put an `x` in items that apply -->

-   [x] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [x] Looks good on mobile and tablet
-   [x] Updated documentation
-   [x] Added/updated tests

**Screenshots**
<img width="1624" height="1061" alt="image" src="https://github.com/user-attachments/assets/c383aea9-c25d-457a-ac6d-123bee5dd983" />
