### PR TITLE
[MOL-20727]Memorize Masthead component

### DIFF
--- a/src/masthead/masthead.tsx
+++ b/src/masthead/masthead.tsx
@@ -1,11 +1,11 @@
 import "@govtechsg/sgds-web-component/themes/day.css";
 import "@govtechsg/sgds-web-component/themes/night.css";
-import { useContext, useEffect } from "react";
+import { memo, useContext, useEffect } from "react";
 import { ThemeContext } from "styled-components";
 import { Wrapper } from "./masthead.style";
 import { MastheadProps } from "./types";
 
-export const Masthead = ({ stretch = false }: MastheadProps): JSX.Element => {
+const MastheadComponent = ({ stretch = false }: MastheadProps): JSX.Element => {
     const theme = useContext(ThemeContext);
     const isDarkMode = theme?.colourMode === "dark";
 
@@ -66,6 +66,8 @@ export const Masthead = ({ stretch = false }: MastheadProps): JSX.Element => {
         <Wrapper dangerouslySetInnerHTML={createContent()} $stretch={stretch} />
     );
 };
+
+export const Masthead = memo(MastheadComponent);
 
 // =============================================================================
 // CONSTANTS


### PR DESCRIPTION
**Type of changes**

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)

**Description of changes**

- Link to [ticket](https://sgtechstack.atlassian.net/browse/MOL-20727)
- Memorize `Masthead` component to avoid unwanted re-renders.

**Checklist**

- [ ] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
- [x] Looks good on mobile and tablet
- [ ] Updated documentation
- [ ] Added/updated tests

**Notes**

- **Background**: On the LifeSG web landing page, at resolution 1135×1666, clicking on the `How to identify` text doesn’t open the detail panel—it closes immediately instead.
- **Root cause**: Clicking on `How to identify` somehow triggers a re-render of the NavBar component, which also causes the Masthead component to re-render. When Masthead re-mounted. This resets the panel’s visibility state, leading to the behavior described above.