### PR TITLE
[BOOKINGSG-9316] Disable Turbopack to work around non-deterministic css load order, other e2e test fixes

### DIFF
--- a/e2e/nextjs-app/next.config.ts
+++ b/e2e/nextjs-app/next.config.ts
@@ -3,9 +3,11 @@ import type { NextConfig } from "next";
 import path from "node:path";
 
 const ciConfig: NextConfig = {
-    turbopack: {
-        root: path.join(__dirname),
-    },
+    // FIXME: BOOKINGSG-9316: Turbopack is currently disabled due to an issue with CSS load order. Re-enable once the issue is resolved.
+    // turbopack: {
+    //     root: path.join(__dirname),
+    // },
+    outputFileTracingRoot: path.join(__dirname),
     typescript: {
         tsconfigPath: "tsconfig.ci.json",
     },
@@ -17,12 +19,14 @@ const ciConfig: NextConfig = {
 
 const devConfig: LinariaConfig = withLinaria({
     devIndicators: false,
-    turbopack: {
-        root: path.join(__dirname, "../../"),
-        resolveAlias: {
-            "@lifesg/react-design-system": "../../src",
-        },
-    },
+    // FIXME: BOOKINGSG-9316: Turbopack is currently disabled due to an issue with CSS load order. Re-enable once the issue is resolved.
+    // turbopack: {
+    //     root: path.join(__dirname, "../../"),
+    //     resolveAlias: {
+    //         "@lifesg/react-design-system": "../../src",
+    //     },
+    // },
+    outputFileTracingRoot: path.join(__dirname, "../../"),
     typescript: {
         tsconfigPath: "tsconfig.json",
     },

--- a/e2e/nextjs-app/package.json
+++ b/e2e/nextjs-app/package.json
@@ -3,8 +3,8 @@
     "version": "0.1.0",
     "private": true,
     "scripts": {
-        "dev": "next dev",
-        "build": "next build",
+        "dev": "next dev --webpack",
+        "build": "next build --webpack",
         "start": "next start",
         "lint": "eslint",
         "lint:src": "eslint 'src/**/*.{ts,tsx,js,jsx}'",

--- a/e2e/nextjs-app/src/app/components/range-slider/interaction.e2e.tsx
+++ b/e2e/nextjs-app/src/app/components/range-slider/interaction.e2e.tsx
@@ -10,6 +10,7 @@ export default function Story() {
 
     return (
         <div className="story-column-container">
+            <button data-testid="focus-target-before">before</button>
             <InputRangeSlider
                 value={value}
                 onChange={handleChange}
@@ -27,6 +28,7 @@ export default function Story() {
                 Max value:{" "}
                 <span data-testid="range-slider-max-value">{value[1]}</span>
             </p>
+            <button data-testid="focus-target-after">after</button>
         </div>
     );
 }

--- a/e2e/tests/components/range-slider/range-slider.e2e.spec.ts
+++ b/e2e/tests/components/range-slider/range-slider.e2e.spec.ts
@@ -16,6 +16,8 @@ class StoryPage extends AbstractStoryPage {
         error: Locator;
         prefilled: Locator;
         interaction: Locator;
+        focusTargetBefore: Locator;
+        focusTargetAfter: Locator;
     };
 
     constructor(page: Page) {
@@ -35,6 +37,8 @@ class StoryPage extends AbstractStoryPage {
             error: page.getByTestId("range-slider-error"),
             prefilled: page.getByTestId("range-slider-prefilled"),
             interaction: page.getByTestId("range-slider-interaction"),
+            focusTargetBefore: page.getByTestId("focus-target-before"),
+            focusTargetAfter: page.getByTestId("focus-target-after"),
         };
     }
 
@@ -307,6 +311,7 @@ test.describe("RangeSlider", () => {
     test.describe("Keyboard navigation", () => {
         test.beforeEach(async ({ story }) => {
             await story.init("interaction");
+            await story.locators.focusTargetBefore.focus();
         });
 
         test("Tab to focus thumbs", async ({ story }) => {

--- a/e2e/tests/utils.ts
+++ b/e2e/tests/utils.ts
@@ -85,6 +85,7 @@ export const compareScreenshot = async (
                 height: box.height + 20,
             },
             threshold: 0.01, // Strict colour matching
+            maxDiffPixelRatio: 0.01, // Allow a small percentage of pixels to differ
         });
         return;
     }
@@ -96,6 +97,7 @@ export const compareScreenshot = async (
     await expect.soft(target).toHaveScreenshot(`${name}.png`, {
         fullPage: options?.fullscreen ?? false,
         threshold: 0.01, // Strict colour matching
+        maxDiffPixelRatio: 0.01, // Allow a small percentage of pixels to differ
     });
 };
 


### PR DESCRIPTION
**Description of changes**

Addresses a few issues:
- Non-deterministic CSS load order causing tests to fail in CI mode
  - See [this open NextJS issue](https://redirect.github.com/vercel/next.js/issues/89523) (and its various clones), there's an associated PR but I doubt it will be merged in so soon
  -   As a temporary workaround, disable Turbopack on our testing app
- Random small pixel diffs between dev and CI mode
  - Possibly some kind of artifacting that's not visible to the naked eye. Resolved by setting `maxDiffPixelRatio` (it's not set by default)
- Failed range slider test
  - Probably due to the new NextJS dev indicator workaround, though not sure why it didn't fail earlier
  - Just need to set explicit focus on a canary button

**Screenshots**

With Turbopack disabled, tests on https://github.com/LifeSG/react-design-system/pull/1119 pass:
<img width="778" height="190" alt="Screenshot 2026-05-06 at 3 08 45 PM" src="https://github.com/user-attachments/assets/ca66db8a-74ac-4fc4-b59a-50e300ebf448" />

With Turbopack enabled, tests fail:
<img width="778" height="178" alt="Screenshot 2026-05-06 at 3 10 04 PM" src="https://github.com/user-attachments/assets/18fe2453-1a93-4dbd-8900-0e832544f5d2" />

