### PR TITLE
[CCUBE-2148] feat: use inverted colored brush for e-signature in dark mode

### DIFF
--- a/src/e-signature/e-signature-canvas.tsx
+++ b/src/e-signature/e-signature-canvas.tsx
@@ -94,7 +94,14 @@ const Component = (
             fabricCanvas.current.isDrawingMode = true;
 
             pencilBrush.current = new PencilBrush(fabricCanvas.current);
-            pencilBrush.current.color = Colour["text"]({ theme });
+            if (theme) {
+                pencilBrush.current.color = Colour["text"]({
+                    theme: {
+                        ...theme,
+                        colourMode: "light",
+                    },
+                });
+            }
             pencilBrush.current.width = 3;
 
             fabricCanvas.current.freeDrawingBrush = pencilBrush.current;

--- a/src/e-signature/e-signature-canvas.tsx
+++ b/src/e-signature/e-signature-canvas.tsx
@@ -101,6 +101,8 @@ const Component = (
                         colourMode: "light",
                     },
                 });
+            } else {
+                pencilBrush.current.color = "#000000";
             }
             pencilBrush.current.width = 3;
 

--- a/src/e-signature/e-signature.styles.ts
+++ b/src/e-signature/e-signature.styles.ts
@@ -96,8 +96,7 @@ export const SignaturePreviewImage = styled.img`
     width: calc(100% - (3rem + ${Spacing["spacing-16"]}) * 2);
     height: 100%;
 
-    ${(props) =>
-        props.theme?.colourMode === "dark" ? `filter: invert(1);` : ""}
+    ${(props) => props.theme?.colourMode === "dark" && `filter: invert(1);`}
 `;
 
 export const ProgressBox = styled.div`
@@ -264,6 +263,5 @@ export const SignatureCanvasContainer = styled.div`
 export const SignatureCanvas = styled.canvas`
     cursor: crosshair;
 
-    ${(props) =>
-        props.theme?.colourMode === "dark" ? `filter: invert(1);` : ""}
+    ${(props) => props.theme?.colourMode === "dark" && `filter: invert(1);`}
 `;

--- a/src/e-signature/e-signature.styles.ts
+++ b/src/e-signature/e-signature.styles.ts
@@ -28,15 +28,15 @@ const mobileMediaQuery = css`
     ${(props) => `
         ${MediaQuery.MaxWidth.sm(props)},
         (orientation: landscape) and (max-height: ${Breakpoint["sm-max"](
-    props
-)}px)
+            props
+        )}px)
     `}
 `;
 const mobileLandscapeMediaQuery = css`
     ${(props) => `
         @media (orientation: landscape) and (max-height: ${Breakpoint["sm-max"](
-    props
-)}px)
+            props
+        )}px)
     `}
 `;
 
@@ -56,12 +56,12 @@ export const SignatureArea = styled.div<SignatureAreaProps>`
     ${(props) =>
         css`
             ${Border.Util["dashed-default"]({
-            radius: Radius["sm"],
-            thickness: Border["width-040"],
-            colour: props.$disabled
-                ? Colour["border-disabled"]
-                : Colour["border"],
-        })}
+                radius: Radius["sm"],
+                thickness: Border["width-040"],
+                colour: props.$disabled
+                    ? Colour["border-disabled"]
+                    : Colour["border"],
+            })}
 
             background-color: ${props.$disabled
                 ? Colour["bg-disabled"]
@@ -95,6 +95,9 @@ export const SignaturePreviewImage = styled.img`
     object-position: center;
     width: calc(100% - (3rem + ${Spacing["spacing-16"]}) * 2);
     height: 100%;
+
+    ${(props) =>
+        props.theme?.colourMode === "dark" ? `filter: invert(1);` : ""}
 `;
 
 export const ProgressBox = styled.div`
@@ -260,4 +263,7 @@ export const SignatureCanvasContainer = styled.div`
 
 export const SignatureCanvas = styled.canvas`
     cursor: crosshair;
+
+    ${(props) =>
+        props.theme?.colourMode === "dark" ? `filter: invert(1);` : ""}
 `;


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)

**Description of changes**

-   [Link to [ticket](url)](https://sgtechstack.atlassian.net/browse/CCUBE-2148)

**Checklist**

<!-- Put an `x` in items that apply -->

-   [X] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [X] Looks good on mobile and tablet
-   [ ] Updated documentation
-   [X] Added/updated tests

**Screenshots**

<img width="3004" height="1658" alt="image" src="https://github.com/user-attachments/assets/3cb377e0-4f59-4a79-9447-fd58c9a25fdb" />
