### PR TITLE
[MISC][GZ] scope SSR date mock per request

### DIFF
--- a/e2e/nextjs-app/src/app/components/[component]/[story]/page.tsx
+++ b/e2e/nextjs-app/src/app/components/[component]/[story]/page.tsx
@@ -1,8 +1,10 @@
 import dynamic from "next/dynamic";
+import { after } from "next/server";
 import {
     applyE2EDateMock,
+    initializeNativeDate,
     type E2EDateMockGlobal,
-} from "../../../../utils/date";
+} from "@/utils/date";
 
 /**
  * Components that must be rendered client-side only to avoid hydration mismatches.
@@ -33,14 +35,26 @@ export default async function Page({
 }>) {
     const { component, story } = await params;
     const { now } = await searchParams;
+    const globalObj = globalThis as typeof globalThis & E2EDateMockGlobal;
+    const nativeDate = initializeNativeDate(globalObj);
 
     // Extract timestamp seed from query params for deterministic time-based rendering
     const nowSeed = Array.isArray(now) ? now[0] : now;
 
-    // Mock Date on server-side during SSR if timestamp seed is provided.
-    // This ensures server-rendered components use the same time as client hydration.
     if (nowSeed !== undefined) {
-        applyE2EDateMock(nowSeed, globalThis as E2EDateMockGlobal);
+        // Ensure a stale mock from a prior request is always cleared first.
+        globalObj.Date = nativeDate;
+        globalObj.__E2E_ACTIVE_DATE_SEED__ = undefined;
+
+        applyE2EDateMock(nowSeed, globalObj);
+
+        if (globalObj.Date !== nativeDate) {
+            // Restore native Date after this request finishes streaming.
+            after(() => {
+                globalObj.Date = nativeDate;
+                globalObj.__E2E_ACTIVE_DATE_SEED__ = undefined;
+            });
+        }
     }
 
     const Story = dynamic(
@@ -50,5 +64,19 @@ export default async function Page({
         }
     );
 
-    return <Story />;
+    const activeSeed = globalObj.__E2E_ACTIVE_DATE_SEED__ ?? "";
+    const isDateMocked = globalObj.Date !== nativeDate;
+
+    return (
+        <>
+            <div
+                data-testid="e2e-active-date-seed"
+                data-date-mocked={String(isDateMocked)}
+                className={"hidden"}
+            >
+                {activeSeed}
+            </div>
+            <Story />
+        </>
+    );
 }

--- a/e2e/nextjs-app/src/app/globals.css
+++ b/e2e/nextjs-app/src/app/globals.css
@@ -23,6 +23,10 @@
     padding: 1rem;
 }
 
+.hidden {
+    display: none;
+}
+
 @media (prefers-color-scheme: dark) {
     .story-background {
         background-color: #000000;

--- a/e2e/nextjs-app/src/utils/date.ts
+++ b/e2e/nextjs-app/src/utils/date.ts
@@ -59,6 +59,11 @@ export const applyE2EDateMock = (
 ) => {
     const nativeDate = initializeNativeDate(globalObj);
     const fixed = new nativeDate(seed).getTime();
+
+    if (Number.isNaN(fixed)) {
+        return;
+    }
+
     const MockDate = createMockDate(nativeDate, fixed);
 
     globalObj.__E2E_ACTIVE_DATE_SEED__ = seed;

--- a/e2e/tests/regression/date-mock-isolation.e2e.spec.ts
+++ b/e2e/tests/regression/date-mock-isolation.e2e.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/test";
+import { fixedTimestamp } from "../consts";
+
+test.describe("Date mock SSR isolation", () => {
+    test("does not leak seeded Date into subsequent unseeded request", async ({
+        page,
+    }) => {
+        await page.goto(
+            `/components/countdown-timer/non-warn?now=${fixedTimestamp}`
+        );
+
+        const seededMarker = page.getByTestId("e2e-active-date-seed");
+        await expect(seededMarker).toHaveText(fixedTimestamp);
+        await expect(seededMarker).toHaveAttribute("data-date-mocked", "true");
+
+        await page.goto("/components/countdown-timer/non-warn");
+
+        const unseededMarker = page.getByTestId("e2e-active-date-seed");
+        await expect(unseededMarker).toHaveText("");
+        await expect(unseededMarker).toHaveAttribute(
+            "data-date-mocked",
+            "false"
+        );
+    });
+});


### PR DESCRIPTION
> [!WARNING]
> This PR should be framed as reducing SSR mock leakage risk, not as a definitive fix for all render hangs.

### Issue
Some observed the Next.js E2E app hanging on initial page load (first render),  at document/navigation and eventually timing out. The behavior was intermittent so it was difficult to reproduce reliably on demand.

### Possible Root Cause
For seeded runs `?now=...`, SSR date mocking mutates process-global Date in the Next.js server runtime.
Because this mutation is global, it can affect the active request lifecycle itself (including first render) and may also leave unstable state for later requests in dev mode.

### Fix
- Keep SSR enabled for supported stories.
- Initialize native Date once and clear any stale mocked state before applying a new seed.
- Apply seeded Date mocking only for seeded requests.
- Restore native Date after the request lifecycle completes with [after](https://nextjs.org/docs/app/api-reference/functions/after).
- Skip mock setup when the provided seed is invalid.
- Add regression coverage for the seeded and subsequent unseeded leak path.

### What This Change Improves
- Reduces the likelihood of seeded SSR state leaking into later requests.
- Preserves deterministic seeded SSR behavior for supported stories.
- Adds automated coverage for the most directly testable failure mode in this implementation.

### What This Change Does Not Fully Solve
- It does not prove that first-render hangs are fully resolved.
- It does not remove the underlying same-request risk from mutating process-global Date during SSR.

> [!NOTE]
> A complete fix for same-request interference would require removing server-side global Date mocking entirely and switching to a request-scoped source via props/context/provider.




