### PR TITLE
[CCUBE-2144][IT] Incorrect text colour for selected value in dropdowns

### DIFF
--- a/src/shared/dropdown-wrapper/dropdown-wrapper.styles.tsx
+++ b/src/shared/dropdown-wrapper/dropdown-wrapper.styles.tsx
@@ -63,6 +63,7 @@ export const ValueLabel = styled.div<ValueLabelStyleProps>`
         props.$variant === "small"
             ? Font["body-md-regular"]
             : Font["body-baseline-regular"]}
+    color: ${Colour["text"]};
     text-align: left;
     ${(props) => {
         switch (props.$truncateType) {


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)

**Description of changes**

-   Link to [ticket](https://sgtechstack.atlassian.net/browse/CCUBE-2144)
-   Updated color styling for dropdown wrapper
- Verified affected components have been fixed:
  * InputGroup
  * MultiSelect
  * NestedMultiSelect
  * NestedSelect
  * PhoneNumberInput
  * Select

**Checklist**

<!-- Put an `x` in items that apply -->

- [x] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
- [ ] ~Looks good on mobile and tablet~
- [ ] ~Updated documentation~
- [ ] ~Added/updated tests~
