### PR TITLE
[BOOKINGSG-9215][GZ] fix broken css import

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,11 +1,12 @@
+import fs from "node:fs";
+import path from "node:path";
+
 import commonjs from "@rollup/plugin-commonjs";
 import image from "@rollup/plugin-image";
 import json from "@rollup/plugin-json";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import terser from "@rollup/plugin-terser";
 import wyw from "@wyw-in-js/rollup";
-import fs from "fs";
-import path from "path";
 import postcssImports from "postcss-import";
 import copy from "rollup-plugin-copy";
 import excludeDependenciesFromBundle from "rollup-plugin-exclude-dependencies-from-bundle";
@@ -13,7 +14,18 @@ import generatePackageJson from "rollup-plugin-generate-package-json";
 import { libStylePlugin } from "rollup-plugin-lib-style";
 import typescript from "rollup-plugin-typescript2";
 
-const dirsToIgnore = ["custom-types", "shared", "util", "v2_spec", "__mocks__"];
+import { createFixCssImportPathsPlugin } from "./rollup/fix-css-import-paths-plugin.js";
+
+const fixCssImportPathsPlugin = createFixCssImportPathsPlugin({
+    outputDirs: ["dist", "dist/cjs"],
+});
+const dirsToIgnore = new Set([
+    "custom-types",
+    "shared",
+    "util",
+    "v2_spec",
+    "__mocks__",
+]);
 
 const srcDir = "src";
 const subDirs = fs
@@ -22,7 +34,7 @@ const subDirs = fs
         (dirent) =>
             dirent.isDirectory() &&
             fs.existsSync(path.join(srcDir, dirent.name, "index.ts")) &&
-            !dirsToIgnore.includes(dirent.name)
+            !dirsToIgnore.has(dirent.name)
     )
     .map((dirent) => dirent.name);
 
