### PR TITLE
[BOOKINGSG-9325] Improve asset loading

### DIFF
--- a/e2e/tests/utils.ts
+++ b/e2e/tests/utils.ts
@@ -31,6 +31,17 @@ export abstract class AbstractStoryPage {
             });
         }
 
+        await this.page
+            .context()
+            .route(/^https:\/\/assets\.life\.gov\.sg/, async (route) => {
+                const url = route.request().url();
+                const path = new URL(url).pathname;
+                const cdn = `http://host.docker.internal:3000/cdn${path}`;
+
+                const res = await this.page.request.get(cdn);
+                await route.fulfill({ response: res });
+            });
+
         const query = new URLSearchParams();
         if (options?.mode === "light" || options?.mode === "dark") {
             query.set("mode", options.mode);


### PR DESCRIPTION
**Description of changes**

-   Route other asset requests in the page to the local CDN using Playwright `route`
- Tried to update `globals.css` to point back to the original domain as well, but those did not get picked up by `route`, so they still have to manually point to `/cdn`