### PR TITLE
Fix click trigger from sortable DataTable header

### DIFF
--- a/src/data-table/data-table.tsx
+++ b/src/data-table/data-table.tsx
@@ -248,6 +248,21 @@ export const DataTable = ({
     };
 
     // =============================================================================
+    // EVENT HANDLERS
+    // =============================================================================
+    const handleHeaderClick = (fieldKey: string) => {
+        onHeaderClick?.(fieldKey);
+    };
+
+    const handleHeaderButtonClick = (
+        event: React.MouseEvent<HTMLButtonElement>,
+        fieldKey: string
+    ) => {
+        event.stopPropagation();
+        onHeaderClick?.(fieldKey);
+    };
+
+    // =============================================================================
     // RENDER FUNCTIONS
     // =============================================================================
     const renderHeaders = () => (
@@ -285,6 +300,7 @@ export const DataTable = ({
                 aria-sort={getHeaderAriaSort(fieldKey)}
                 style={style}
                 $isCheckbox={false}
+                onClick={() => handleHeaderClick(fieldKey)}
             >
                 <HeaderCellWrapper id={headerCellWrapperId}>
                     {typeof label === "string" ? (
@@ -298,7 +314,11 @@ export const DataTable = ({
                 </HeaderCellWrapper>
                 {(clickable || isSortable) && (
                     <VisuallyHidden>
-                        <button onClick={() => onHeaderClick?.(fieldKey)}>
+                        <button
+                            onClick={(event) =>
+                                handleHeaderButtonClick(event, fieldKey)
+                            }
+                        >
                             {isSortable && "Sort "}
                             <span aria-labelledby={headerCellWrapperId} />
                             {isSortable && getSortButtonAriaLabel(fieldKey)}


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)

**Description of changes**

-   Add missed out click handler for the header container
-  Ensure button trigger does not trigger `onHeaderClick` twice

**Checklist**

<!-- Put an `x` in items that apply -->

-   [x] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [ ] ~~Looks good on mobile and tablet~~
-   [ ] ~~Updated documentation~~
-   [ ] ~~Added/updated tests~~

**Screenshots**

https://github.com/user-attachments/assets/94d8ee34-401d-4c4c-b038-222e9dafeaeb