@@ -118,10 +130,6 @@ const plugins = [
     // Injects an import statement in the source style file and outputs CSS in the same location.
     libStylePlugin({
         exclude: ["**/node_modules/**"],
-        customCSSInjectedPath: (id) => {
-            const filename = path.basename(id);
-            return "/" + filename;
-        },
         customCSSPath: (id) => {
             const relative = path.relative(process.cwd(), id);
             const outputPath = relative.replace("src/", "");
@@ -148,6 +156,7 @@ const plugins = [
     copy({
         targets: [{ src: "src/theme/styles/*", dest: "dist/theme/styles" }],
     }),
+    fixCssImportPathsPlugin,
 ];
 
 const libraryBuildConfig = {
@@ -165,7 +174,7 @@ const libraryBuildConfig = {
             entryFileNames: (chunkInfo) => {
                 if (chunkInfo.name.includes("node_modules")) {
                     return (
-                        chunkInfo.name.replace(/node_modules/g, "external") +
+                        chunkInfo.name.replaceAll("node_modules", "external") +
                         ".js"
                     );
                 }
@@ -184,7 +193,7 @@ const libraryBuildConfig = {
             entryFileNames: (chunkInfo) => {
                 if (chunkInfo.name.includes("node_modules")) {
                     return (
-                        chunkInfo.name.replace(/node_modules/g, "external") +
+                        chunkInfo.name.replaceAll("node_modules", "external") +
                         ".js"
                     );
                 }

--- a/rollup/fix-css-import-paths-plugin.js
+++ b/rollup/fix-css-import-paths-plugin.js
@@ -3,6 +3,7 @@ import path from "node:path";
 
 const IMPORT_CSS_REGEX = /(import\s*["'])([^"']+\.css)(["'])/g;
 const REQUIRE_CSS_REGEX = /(require\(\s*["'])([^"']+\.css)(["']\s*\))/g;
+const LIB_STYLE_MAGIC_PREFIX = "@@_MAGIC_PATH_@@";
 
 // Recursively collects files with a given extension while skipping selected
 // output directories (for example, skip dist/cjs while processing dist).
@@ -41,15 +42,26 @@ const toRelativeImportPath = (fromFile, toFile) => {
 const isFixableCssImportPath = (importPath) => {
     return (
         importPath.endsWith(".css") &&
-        (importPath.startsWith(".") || importPath.startsWith("/"))
+        (importPath.startsWith(".") ||
+            importPath.startsWith("/") ||
+            importPath.startsWith(LIB_STYLE_MAGIC_PREFIX))
     );
 };
 
+const normalizeImportPath = (importPath) => {
+    if (!importPath.startsWith(LIB_STYLE_MAGIC_PREFIX)) return importPath;
+
+    const stripped = importPath.slice(LIB_STYLE_MAGIC_PREFIX.length);
+    return stripped.startsWith("/") ? stripped : `/${stripped}`;
+};
+
 const resolveImportedCssPath = ({ outputDir, jsFile, importPath }) => {
-    if (importPath.startsWith("/")) {
-        return path.resolve(outputDir, "." + importPath);
+    const normalizedPath = normalizeImportPath(importPath);
+
+    if (normalizedPath.startsWith("/")) {
+        return path.resolve(outputDir, "." + normalizedPath);
     }
-    return path.resolve(path.dirname(jsFile), importPath);
+    return path.resolve(path.dirname(jsFile), normalizedPath);
 };
 
 const indexCssByBasename = (cssFiles) => {
@@ -72,6 +84,14 @@ const getRewrittenCssImportPath = ({
     cssByBasename,
 }) => {
     if (!isFixableCssImportPath(importPath)) return null;
+
+    if (importPath.startsWith(LIB_STYLE_MAGIC_PREFIX)) {
+        const normalizedPath = normalizeImportPath(importPath);
+        const resolvedMagicPath = path.resolve(outputDir, "." + normalizedPath);
+        if (fs.existsSync(resolvedMagicPath)) {
+            return toRelativeImportPath(jsFile, resolvedMagicPath);
+        }
+    }
 
     const resolvedPath = resolveImportedCssPath({
         outputDir,

--- a/rollup/fix-css-import-paths-plugin.js
+++ b/rollup/fix-css-import-paths-plugin.js
@@ -101,6 +101,13 @@ const getRewrittenCssImportPath = ({
     if (fs.existsSync(resolvedPath)) return null;
 
     const cssMatches = cssByBasename.get(path.basename(importPath));
+    if (cssMatches?.length > 1) {
+        console.warn(
+            `[fix-css-import-paths] Skipping rewrite: multiple CSS files found for "${path.basename(
+                importPath
+            )}" in ${jsFile}:\n` + cssMatches.map((f) => `  - ${f}`).join("\n")
+        );
+    }
     if (cssMatches?.length !== 1) return null;
 
     return toRelativeImportPath(jsFile, cssMatches[0]);

--- a/rollup/fix-css-import-paths-plugin.js
+++ b/rollup/fix-css-import-paths-plugin.js
@@ -1,0 +1,173 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const IMPORT_CSS_REGEX = /(import\s*["'])([^"']+\.css)(["'])/g;
+const REQUIRE_CSS_REGEX = /(require\(\s*["'])([^"']+\.css)(["']\s*\))/g;
+
+// Recursively collects files with a given extension while skipping selected
+// output directories (for example, skip dist/cjs while processing dist).
+const collectFiles = (dir, extension, files = [], ignoredDirs = new Set()) => {
+    if (!fs.existsSync(dir)) return files;
+
+    const resolvedDir = path.resolve(dir);
+    if (ignoredDirs.has(resolvedDir)) return files;
+
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+            collectFiles(fullPath, extension, files, ignoredDirs);
+            continue;
+        }
+
+        if (entry.isFile() && fullPath.endsWith(extension)) {
+            files.push(fullPath);
+        }
+    }
+
+    return files;
+};
+
+// Ensures rewritten imports are valid module specifiers.
+const toRelativeImportPath = (fromFile, toFile) => {
+    const relativePath = path
+        .relative(path.dirname(fromFile), toFile)
+        .split(path.sep)
+        .join("/");
+    return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
+};
+
+const isFixableCssImportPath = (importPath) => {
+    return (
+        importPath.endsWith(".css") &&
+        (importPath.startsWith(".") || importPath.startsWith("/"))
+    );
+};
+
+const resolveImportedCssPath = ({ outputDir, jsFile, importPath }) => {
+    if (importPath.startsWith("/")) {
+        return path.resolve(outputDir, "." + importPath);
+    }
+    return path.resolve(path.dirname(jsFile), importPath);
+};
+
+const indexCssByBasename = (cssFiles) => {
+    const cssByBasename = new Map();
+
+    for (const cssFile of cssFiles) {
+        const basename = path.basename(cssFile);
+        const matches = cssByBasename.get(basename) || [];
+        matches.push(cssFile);
+        cssByBasename.set(basename, matches);
+    }
+
+    return cssByBasename;
+};
+
+const getRewrittenCssImportPath = ({
+    outputDir,
+    jsFile,
+    importPath,
+    cssByBasename,
+}) => {
+    if (!isFixableCssImportPath(importPath)) return null;
+
+    const resolvedPath = resolveImportedCssPath({
+        outputDir,
+        jsFile,
+        importPath,
+    });
+    if (fs.existsSync(resolvedPath)) return null;
+
+    const cssMatches = cssByBasename.get(path.basename(importPath));
+    if (cssMatches?.length !== 1) return null;
+
+    return toRelativeImportPath(jsFile, cssMatches[0]);
+};
+
+const rewriteCssImportsInJsSource = ({
+    source,
+    outputDir,
+    jsFile,
+    cssByBasename,
+}) => {
+    const replaceImportPath = (full, prefix, importPath, suffix) => {
+        const rewrittenImportPath = getRewrittenCssImportPath({
+            outputDir,
+            jsFile,
+            importPath,
+            cssByBasename,
+        });
+
+        if (!rewrittenImportPath) return full;
+        return `${prefix}${rewrittenImportPath}${suffix}`;
+    };
+
+    return source
+        .replaceAll(IMPORT_CSS_REGEX, replaceImportPath)
+        .replaceAll(REQUIRE_CSS_REGEX, replaceImportPath);
+};
+
+// For each output root, mark nested output roots as ignored to prevent
+// basename collisions between ESM/CJS trees.
+const buildIgnoredDirsMap = (outputDirs) => {
+    const resolvedDirs = outputDirs.map((dir) => path.resolve(dir));
+    const ignoredByDir = new Map();
+
+    for (const baseDir of resolvedDirs) {
+        const ignored = new Set();
+        for (const candidate of resolvedDirs) {
+            if (candidate === baseDir) continue;
+            if (candidate.startsWith(baseDir + path.sep)) {
+                ignored.add(candidate);
+            }
+        }
+        ignoredByDir.set(baseDir, ignored);
+    }
+
+    return ignoredByDir;
+};
+
+// Rewrites only broken CSS imports in emitted JS files.
+// Context:
+// - rollup-plugin-lib-style uses a global magic path replacement.
+// - with preserveModules, nested chunks can end up with incorrect relative CSS paths.
+// - this repairs those imports after final files are written.
+const rewriteBrokenCssImports = (outputDir, ignoredDirs = new Set()) => {
+    const cssFiles = collectFiles(outputDir, ".css", [], ignoredDirs);
+    const jsFiles = collectFiles(outputDir, ".js", [], ignoredDirs);
+    const cssByBasename = indexCssByBasename(cssFiles);
+
+    for (const jsFile of jsFiles) {
+        const source = fs.readFileSync(jsFile, "utf8");
+        const rewritten = rewriteCssImportsInJsSource({
+            source,
+            outputDir,
+            jsFile,
+            cssByBasename,
+        });
+
+        if (rewritten !== source) {
+            fs.writeFileSync(jsFile, rewritten);
+        }
+    }
+};
+
+// Rollup plugin factory that runs the repair pass in closeBundle.
+export const createFixCssImportPathsPlugin = ({ outputDirs }) => {
+    const ignoredDirsByOutput = buildIgnoredDirsMap(outputDirs);
+
+    return {
+        name: "fix-css-import-paths",
+        closeBundle() {
+            for (const outputDir of outputDirs) {
+                const resolved = path.resolve(outputDir);
+                rewriteBrokenCssImports(
+                    outputDir,
+                    ignoredDirsByOutput.get(resolved)
+                );
+            }
+        },
+    };
+};


### PR DESCRIPTION
## **Type of changes**

<!-- Put an `x` in the items that apply -->

-   [X] Bug fix (non-breaking change which fixes an issue) for [Invalid import path in build](https://sgtechstack.atlassian.net/browse/BOOKINGSG-9215)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)

## Summary
Fixes broken CSS import paths in DS package artifacts, which caused Next.js consumer builds to fail

## Root Cause
`rollup-plugin-lib-style` uses global magic-path replacement, which is not per-importer-file aware. With nested preserved modules and transitive style dependencies, this can produce invalid relative CSS imports.

## Changes
Adds a local post-build Rollup plugin, it works by
- scans emitted JS and CSS files per output directory
- detects broken CSS import paths
- rewrites to correct relative paths based on actual emitted CSS location
- skips ambiguous basename matches

## **Checklist**

<!-- Put an `x` in items that apply -->

-   [X] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [ ] Looks good on mobile and tablet
-   [ ] Updated documentation
-   [ ] Added/updated tests

