### PR TITLE
Narrow modal child typings

### DIFF
--- a/src/modal-v2/modal-v2.tsx
+++ b/src/modal-v2/modal-v2.tsx
@@ -37,8 +37,7 @@ export const ModalV2 = ({
     const { verticalHeight, offsetTop } = useViewport();
     const childRef = useRef<HTMLDivElement>(null);
     const childWithRef =
-        children &&
-        React.cloneElement(children as React.ReactElement, { ref: childRef });
+        children && React.cloneElement(children, { ref: childRef });
 
     // =========================================================================
     // FLOATING UI CONFIG

--- a/src/modal-v2/types.ts
+++ b/src/modal-v2/types.ts
@@ -25,7 +25,11 @@ export interface ModalFooterProps extends React.HTMLAttributes<HTMLDivElement> {
 export interface ModalV2Props extends React.HTMLAttributes<HTMLDivElement> {
     "data-testid"?: string | undefined;
     show: boolean;
-    children: React.ReactNode;
+    /** The content of the modal. The parent element must be a valid HTML
+     * element or a component that forwards a ref to a valid HTML element. This
+     * element is used to determine the boundaries for overlay click
+     * detection. Fragments are not supported. */
+    children: React.JSX.Element;
     /** Animation direction of appearance and dismissal. Values: "top" | "bottom" | "left" | "right" */
     animationFrom?: ModalAnimationDirection | undefined;
     enableOverlayClick?: boolean | undefined;

--- a/src/modal/modal.tsx
+++ b/src/modal/modal.tsx
@@ -23,8 +23,7 @@ export const Modal = ({
     const { verticalHeight, offsetTop } = useViewport();
     const childRef = useRef<HTMLDivElement>(null);
     const childWithRef =
-        children &&
-        React.cloneElement(children as React.ReactElement, { ref: childRef });
+        children && React.cloneElement(children, { ref: childRef });
 
     // =============================================================================
     // EFFECTS

--- a/src/modal/types.ts
+++ b/src/modal/types.ts
@@ -2,7 +2,11 @@ import { ModalAnimationDirection } from "../modal-v2/types";
 
 export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
     show: boolean;
-    children: React.ReactNode;
+    /** The content of the modal. The parent element must be a valid HTML
+     * element or a component that forwards a ref to a valid HTML element. This
+     * element is used to determine the boundaries for overlay click
+     * detection. Fragments are not supported. */
+    children: React.JSX.Element;
     /** Animation direction of appearance and dismissal. Values: "top" | "bottom" | "left" | "right" */
     animationFrom?: ModalAnimationDirection | undefined;
     enableOverlayClick?: boolean | undefined;

--- a/src/overlay/types.ts
+++ b/src/overlay/types.ts
@@ -1,9 +1,8 @@
 export interface OverlayProps {
     children?: JSX.Element | undefined;
     show?: boolean | undefined;
-    rootId?:
-        | string
-        | undefined /* the id of the root element to attach the overlay to */;
+    /** The id of the root element to attach the overlay to */
+    rootId?: string | undefined;
     /** @deprecated no longer has effect */
     backgroundOpacity?: number | undefined;
     backgroundBlur?: boolean | undefined;
@@ -12,6 +11,7 @@ export interface OverlayProps {
     zIndex?: number | undefined;
     onOverlayClick?: (() => void) | undefined;
     id?: string | undefined;
+    /** The container that defines the boundaries for overlay click detection */
     containerRef?: React.RefObject<HTMLElement> | undefined;
 }
 

--- a/stories/modal-v2/props-table.tsx
+++ b/stories/modal-v2/props-table.tsx
@@ -14,6 +14,19 @@ const MODAL_DATA: ApiTableSectionProps[] = [
                 propTypes: ["string"],
             },
             {
+                name: "children",
+                description: (
+                    <>
+                        The content of the modal. The parent element must be a
+                        valid HTML element or a component that forwards a ref to
+                        a valid HTML element. This element is used to determine
+                        the boundaries for overlay click detection. Note:
+                        Fragments are not supported.
+                    </>
+                ),
+                propTypes: ["JSX.Element"],
+            },
+            {
                 name: "show",
                 mandatory: true,
                 description: (

--- a/stories/modal/props-table.tsx
+++ b/stories/modal/props-table.tsx
@@ -1,114 +1,113 @@
 import {
-    DefaultCol,
-    DescriptionCol,
-    NameCol,
-    Table,
-} from "../storybook-common/api-table";
-import { TabAttribute, Tabs } from "../storybook-common/tabs";
+    ApiTable,
+    ApiTableSectionProps,
+    TabAttribute,
+    Tabs,
+} from "stories/storybook-common";
 
-export const ModalTable = () => (
-    <Table>
-        <tr>
-            <NameCol mandatory>show</NameCol>
-            <DescriptionCol propTypes={["boolean"]}>
-                <>
-                    Toggles the visibility of the <code>Modal</code>
-                </>
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-        <tr>
-            <NameCol>rootComponentId</NameCol>
-            <DescriptionCol propTypes={["string"]}>
-                <>
-                    The identifier of the element to inject the{" "}
-                    <code>Modal</code> into. Not specifying the root element
-                    will make <code>{`<body>`}</code> the root element.
-                </>
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-        <tr>
-            <NameCol>animationFrom</NameCol>
-            <DescriptionCol
-                propTypes={[`"top"`, `"bottom"`, `"left"`, `"right"`]}
-            >
-                <>
-                    The animation direction of which the <code>Modal</code> will
-                    appear
-                </>
-            </DescriptionCol>
-            <DefaultCol>{[`"bottom"`]}</DefaultCol>
-        </tr>
-        <tr>
-            <NameCol>enableOverlayClick</NameCol>
-            <DescriptionCol propTypes={["boolean"]}>
-                <>
-                    Toggles whether <code>Modal</code> can be dismissed by
-                    clicking on the overlay
-                </>
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-        <tr>
-            <NameCol>zIndex</NameCol>
-            <DescriptionCol propTypes={["number"]}>
-                <>
-                    Allows a custom <code>z-index</code> to be specified (useful
-                    for modal stacking)
-                </>
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-        <tr>
-            <NameCol>onOverlayClick</NameCol>
-            <DescriptionCol propTypes={["() => void"]}>
-                <>
-                    The callback when the overlay is being clicked on. Will be
-                    triggered if <code>enableOverlayClick</code>
-                    is specified to <code>true</code>
-                </>
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-        <tr>
-            <NameCol>dismissKeyboardOnShow</NameCol>
-            <DescriptionCol propTypes={["boolean"]}>
-                <>Dismisses keyboard when modal is shown</>
-            </DescriptionCol>
-            <DefaultCol>{["true"]}</DefaultCol>
-        </tr>
-    </Table>
-);
+const MODAL_DATA: ApiTableSectionProps[] = [
+    {
+        attributes: [
+            {
+                name: "show",
+                mandatory: true,
+                description: (
+                    <>
+                        Toggles the visibility of the <code>Modal</code>
+                    </>
+                ),
+                propTypes: ["boolean"],
+            },
+            {
+                name: "rootComponentId",
+                description: (
+                    <>
+                        The identifier of the element to inject the{" "}
+                        <code>Modal</code> into. Not specifying the root element
+                        will make <code>{`<body>`}</code> the root element.
+                    </>
+                ),
+                propTypes: ["string"],
+            },
+            {
+                name: "animationFrom",
+                description: (
+                    <>
+                        The animation direction of which the <code>Modal</code>{" "}
+                        will appear
+                    </>
+                ),
+                propTypes: [`"top"`, `"bottom"`, `"left"`, `"right"`],
+                defaultValue: `"bottom"`,
+            },
+            {
+                name: "enableOverlayClick",
+                description: (
+                    <>
+                        Toggles whether <code>Modal</code> can be dismissed by
+                        clicking on the overlay
+                    </>
+                ),
+                propTypes: ["boolean"],
+            },
+            {
+                name: "zIndex",
+                description: (
+                    <>
+                        Allows a custom <code>z-index</code> to be specified
+                        (useful for modal stacking)
+                    </>
+                ),
+                propTypes: ["number"],
+            },
+            {
+                name: "onOverlayClick",
+                description: (
+                    <>
+                        The callback when the overlay is being clicked on. Will
+                        be triggered if <code>enableOverlayClick</code> is
+                        specified to <code>true</code>
+                    </>
+                ),
+                propTypes: ["() => void"],
+            },
+            {
+                name: "dismissKeyboardOnShow",
+                description: "Dismisses keyboard when modal is shown",
+                propTypes: ["boolean"],
+                defaultValue: "true",
+            },
+        ],
+    },
+];
 
-export const ModalBoxTable = () => (
-    <Table>
-        <tr>
-            <NameCol>showCloseButton</NameCol>
-            <DescriptionCol propTypes={["boolean"]}>
-                This toggles the visibility of the close button
-            </DescriptionCol>
-            <DefaultCol>{["true"]}</DefaultCol>
-        </tr>
-        <tr>
-            <NameCol>onClose</NameCol>
-            <DescriptionCol propTypes={["() => void"]}>
-                Callback when the close button is clicked. Will be triggered if
-                the close button is visible
-            </DescriptionCol>
-            <DefaultCol />
-        </tr>
-    </Table>
-);
+const MODAL_BOX_DATA: ApiTableSectionProps[] = [
+    {
+        attributes: [
+            {
+                name: "showCloseButton",
+                description: "This toggles the visibility of the close button",
+                propTypes: ["boolean"],
+                defaultValue: "true",
+            },
+            {
+                name: "onClose",
+                description:
+                    "Callback when the close button is clicked. Will be triggered if the close button is visible",
+                propTypes: ["() => void"],
+            },
+        ],
+    },
+];
 
 const PROPS_TABLE_DATA: TabAttribute[] = [
     {
         title: "Modal",
-        component: <ModalTable />,
+        component: <ApiTable sections={MODAL_DATA} />,
     },
     {
         title: "Modal.Box",
-        component: <ModalBoxTable />,
+        component: <ApiTable sections={MODAL_BOX_DATA} />,
     },
 ];
 

--- a/stories/modal/props-table.tsx
+++ b/stories/modal/props-table.tsx
@@ -9,6 +9,19 @@ const MODAL_DATA: ApiTableSectionProps[] = [
     {
         attributes: [
             {
+                name: "children",
+                description: (
+                    <>
+                        The content of the modal. The parent element must be a
+                        valid HTML element or a component that forwards a ref to
+                        a valid HTML element. This element is used to determine
+                        the boundaries for overlay click detection. Note:
+                        Fragments are not supported.
+                    </>
+                ),
+                propTypes: ["JSX.Element"],
+            },
+            {
                 name: "show",
                 mandatory: true,
                 description: (


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing apis or functionality to change)

**Description of changes**

- Modal expects a valid parent element (component or inlined JSX) so that it can forward the ref to the element to detect the container boundaries
- However the typing for ReactNode allows strings and multiple children, which don't work with `cloneElement` and causes an error during rendering
- One way to limit this issue is to make the typings stricter. Though it is not possible to detect Fragments afaik; a fragment does not cause an error, but overlay click detection will no longer work

**Checklist**

<!-- Put an `x` in items that apply -->

-   [x] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [ ] ~~Looks good on mobile and tablet~~
-   [x] Updated documentation
-   [ ] ~~Added/updated tests~~
