### PR TITLE
[MOL-20186][TIEN] Simplify modal viewport handling by removing offset…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13771,12 +13771,13 @@
             }
         },
         "node_modules/js-cookie": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-            "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+            "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=14"
+                "node": ">=20"
             }
         },
         "node_modules/js-tokens": {

--- a/src/modal-v2/modal-v2.styles.tsx
+++ b/src/modal-v2/modal-v2.styles.tsx
@@ -3,10 +3,8 @@ import { MediaQuery, Motion } from "../theme";
 import { ModalAnimationDirection } from "./types";
 
 interface Props {
-    $show: boolean;
     $animationFrom?: ModalAnimationDirection;
     $verticalHeight?: number;
-    $offsetTop?: number;
 }
 
 export const Container = styled.div<Props>`
@@ -17,17 +15,16 @@ export const Container = styled.div<Props>`
     overflow: auto;
 
     ${MediaQuery.MaxWidth.sm} {
-        ${(props) => {
-            return css`
-                height: calc(
-                    ${props.$verticalHeight
-                            ? `${props.$verticalHeight}px`
-                            : "1vh"} * 100
-                );
-            `;
-        }}
+        height: calc(
+            ${(props) =>
+                    props.$verticalHeight
+                        ? `${props.$verticalHeight}px`
+                        : "1vh"} * 100
+        );
+    }
 
-        top: ${(props) => props.$offsetTop || 0}px;
+    @supports (height: 100dvh) {
+        height: 100dvh;
     }
 
     ${(props) => css`

--- a/src/modal-v2/modal-v2.tsx
+++ b/src/modal-v2/modal-v2.tsx
@@ -5,7 +5,7 @@ import {
     useInteractions,
     useTransitionStatus,
 } from "@floating-ui/react";
-import React, { useEffect, useRef } from "react";
+import React, { useRef } from "react";
 import { Overlay } from "../overlay/overlay";
 import { useViewport } from "../shared/hooks";
 import { useEvent } from "../util";
@@ -34,7 +34,15 @@ export const ModalV2 = ({
     // =========================================================================
     // CONST, STATE, REF
     // =========================================================================
-    const { verticalHeight, offsetTop } = useViewport();
+    const dismissKeyboard = useEvent(() => {
+        if (dismissKeyboardOnShow) {
+            (document.activeElement as HTMLElement)?.blur?.();
+        }
+    });
+    const { verticalHeight } = useViewport({
+        enabled: show,
+        onBeforeStart: dismissKeyboard,
+    });
     const childRef = useRef<HTMLDivElement>(null);
     const childWithRef =
         children && React.cloneElement(children, { ref: childRef });
@@ -61,27 +69,12 @@ export const ModalV2 = ({
     const { getFloatingProps } = useInteractions([dismiss]);
 
     // =========================================================================
-    // EFFECTS
-    // =========================================================================
-    const dismissKeyboard = useEvent(() => {
-        if (dismissKeyboardOnShow) {
-            (document.activeElement as HTMLElement)?.blur?.();
-        }
-    });
-
-    useEffect(() => {
-        if (show) {
-            dismissKeyboard();
-        }
-    }, [show, dismissKeyboard]);
-
-    // =========================================================================
     // RENDER FUNCTIONS
     // =========================================================================
     return (
         <Overlay
             data-testid={`${testId}-overlay`}
-            show={isMounted}
+            show={show}
             enableOverlayClick={enableOverlayClick}
             onOverlayClick={onOverlayClick}
             id={id}
@@ -90,11 +83,9 @@ export const ModalV2 = ({
             zIndex={zIndex}
         >
             <Container
-                $show={isMounted}
                 $animationFrom={animationFrom}
                 data-testid={testId}
                 $verticalHeight={verticalHeight}
-                $offsetTop={offsetTop}
                 data-status={status}
                 {...otherProps}
             >

--- a/src/modal/modal.styles.tsx
+++ b/src/modal/modal.styles.tsx
@@ -4,15 +4,24 @@ import { MediaQuery } from "../theme";
 
 interface Props {
     $show: boolean;
+    $ready?: boolean;
     $animationFrom?: ModalAnimationDirection;
     $verticalHeight?: number;
-    $offsetTop?: number;
 }
 
 const visibilityStyle = (
     show: boolean,
-    animationFrom: ModalAnimationDirection
+    animationFrom: ModalAnimationDirection,
+    ready?: boolean
 ) => {
+    if (show && !ready) {
+        return `
+			${animationFrom}: -3%;
+			opacity: 0;
+			transition: none;
+		`;
+    }
+
     if (show) {
         return `
 			${animationFrom}: 0;
@@ -37,7 +46,13 @@ export const Container = styled.div<Props>`
     height: 100%;
     width: 100%;
     overflow: hidden;
-    ${(props) => visibilityStyle(props.$show, props.$animationFrom || "bottom")}
+
+    ${(props) =>
+        visibilityStyle(
+            props.$show,
+            props.$animationFrom || "bottom",
+            props.$ready
+        )}
 
     ${MediaQuery.MaxWidth.sm} {
         height: calc(
@@ -46,7 +61,5 @@ export const Container = styled.div<Props>`
                         ? `${props.$verticalHeight}px`
                         : "1vh"} * 100
         );
