### PR TITLE
[BOOKINGSG-9312] Split SGDS css files to fix overwriting

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -140,13 +140,25 @@ const plugins = [
     // Handles external SGDS web component CSS from node_modules.
     // Ensures SGDS styles are bundled and output to a fixed path for masthead usage.
     libStylePlugin({
-        include: ["node_modules/@govtechsg/sgds-web-component/**/*.css"],
+        include: ["node_modules/@govtechsg/sgds-web-component/themes/day.css"],
         postCssPlugins: [postcssImports()],
         customCSSInjectedPath: () => {
-            return "/sgds.css";
+            return "/sgds-day.css";
         },
         customCSSPath: () => {
-            return "/masthead/sgds.css";
+            return "/masthead/sgds-day.css";
+        },
+    }),
+    libStylePlugin({
+        include: [
+            "node_modules/@govtechsg/sgds-web-component/themes/night.css",
+        ],
+        postCssPlugins: [postcssImports()],
+        customCSSInjectedPath: () => {
+            return "/sgds-night.css";
+        },
+        customCSSPath: () => {
+            return "/masthead/sgds-night.css";
         },
     }),
     wyw({


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)

**Description of changes**

-   Link to [ticket](https://sgtechstack.atlassian.net/browse/BOOKINGSG-9312)
-   The plugin config resulted in both `day.css` and `night.css` being written to the same output file, causing one theme to be overwritten at the end of the build. This meant at any one time, either light or dark mode would render without the theme colours
- Updated to handle the output path explicitly
- Masthead visual tests are now passing

**Checklist**

<!-- Put an `x` in items that apply -->

-   [x] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [ ] ~~Looks good on mobile and tablet~~
-   [ ] ~~Updated documentation~~
-   [ ] ~~Added/updated tests~~
