### PR TITLE
Fix failing style unit test

### DIFF
--- a/tests/alert/alert.spec.tsx
+++ b/tests/alert/alert.spec.tsx
@@ -29,15 +29,18 @@ describe("Alert", () => {
             ${"warning"}     | ${Colour["bg-warning"]} | ${Colour["border-warning"]}
             ${"error"}       | ${Colour["bg-error"]}   | ${Colour["border-error"]}
             ${"info"}        | ${Colour["bg-info"]}    | ${Colour["border-info"]}
-            ${"description"} | ${Colour["bg-strong"]}  | ${Colour["border"]}
+            ${"description"} | ${Colour["bg-strong"]}  | ${Colour["border-strong"]}
         `(
             "should render background $backgroundColor with border $borderColor for $type type",
             ({ type, backgroundColor, borderColor }) => {
-                render(<Alert type={type}>{DEFAULT_TEXT}</Alert>);
-
-                expect(screen.getByText(DEFAULT_TEXT)).toHaveStyle({
-                    backgroundColor,
-                    borderColor: `2px solid ${borderColor}`,
+                render(
+                    <Alert data-testid="alert" type={type}>
+                        {DEFAULT_TEXT}
+                    </Alert>
+                );
+                expect(screen.getByTestId("alert")).toHaveStyle({
+                    background: backgroundColor,
+                    borderLeftColor: borderColor,
                 });
             }
         );


### PR DESCRIPTION
**Description of changes**

-   One of the alert unit tests is failing on the main branch, suspect the jsdom upgrade changed something since the tests passed on the PR branch
- Seems to work again just by making sure the target element is the main parent that received the variant class name and to target the exact properties

**Checklist**

<!-- Put an `x` in items that apply -->

-   [x] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [ ] ~~Looks good on mobile and tablet~~
-   [ ] ~~Updated documentation~~
-   [ ] ~~Added/updated tests~~

**Screenshots**

N/A