### PR TITLE
[DCUBESDQLR-2652][TIM] change body.md font size of DL theme from 1.2rem to 1.25rem

### DIFF
--- a/src/theme/font-spec/specs/sgw-digital-lobby-font-spec-set.ts
+++ b/src/theme/font-spec/specs/sgw-digital-lobby-font-spec-set.ts
@@ -31,7 +31,7 @@ export const SGWDigitalLobbyFontSpecSet: FontSpecSet = {
     "body-font-family": "Libre Franklin",
 
     "body-size-baseline": "1.375rem",
-    "body-size-md": "1.2rem",
+    "body-size-md": "1.25rem",
     "body-size-sm": "1.125rem",
     "body-size-xs": "1rem",
 


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)

**Description of changes**

-   Link to [ticket](https://sgtechstack.atlassian.net/browse/DCUBESDQLR-2652)
-   Link to [Figma](N/A - styling fix, no design changes)
- Update DL theme font size to match the 20px baseline in Figma


**Checklist**

<!-- Put an `x` in items that apply -->

-   [x] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [x] Looks good on mobile and tablet
-   [ ] Updated documentation
-   [ ] Added/updated tests

