### PR TITLE
[DCUBESDQLR-2296][DAN] refactor standalone date input components to use size wrappers for improved styling

### DIFF
--- a/src/shared/standalone-date-input/standalone-date-input.style.tsx
+++ b/src/shared/standalone-date-input/standalone-date-input.style.tsx
@@ -34,6 +34,7 @@ export const InputSection = styled.div`
 export const InputContainer = styled.div<InputContainerStyleProps>`
     display: flex;
     align-items: center;
+    gap: ${Spacing["spacing-4"]};
 
     ${(props) => {
         if (props.$hover) {
@@ -46,24 +47,46 @@ export const InputContainer = styled.div<InputContainerStyleProps>`
     }}
 `;
 
+const InputSizerBase = styled.span`
+    display: inline-block;
+    position: relative;
+
+    &::after {
+        ${Font["body-baseline-regular"]}
+        visibility: hidden;
+        pointer-events: none;
+        white-space: pre;
+    }
+`;
+
+export const DayInputSizer = styled(InputSizerBase)`
+    &::after {
+        content: "DD";
+    }
+`;
+
+export const MonthInputSizer = styled(InputSizerBase)`
+    &::after {
+        content: "MM";
+    }
+`;
+
+export const YearInputSizer = styled(InputSizerBase)`
+    &::after {
+        content: "YYYY";
+    }
+`;
+
 const BaseInput = styled(BasicInput)`
     background: transparent;
     text-align: center;
+    position: absolute;
+    inset: 0;
 `;
 
-export const DayInput = styled(BaseInput)`
-    width: 2rem;
-    margin-right: ${Spacing["spacing-4"]};
-`;
-
-export const MonthInput = styled(BaseInput)`
-    width: 2.5rem;
-`;
-
-export const YearInput = styled(BaseInput)`
-    width: 3rem;
-    margin-left: ${Spacing["spacing-4"]};
-`;
+export const DayInput = styled(BaseInput)``;
+export const MonthInput = styled(BaseInput)``;
+export const YearInput = styled(BaseInput)``;
 
 export const Divider = styled.span<DividerStyleProps>`
     ${Font["body-baseline-regular"]}

--- a/src/shared/standalone-date-input/standalone-date-input.tsx
+++ b/src/shared/standalone-date-input/standalone-date-input.tsx
@@ -4,12 +4,15 @@ import React, { useEffect, useImperativeHandle, useRef, useState } from "react";
 import { DateInputHelper, StringHelper, useStateRef } from "../../util";
 import {
     DayInput,
+    DayInputSizer,
     Divider,
     InputContainer,
     InputSection,
     MonthInput,
+    MonthInputSizer,
     Placeholder,
     YearInput,
+    YearInputSizer,
 } from "./standalone-date-input.style";
 
 dayjs.extend(customParseFormat);
@@ -350,73 +353,79 @@ export const Component = (
             onFocus={handleSectionFocus}
         >
             <InputContainer ref={nodeRef} $hover={!!hoverValue}>
-                <DayInput
-                    ref={dayInputRef}
-                    name={names[0]}
-                    maxLength={2}
-                    value={hoverDayValue ?? dayValue}
-                    onFocus={handleInputFocus}
-                    onBlur={handleInputBlur}
-                    onChange={handleInputChange}
-                    type="text"
-                    inputMode={inputMode}
-                    pattern="[0-9]{2}"
-                    data-testid={`${names[0]}-input`}
-                    aria-label={inputLabels[0]}
-                    disabled={disabled}
-                    readOnly={readOnly}
-                    tabIndex={readOnly ? -1 : 0}
-                    autoComplete="off"
-                    placeholder={
-                        currentFocus === names[0] && !readOnly ? "" : "DD"
-                    }
-                />
+                <DayInputSizer>
+                    <DayInput
+                        ref={dayInputRef}
+                        name={names[0]}
+                        maxLength={2}
+                        value={hoverDayValue ?? dayValue}
+                        onFocus={handleInputFocus}
+                        onBlur={handleInputBlur}
+                        onChange={handleInputChange}
+                        type="text"
+                        inputMode={inputMode}
+                        pattern="[0-9]{2}"
+                        data-testid={`${names[0]}-input`}
+                        aria-label={inputLabels[0]}
+                        disabled={disabled}
+                        readOnly={readOnly}
+                        tabIndex={readOnly ? -1 : 0}
+                        autoComplete="off"
+                        placeholder={
+                            currentFocus === names[0] && !readOnly ? "" : "DD"
+                        }
+                    />
+                </DayInputSizer>
                 <Divider $inactive={dayValue.length === 0}>/</Divider>
-                <MonthInput
-                    ref={monthInputRef}
-                    name={names[1]}
-                    maxLength={2}
-                    value={hoverMonthValue ?? monthValue}
-                    onFocus={handleInputFocus}
-                    onBlur={handleInputBlur}
-                    onChange={handleInputChange}
-                    onKeyDown={handleKeyDown}
-                    type="text"
-                    inputMode={inputMode}
-                    pattern="[0-9]{2}"
-                    data-testid={`${names[1]}-input`}
-                    aria-label={inputLabels[1]}
-                    disabled={disabled}
-                    readOnly={readOnly}
-                    tabIndex={readOnly ? -1 : 0}
-                    autoComplete="off"
-                    placeholder={
-                        currentFocus === names[1] && !readOnly ? "" : "MM"
-                    }
-                />
+                <MonthInputSizer>
+                    <MonthInput
+                        ref={monthInputRef}
+                        name={names[1]}
+                        maxLength={2}
+                        value={hoverMonthValue ?? monthValue}
+                        onFocus={handleInputFocus}
+                        onBlur={handleInputBlur}
+                        onChange={handleInputChange}
+                        onKeyDown={handleKeyDown}
+                        type="text"
+                        inputMode={inputMode}
+                        pattern="[0-9]{2}"
+                        data-testid={`${names[1]}-input`}
+                        aria-label={inputLabels[1]}
+                        disabled={disabled}
+                        readOnly={readOnly}
+                        tabIndex={readOnly ? -1 : 0}
+                        autoComplete="off"
+                        placeholder={
+                            currentFocus === names[1] && !readOnly ? "" : "MM"
+                        }
+                    />
+                </MonthInputSizer>
                 <Divider $inactive={monthValue.length === 0}>/</Divider>
-                <YearInput
-                    ref={yearInputRef}
-                    name={names[2]}
-                    maxLength={4}
-                    value={hoverYearValue ?? yearValue}
-                    onFocus={handleInputFocus}
-                    onBlur={handleInputBlur}
-                    onChange={handleInputChange}
-                    onKeyDown={handleKeyDown}
-                    type="text"
-                    inputMode={inputMode}
-                    pattern="[0-9]{4}"
-                    data-testid={`${names[2]}-input`}
-                    aria-label={inputLabels[2]}
-                    disabled={disabled}
-                    readOnly={readOnly}
-                    tabIndex={readOnly ? -1 : 0}
-                    autoComplete="off"
-                    placeholder={
-                        currentFocus === names[2] && !readOnly ? "" : "YYYY"
-                    }
-                />
+                <YearInputSizer>
+                    <YearInput
+                        ref={yearInputRef}
+                        name={names[2]}
+                        maxLength={4}
+                        value={hoverYearValue ?? yearValue}
+                        onFocus={handleInputFocus}
+                        onBlur={handleInputBlur}
+                        onChange={handleInputChange}
+                        onKeyDown={handleKeyDown}
+                        type="text"
+                        inputMode={inputMode}
+                        pattern="[0-9]{4}"
+                        data-testid={`${names[2]}-input`}
+                        aria-label={inputLabels[2]}
+                        disabled={disabled}
+                        readOnly={readOnly}
+                        tabIndex={readOnly ? -1 : 0}
+                        autoComplete="off"
+                        placeholder={
+                            currentFocus === names[2] && !readOnly ? "" : "YYYY"
+                        }
+                    />
+                </YearInputSizer>
             </InputContainer>
             {renderPlaceholder()}
         </InputSection>


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)

**Description of changes**

-   Link to [ticket](https://sgtechstack.atlassian.net/browse/DCUBESDQLR-2296)
-   Link to [Figma](N/A - styling fix, no design changes)
-   Fixed date input field widths to adapt to different theme fonts (e.g., SGWDigitalLobby). Replaced fixed **rem** widths with ghost-sizing wrappers that measure placeholder text ("DD", "MM", "YYYY") in the actual theme font, preventing clipping in larger fonts while keeping consistent spacing.

**Checklist**

<!-- Put an `x` in items that apply -->

-   [x] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [x] Looks good on mobile and tablet
-   [ ] Updated documentation
-   [ ] Added/updated tests



