### PR TITLE
[MOL-20717][RP] remove divider from link-container variant

### DIFF
--- a/src/language-switcher/link-container-variant.style.tsx
+++ b/src/language-switcher/link-container-variant.style.tsx
@@ -35,13 +35,6 @@ export const LinkListItem = styled.li`
     align-items: center;
 `;
 
-export const LinkDivider = styled.span`
-    width: ${Border["width-010"]};
-    height: 1rem;
-    background: ${Colour["border-strong"]};
-    flex-shrink: 0;
-`;
-
 export const LinkItem = styled.button<LinkItemStyleProps>`
     display: flex;
     padding: 0.25rem 0.5rem;

--- a/src/language-switcher/link-container-variant.tsx
+++ b/src/language-switcher/link-container-variant.tsx
@@ -1,7 +1,6 @@
 import React, { useRef } from "react";
 import {
     LinkContainerWrapper,
-    LinkDivider,
     LinkItem,
     LinkList,
     LinkListItem,
@@ -62,30 +61,23 @@ export const LinkContainerVariant = ({
                 {LANGUAGE_CODES.map((code, index) => {
                     const isActive = code === selectedLanguage;
                     return (
-                        <React.Fragment key={code}>
-                            {index > 0 && (
-                                <li aria-hidden>
-                                    <LinkDivider />
-                                </li>
-                            )}
-                            <LinkListItem>
-                                <LinkItem
-                                    ref={(el) => {
-                                        itemRefs.current[index] = el;
-                                    }}
-                                    type="button"
-                                    lang={code}
-                                    $active={isActive}
-                                    aria-pressed={isActive}
-                                    tabIndex={isActive ? 0 : -1}
-                                    onClick={() => onSelectLanguage(code)}
-                                    onKeyDown={(e) => handleKeyDown(e, index)}
-                                    data-testid={`${testId}--item-${code}`}
-                                >
-                                    {LANGUAGE_DISPLAY_MAP[code]}
-                                </LinkItem>
-                            </LinkListItem>
-                        </React.Fragment>
+                        <LinkListItem key={code}>
+                            <LinkItem
+                                ref={(el) => {
+                                    itemRefs.current[index] = el;
+                                }}
+                                type="button"
+                                lang={code}
+                                $active={isActive}
+                                aria-pressed={isActive}
+                                tabIndex={isActive ? 0 : -1}
+                                onClick={() => onSelectLanguage(code)}
+                                onKeyDown={(e) => handleKeyDown(e, index)}
+                                data-testid={`${testId}--item-${code}`}
+                            >
+                                {LANGUAGE_DISPLAY_MAP[code]}
+                            </LinkItem>
+                        </LinkListItem>
                     );
                 })}
             </LinkList>


### PR DESCRIPTION
What changed:

- Removed the LinkDivider style — The styled separator component that was a 1px vertical line between language options is gone from link-container-variant.style.tsx.

- Simplified the render logic — In link-container-variant.tsx, we removed the conditional that inserted a separator between each language button

- Cleaned up JSX structure — The map now directly renders <LinkListItem> for each language instead of wrapping it in a Fragment with conditional divider logic.

No side effects — Nothing else in the codebase referenced LinkDivider, so the change is isolated and clean. Keyboard navigation and all other functionality remain unchanged.