### PR TITLE
[BOOKINGSG-9306][GZ] remove date input style dependency

### DIFF
--- a/src/shared/standalone-date-input/standalone-date-input.styles.ts
+++ b/src/shared/standalone-date-input/standalone-date-input.styles.ts
@@ -14,9 +14,44 @@ export const inputSection = css`
 `;
 
 export const baseInput = css`
+    ${Font["body-baseline-regular"]}
+    color: ${Colour["text"]};
+    display: block;
+    background: transparent;
+    border: none;
+    outline: none;
+    box-shadow: none;
+    padding: 0;
+    margin: 0;
     text-align: center;
     position: absolute;
     inset: 0;
+
+    &:disabled {
+        color: ${Colour["text-subtler"]};
+
+        &:hover {
+            cursor: not-allowed;
+        }
+    }
+
+    &::placeholder,
+    &::-webkit-input-placeholder {
+        color: ${Colour["text-subtler"]};
+    }
+
+    // Chrome, Safari, Edge, Opera
+    &::-webkit-outer-spin-button,
+    &::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+    }
+
+    // Safari (remove top shadow)
+    --webkit-appearance: none;
+
+    // Firefox
+    --moz-appearance: textfield;
 `;
 
 export const baseInputHover = css`

--- a/src/shared/standalone-date-input/standalone-date-input.tsx
+++ b/src/shared/standalone-date-input/standalone-date-input.tsx
@@ -4,7 +4,6 @@ import customParseFormat from "dayjs/plugin/customParseFormat";
 import React, { useEffect, useImperativeHandle, useRef, useState } from "react";
 
 import { DateInputHelper, StringHelper, useStateRef } from "../../util";
-import { basicInput } from "../input-wrapper/input-wrapper.styles";
 import * as styles from "./standalone-date-input.styles";
 
 dayjs.extend(customParseFormat);
@@ -376,7 +375,6 @@ export const Component = (
                             currentFocus === names[0] && !readOnly ? "" : "DD"
                         }
                         className={clsx(
-                            basicInput,
                             styles.baseInput,
                             !!hoverValue && styles.baseInputHover
                         )}
@@ -419,7 +417,6 @@ export const Component = (
                             currentFocus === names[1] && !readOnly ? "" : "MM"
                         }
                         className={clsx(
-                            basicInput,
                             styles.baseInput,
                             !!hoverValue && styles.baseInputHover
                         )}
@@ -462,7 +459,6 @@ export const Component = (
                             currentFocus === names[2] && !readOnly ? "" : "YYYY"
                         }
                         className={clsx(
-                            basicInput,
                             styles.baseInput,
                             !!hoverValue && styles.baseInputHover
                         )}


### PR DESCRIPTION
### Type of changes

<!-- Put an `x` in the items that apply -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)

### Description of changes

[BOOKINGSG-9306](https://sgtechstack.atlassian.net/browse/BOOKINGSG-9306)

This PR fixes a flaky Date Input E2E failure seen in CI by removing a cross-module style dependency and making the component’s base input styling self-contained.

Previously, the date fields combined a shared base input class with local date-input classes. In CI builds, CSS extraction and chunk ordering could change which same-specificity rules won, leading to inconsistent computed styles.

### Validation
Ran: `CI=true npx playwright test e2e/tests/components/date-input` on local


<img width="686" height="582" alt="image" src="https://github.com/user-attachments/assets/4b796faa-0ec6-49ca-af79-c7a12203c47c" />
