### PR TITLE
Add npmrc with `min-release-age` setting

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,6 +111,10 @@
                 "styled-components": "^6.1.19",
                 "typescript": "^5.7.3"
             },
+            "engines": {
+                "node": ">=22.0.0",
+                "npm": ">=11.10.0"
+            },
             "peerDependencies": {
                 "@floating-ui/react": ">=0.26.23 <1.0.0",
                 "@lifesg/react-icons": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
     "main": "dist/cjs/index.js",
     "module": "dist/index.js",
     "typings": "dist/index.d.ts",
+    "engines": {
+        "npm": ">=11.10.0",
+        "node": ">=22.0.0"
+    },
     "bin": {
         "lifesg-react-design-system": "./codemods/run-codemod.js"
     },


### PR DESCRIPTION
**Description of changes**

-   Added `min-release-age` config per our project team's security recommendations. Note that this requires npm v11.10.0 minimum
- Added `engines` entry to indicate our minimum node and npm versions
