### PR TITLE
Fix font weight for Textarea error message

### DIFF
--- a/src/form/form-textarea.style.tsx
+++ b/src/form/form-textarea.style.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { Spacing } from "../theme";
+import { Font, Spacing } from "../theme";
 import { ErrorMessage } from "./form-label.style";
 
 export const LabelContainer = styled.div`
@@ -9,6 +9,7 @@ export const LabelContainer = styled.div`
 `;
 
 export const ErrorMessageContainer = styled.div`
+    ${Font["body-sm-semibold"]}
     display: flex;
     flex: 1;
     margin-right: ${Spacing["spacing-12"]};


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)

**Description of changes**

-   Set font weight for textarea error message container

**Checklist**

<!-- Put an `x` in items that apply -->

-   [x] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [x] Looks good on mobile and tablet
-   [ ] ~~Updated documentation~~
-   [ ] ~~Added/updated tests~~

**Screenshots**

Current prod: https://designsystem.life.gov.sg/react/index.html?path=/docs/form-textarea--docs

Fixed: 
<img width="555" height="250" alt="Screenshot 2026-05-15 at 1 22 13 PM" src="https://github.com/user-attachments/assets/79ba69cb-b081-45bd-a06e-4331a4ea0a9e" />