-
-        top: ${(props) => props.$offsetTop || 0}px;
     }
 `;

--- a/src/modal/modal.tsx
+++ b/src/modal/modal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useRef } from "react";
 import { Overlay } from "../overlay/overlay";
 import { useViewport } from "../shared/hooks";
 import { useEvent } from "../util";
@@ -20,25 +20,18 @@ export const Modal = ({
     // =============================================================================
     // CONST, STATE, REF
     // =============================================================================
-    const { verticalHeight, offsetTop } = useViewport();
-    const childRef = useRef<HTMLDivElement>(null);
-    const childWithRef =
-        children && React.cloneElement(children, { ref: childRef });
-
-    // =============================================================================
-    // EFFECTS
-    // =============================================================================
     const dismissKeyboard = useEvent(() => {
         if (dismissKeyboardOnShow) {
             (document.activeElement as HTMLElement)?.blur?.();
         }
     });
-
-    useEffect(() => {
-        if (show) {
-            dismissKeyboard();
-        }
-    }, [show, dismissKeyboard]);
+    const { verticalHeight, ready } = useViewport({
+        enabled: show,
+        onBeforeStart: dismissKeyboard,
+    });
+    const childRef = useRef<HTMLDivElement>(null);
+    const childWithRef =
+        children && React.cloneElement(children, { ref: childRef });
 
     // =============================================================================
     // RENDER FUNCTIONS
@@ -56,10 +49,10 @@ export const Modal = ({
         >
             <Container
                 $show={show}
+                $ready={ready}
                 $animationFrom={animationFrom}
                 data-testid={id}
                 $verticalHeight={verticalHeight}
-                $offsetTop={offsetTop}
                 {...otherProps}
             >
                 {childWithRef}

--- a/src/shared/hooks/useViewport.tsx
+++ b/src/shared/hooks/useViewport.tsx
@@ -1,13 +1,30 @@
-import throttle from "lodash/throttle";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
-export const useViewport = () => {
+const STABLE_FRAMES = 2;
+const HEIGHT_OFFSET = 0.5;
+// This 180 ms duration is chosen to align with the mobile Chrome/keyboard animation (150–300 ms range) and the modal’s entrance `transition-delay` (200 ms) before we force it into the `ready` state.
+const FALLBACK_TIME = 180;
+
+interface UseViewportProps {
+    enabled?: boolean;
+    onBeforeStart?: () => void;
+}
+
+export const useViewport = ({
+    enabled = false,
+    onBeforeStart,
+}: UseViewportProps = {}) => {
     const [verticalHeight, setVerticalHeight] = useState<number>();
-    const [offsetTop, setOffsetTop] = useState<number>();
+    const [ready, setReady] = useState(false);
+    const pendingFramesRef = useRef<number[]>([]);
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const hasResolvedRef = useRef(false);
+    const onBeforeStartRef = useRef(onBeforeStart);
 
-    // =============================================================================
-    // EVENT HANDLERS
-    // =============================================================================
+    useEffect(() => {
+        onBeforeStartRef.current = onBeforeStart;
+    }, [onBeforeStart]);
+
     const handleWindowResize = useCallback(() => {
         const newVerticalHeight = window.innerHeight * 0.01;
         setVerticalHeight(newVerticalHeight);
@@ -17,7 +34,6 @@ export const useViewport = () => {
         if (window.visualViewport) {
             const newVerticalHeight = window.visualViewport.height * 0.01;
             setVerticalHeight(newVerticalHeight);
-            setOffsetTop(window.visualViewport.offsetTop);
         }
     }, []);
 
@@ -26,39 +42,102 @@ export const useViewport = () => {
 
         // use VisualViewport API if available, it gives more accurate dimensions when iOS software keyboard is active
         if (window.visualViewport) {
-            const handleViewportScroll = throttle(handleViewportResize, 300);
             handleViewportResize();
             window.visualViewport.addEventListener(
                 "resize",
                 handleViewportResize
             );
-            window.visualViewport.addEventListener(
-                "scroll",
-                handleViewportScroll
-            );
-
             return () => {
                 window.visualViewport?.removeEventListener(
                     "resize",
                     handleViewportResize
                 );
-                window.visualViewport?.removeEventListener(
-                    "scroll",
-                    handleViewportScroll
-                );
-            };
-        } else {
-            // fallback to Window API
-            handleWindowResize();
-            window.addEventListener("resize", handleWindowResize);
-            return () => {
-                window.removeEventListener("resize", handleWindowResize);
             };
         }
-    }, []);
+
+        handleWindowResize();
+        window.addEventListener("resize", handleWindowResize);
+        return () => {
+            window.removeEventListener("resize", handleWindowResize);
+        };
+    }, [handleViewportResize, handleWindowResize]);
+
+    useEffect(() => {
+        const scheduleFrame = (fn: FrameRequestCallback) => {
+            pendingFramesRef.current.push(requestAnimationFrame(fn));
+        };
+
+        const clearPending = () => {
+            pendingFramesRef.current.forEach((id) => cancelAnimationFrame(id));
+            pendingFramesRef.current = [];
+
+            if (timeoutRef.current !== null) {
+                clearTimeout(timeoutRef.current);
+                timeoutRef.current = null;
+            }
+
+            hasResolvedRef.current = false;
+        };
+
+        const resolve = () => {
+            if (hasResolvedRef.current) {
+                return;
+            }
+            hasResolvedRef.current = true;
+            setReady(true);
+        };
+        // Compare the viewport height across consecutive frames;
+        // once it remains stable for at least 2 frames, trigger the modal animation
+        const waitForStableViewport = () => {
+            let lastHeight =
+                window.visualViewport?.height ?? window.innerHeight;
+            let stableFrames = 0;
+
+            const checkViewportStability = () => {
+                const currentHeight =
+                    window.visualViewport?.height ?? window.innerHeight;
+                // Use a small offset to account for fluctuations in reported height
+                // even when the viewport hasn’t actually changed
+                if (Math.abs(currentHeight - lastHeight) < HEIGHT_OFFSET) {
+                    stableFrames += 1;
+                } else {
+                    stableFrames = 0;
+                    lastHeight = currentHeight;
+                }
+
+                if (stableFrames >= STABLE_FRAMES) {
+                    resolve();
+                    return;
+                }
+
+                scheduleFrame(checkViewportStability);
+            };
+
+            scheduleFrame(checkViewportStability);
+        };
+
+        clearPending();
+        setReady(false);
+
+        if (!enabled) {
+            return clearPending;
+        }
+
+        onBeforeStartRef.current?.();
+
+        if (!window.visualViewport) {
+            scheduleFrame(resolve);
+            return clearPending;
+        }
+
+        waitForStableViewport();
+        timeoutRef.current = setTimeout(resolve, FALLBACK_TIME);
+
+        return clearPending;
+    }, [enabled]);
 
     return {
         verticalHeight,
-        offsetTop,
+        ready,
     };
 };

--- a/tests/e-signature/e-signature.spec.tsx
+++ b/tests/e-signature/e-signature.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { ESignature } from "../../src/e-signature";
 
 // =============================================================================
@@ -43,18 +43,18 @@ describe("ESignature", () => {
         expect(getEditSignatureButton()).toBeInTheDocument();
     });
 
-    it("should show signature modal on clicking add signature button", () => {
+    it("should show signature modal on clicking add signature button", async () => {
         render(<ESignature />);
         fireEvent.click(getAddSignatureButton());
 
-        expect(getSignatureModal()).toBeVisible();
+        await waitFor(() => expect(getSignatureModal()).toBeVisible());
     });
 
-    it("should show signature modal on clicking edit button", () => {
+    it("should show signature modal on clicking edit button", async () => {
         render(<ESignature value={PNG_BASE64} />);
         fireEvent.click(getEditSignatureButton());
 
-        expect(getSignatureModal()).toBeVisible();
+        await waitFor(() => expect(getSignatureModal()).toBeVisible());
     });
 
     it("should dismiss the signature modal, call onChange callback and show the signature preview on clicking save button", () => {


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)

**Description of changes**

-   Link to [ticket](https://sgtechstack.atlassian.net/browse/MOL-20186)
-   Refactored modal viewport-stability orchestration into a reusable `useStableViewport` hook.
-   `useStableViewport(onStable, enabled)` now owns rAF polling + timeout fallback and triggers `onStable` once after viewport stabilizes (or fallback timeout), with full cleanup on close/unmount.
-   Simplified `Modal` logic by removing inline viewport polling/timer refs and using a lean effect for keyboard dismiss + animation reset.
-   Preserved the existing behavior goal: delay modal entrance animation until viewport height settles (to reduce top cut/jank around soft keyboard transitions).
-   Updated `e-signature` tests to wait for modal visibility asynchronously, aligning with animation-gated modal behavior.

**Checklist**

<!-- Put an `x` in items that apply -->

-   [x] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [x] Looks good on mobile and tablet
-   [ ] ~~Updated documentation~~
-   [x] Added/updated tests