### PR TITLE
[CCUBE-2180][GZ] check and report e2e stale snapshots

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           name: screenshot-manifest-${{ matrix.shard }}
           path: .screenshot-manifest-${{ matrix.shard }}.txt
+          include-hidden-files: true
           retention-days: 1
 
   merge-reports:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -102,11 +102,11 @@ jobs:
           merge-multiple: true
       - name: Merge reports
         run: npx playwright merge-reports --reporter=github,html ./blob-reports
-      - name: Check for stale screenshots
-        if: ${{ needs.test.result == 'success' }}
-        run: npm run test-e2e:check-stale-screenshots -- --manifest='screenshot-manifests/.screenshot-manifest-*.txt'
       - uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: playwright-report/
           retention-days: 14
+      - name: Check for stale screenshots
+        if: ${{ needs.test.result == 'success' }}
+        run: npm run test-e2e:check-stale-screenshots -- --manifest='screenshot-manifests/.screenshot-manifest-*.txt'

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -104,7 +104,7 @@ jobs:
         run: npx playwright merge-reports --reporter=github,html ./blob-reports
       - name: Check for stale screenshots
         if: ${{ needs.test.result == 'success' }}
-        run: npx tsx scripts/check-stale-screenshots.ts --manifest='screenshot-manifests/.screenshot-manifest-*.txt'
+        run: npm run check-stale-screenshots -- --manifest='screenshot-manifests/.screenshot-manifest-*.txt'
       - uses: actions/upload-artifact@v7
         with:
           name: playwright-report

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -72,7 +72,7 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: screenshot-manifest-${{ matrix.shard }}
-          path: .screenshot-manifest-*.txt
+          path: .screenshot-manifest-${{ matrix.shard }}.txt
           retention-days: 1
 
   merge-reports:
@@ -102,6 +102,7 @@ jobs:
       - name: Merge reports
         run: npx playwright merge-reports --reporter=github,html ./blob-reports
       - name: Check for stale screenshots
+        if: ${{ needs.test.result == 'success' }}
         run: npx tsx scripts/check-stale-screenshots.ts --manifest='screenshot-manifests/.screenshot-manifest-*.txt'
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -104,7 +104,7 @@ jobs:
         run: npx playwright merge-reports --reporter=github,html ./blob-reports
       - name: Check for stale screenshots
         if: ${{ needs.test.result == 'success' }}
-        run: npm run check-stale-screenshots -- --manifest='screenshot-manifests/.screenshot-manifest-*.txt'
+        run: npm run test-e2e:check-stale-screenshots -- --manifest='screenshot-manifests/.screenshot-manifest-*.txt'
       - uses: actions/upload-artifact@v7
         with:
           name: playwright-report

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -58,12 +58,21 @@ jobs:
         run: npm run test-e2e:setup
       - name: Run Playwright tests (shard ${{ matrix.shard }}/4)
         run: ./scripts/e2e-ci-test.sh ${{ matrix.shard }}/4
+        env:
+          SHARD: ${{ matrix.shard }}
       - name: Upload blob report
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: blob-report-${{ matrix.shard }}
           path: blob-report/
+          retention-days: 1
+      - name: Upload screenshot manifest
+        uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: screenshot-manifest-${{ matrix.shard }}
+          path: .screenshot-manifest-*.txt
           retention-days: 1
 
   merge-reports:
@@ -84,8 +93,16 @@ jobs:
           pattern: blob-report-*
           path: blob-reports/
           merge-multiple: true
+      - name: Download all screenshot manifests
+        uses: actions/download-artifact@v8
+        with:
+          pattern: screenshot-manifest-*
+          path: screenshot-manifests/
+          merge-multiple: true
       - name: Merge reports
         run: npx playwright merge-reports --reporter=github,html ./blob-reports
+      - name: Check for stale screenshots
+        run: npx tsx scripts/check-stale-screenshots.ts --manifest='screenshot-manifests/.screenshot-manifest-*.txt'
       - uses: actions/upload-artifact@v7
         with:
           name: playwright-report

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ junit.xml
 /blob-report/
 /playwright/.cache/
 /playwright/.auth/
+.screenshot-manifest*.txt

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -5,5 +5,5 @@ npx concurrently --kill-others-on-fail --group --timings \
   --names "test+build,e2e" \
   --prefix "[{name}]" \
   --prefix-colors "blue,magenta" \
-  "jest --reporters=summary --coverageReporters=none && npm run build" \
+  "npm run test && npm run build" \
   "./scripts/e2e/pre-push.sh"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,9 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run test && npm run build
+npx concurrently --kill-others-on-fail --group --timings \
+  --names "test+build,e2e" \
+  --prefix "[{name}]" \
+  --prefix-colors "blue,magenta" \
+  "jest --reporters=summary --coverageReporters=none && npm run build" \
+  "./scripts/e2e/pre-push.sh"

--- a/e2e/screenshot-manifest-reporter.ts
+++ b/e2e/screenshot-manifest-reporter.ts
@@ -1,0 +1,98 @@
+import type {
+    FullConfig,
+    FullResult,
+    Reporter,
+    Suite,
+    TestCase,
+    TestResult,
+} from "@playwright/test/reporter";
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+function sanitizeForFilePath(s: string): string {
+    return s.replace(/[\x00-\x2C\x2E-\x2F\x3A-\x40\x5B-\x60\x7B-\x7F]+/g, "-");
+}
+
+function trimLongString(s: string, length = 100): string {
+    if (s.length <= length) return s;
+    const hash = createHash("sha1").update(s).digest("hex");
+    const middle = `-${hash.substring(0, 5)}-`;
+    const start = Math.floor((length - middle.length) / 2);
+    const end = length - middle.length - start;
+    return s.substring(0, start) + middle + s.slice(-end);
+}
+
+interface ReporterOptions {
+    outputFile?: string;
+}
+
+class ScreenshotManifestReporter implements Reporter {
+    private readonly usedScreenshots = new Set<string>();
+    private readonly coveredDirs = new Set<string>();
+    private readonly outputFile: string;
+
+    constructor(options: ReporterOptions = {}) {
+        this.outputFile = options.outputFile || ".screenshot-manifest.txt";
+    }
+
+    onBegin(_config: FullConfig, _suite: Suite): void {}
+
+    onTestEnd(test: TestCase, result: TestResult): void {
+        const project = test.parent.project()!;
+        const testDir = project.testDir;
+        const testFilePath = test.location.file;
+        const relativeTestFileDir = path.dirname(
+            path.relative(testDir, testFilePath)
+        );
+        const projectName = sanitizeForFilePath(project.name);
+        const fullTitleWithoutSpec = test.titlePath().slice(1).join(" ");
+        const testName = sanitizeForFilePath(
+            trimLongString(fullTitleWithoutSpec)
+        );
+
+        const screenshotDir = path.resolve(
+            testDir,
+            relativeTestFileDir,
+            "__screenshots__",
+            projectName
+        );
+        this.coveredDirs.add(screenshotDir);
+
+        for (const annotation of result.annotations) {
+            if (annotation.type !== "screenshot-used") continue;
+            const screenshotFileName = annotation.description;
+            if (!screenshotFileName) continue;
+
+            const ext = path.extname(screenshotFileName);
+            const arg = screenshotFileName.replace(ext, "");
+
+            const snapshotPath = path.join(
+                screenshotDir,
+                `${testName}--${arg}${ext}`
+            );
+
+            this.usedScreenshots.add(snapshotPath);
+        }
+    }
+
+    async onEnd(_result: FullResult): Promise<void> {
+        const lines = [
+            "# Directories covered by this test run",
+            ...[...this.coveredDirs].sort().map((d) => `dir:${d}`),
+            "# Screenshots referenced by tests",
+            ...[...this.usedScreenshots].sort(),
+        ];
+        fs.writeFileSync(this.outputFile, lines.join("\n") + "\n", "utf-8");
+        console.log(
+            `\n[screenshot-manifest] Wrote ${this.usedScreenshots.size} screenshots ` +
+                `across ${this.coveredDirs.size} directories to ${this.outputFile}`
+        );
+    }
+
+    printsToStdio(): boolean {
+        return false;
+    }
+}
+
+export default ScreenshotManifestReporter;

--- a/e2e/screenshot-manifest-reporter.ts
+++ b/e2e/screenshot-manifest-reporter.ts
@@ -46,7 +46,8 @@ class ScreenshotManifestReporter implements Reporter {
             path.relative(testDir, testFilePath)
         );
         const projectName = sanitizeForFilePath(project.name);
-        const fullTitleWithoutSpec = test.titlePath().slice(1).join(" ");
+        // slice(3) skips [root, projectName, filePath] to match Playwright's internal _fsSanitizedTestName
+        const fullTitleWithoutSpec = test.titlePath().slice(3).join(" ");
         const testName = sanitizeForFilePath(
             trimLongString(fullTitleWithoutSpec)
         );

--- a/e2e/screenshot-manifest-reporter.ts
+++ b/e2e/screenshot-manifest-reporter.ts
@@ -1,3 +1,33 @@
+/**
+ * A custom Playwright reporter that tracks which screenshot files are actively
+ * referenced by tests. Its output is consumed by scripts/check-stale-screenshots.ts
+ * to detect and optionally delete orphaned .png files.
+ *
+ * How it works:
+ *  1. After each test, the reporter reads "screenshot-used" annotations that
+ *     compareScreenshot() (in e2e/tests/utils.ts) pushes onto the test.
+ *  2. It reconstructs the absolute path that Playwright would have written the
+ *     screenshot to, using the same sanitization rules as Playwright itself.
+ *  3. It also records every __screenshots__ directory it encounters so the stale
+ *     checker knows which directories were covered by this run.
+ *  4. On completion it writes everything to a manifest text file.
+ *
+ * In CI the config registers this reporter with a shard-specific output file
+ * (e.g. .screenshot-manifest-1.txt) so parallel shards don't overwrite each other.
+ * The stale checker then reads all manifest files matching the glob pattern.
+ *
+ * ⚠️  Playwright coupling — verified against @playwright/test ^1.58.2:
+ *   - sanitizeForFilePath, trimLongString, sanitizeFilePathBeforeExtension mirror
+ *     Playwright's internal path utilities (playwright/lib/util.js and
+ *     playwright-core/lib/utils). These are not public API. Verify they still
+ *     match after upgrading Playwright; a mismatch causes silent false positives
+ *     in the stale checker (real screenshots flagged as orphaned).
+ *   - titlePath().slice(3) assumes the title array is structured as
+ *     [root, projectName, filePath, ...testTitles]. Verify this still holds
+ *     after a Playwright upgrade by checking _fsSanitizedTestName in
+ *     playwright/lib/worker/testInfo.js.
+ */
+
 import type {
     FullConfig,
     FullResult,
@@ -10,10 +40,20 @@ import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+/**
+ * Mirrors Playwright's internal sanitizeForFilePath utility.
+ * Replaces characters that are unsafe in file paths with hyphens.
+ */
 function sanitizeForFilePath(s: string): string {
     return s.replace(/[\x00-\x2C\x2E-\x2F\x3A-\x40\x5B-\x60\x7B-\x7F]+/g, "-");
 }
 
+/**
+ * Mirrors Playwright's internal trimLongString utility.
+ * Truncates strings that exceed `length` characters by replacing the middle
+ * section with a short SHA-1 hash to avoid filesystem path-length limits while
+ * keeping the result deterministic.
+ */
 function trimLongString(s: string, length = 100): string {
     if (s.length <= length) return s;
     const hash = createHash("sha1").update(s).digest("hex");
@@ -23,6 +63,11 @@ function trimLongString(s: string, length = 100): string {
     return s.substring(0, start) + middle + s.slice(-end);
 }
 
+/**
+ * Mirrors Playwright's internal sanitizeFilePathBeforeExtension utility.
+ * Sanitizes only the base name portion of a filename, preserving the extension
+ * so that e.g. "non-sticky open.png" becomes "non-sticky-open.png".
+ */
 function sanitizeFilePathBeforeExtension(
     filePath: string,
     ext: string
@@ -35,6 +80,12 @@ interface ReporterOptions {
     outputFile?: string;
 }
 
+/**
+ * A Playwright reporter that writes a manifest of all screenshot paths
+ * referenced during a test run.
+ *
+ * Registered in playwright.config.ts. Consumed by check-stale-screenshots.ts.
+ */
 class ScreenshotManifestReporter implements Reporter {
     private readonly usedScreenshots = new Set<string>();
     private readonly coveredDirs = new Set<string>();
@@ -44,8 +95,22 @@ class ScreenshotManifestReporter implements Reporter {
         this.outputFile = options.outputFile || ".screenshot-manifest.txt";
     }
 
+    // Required by the Reporter interface; nothing to do at suite start.
     onBegin(_config: FullConfig, _suite: Suite): void {}
 
+    /**
+     * Called by Playwright after every test completes (pass or fail).
+     *
+     * Reconstructs the absolute path of each screenshot the test declared it
+     * used via the "screenshot-used" annotation, using the same path-building
+     * logic as Playwright's snapshotPathTemplate resolution:
+     *
+     *   {testDir}/{testFileDir}/__screenshots__/{projectName}/{testName}--{arg}{ext}
+     *
+     * The path components are sanitized and truncated in exactly the same way
+     * as Playwright does internally, so the reconstructed paths match the real
+     * files on disk.
+     */
     onTestEnd(test: TestCase, result: TestResult): void {
         const project = test.parent.project()!;
         const testDir = project.testDir;
@@ -54,7 +119,8 @@ class ScreenshotManifestReporter implements Reporter {
             path.relative(testDir, testFilePath)
         );
         const projectName = sanitizeForFilePath(project.name);
-        // slice(3) skips [root, projectName, filePath] to match Playwright's internal _fsSanitizedTestName
+        // slice(3) skips [root, projectName, filePath] to match Playwright's
+        // internal _fsSanitizedTestName which also starts from index 1 of titlePath.
         const fullTitleWithoutSpec = test.titlePath().slice(3).join(" ");
         const testName = sanitizeForFilePath(
             trimLongString(fullTitleWithoutSpec)
@@ -66,6 +132,8 @@ class ScreenshotManifestReporter implements Reporter {
             "__screenshots__",
             projectName
         );
+        // Track this directory so the stale checker knows to inspect it even if
+        // a particular test ends up taking no screenshots.
         this.coveredDirs.add(screenshotDir);
 
         for (const annotation of result.annotations) {
@@ -88,6 +156,12 @@ class ScreenshotManifestReporter implements Reporter {
         }
     }
 
+    /**
+     * Called by Playwright once after all tests have finished.
+     * Writes the manifest file with two sections:
+     *  - "dir:" lines listing every __screenshots__ directory covered by this run
+     *  - absolute paths of every screenshot file referenced by a test
+     */
     async onEnd(_result: FullResult): Promise<void> {
         const lines = [
             "# Directories covered by this test run",
@@ -104,6 +178,7 @@ class ScreenshotManifestReporter implements Reporter {
         );
     }
 
+    // Returning false keeps this reporter's output out of the standard test log.
     printsToStdio(): boolean {
         return false;
     }

--- a/e2e/screenshot-manifest-reporter.ts
+++ b/e2e/screenshot-manifest-reporter.ts
@@ -137,7 +137,7 @@ class ScreenshotManifestReporter implements Reporter {
         this.coveredDirs.add(screenshotDir);
 
         for (const annotation of result.annotations) {
-            if (annotation.type !== "screenshot-used") continue;
+            if (annotation.type !== "_screenshot-used") continue;
             const screenshotFileName = annotation.description;
             if (!screenshotFileName) continue;
 

--- a/e2e/screenshot-manifest-reporter.ts
+++ b/e2e/screenshot-manifest-reporter.ts
@@ -23,6 +23,14 @@ function trimLongString(s: string, length = 100): string {
     return s.substring(0, start) + middle + s.slice(-end);
 }
 
+function sanitizeFilePathBeforeExtension(
+    filePath: string,
+    ext: string
+): string {
+    const base = filePath.substring(0, filePath.length - ext.length);
+    return sanitizeForFilePath(base) + ext;
+}
+
 interface ReporterOptions {
     outputFile?: string;
 }
@@ -66,7 +74,10 @@ class ScreenshotManifestReporter implements Reporter {
             if (!screenshotFileName) continue;
 
             const ext = path.extname(screenshotFileName);
-            const arg = screenshotFileName.replace(ext, "");
+            const arg = sanitizeFilePathBeforeExtension(
+                screenshotFileName,
+                ext
+            ).replace(ext, "");
 
             const snapshotPath = path.join(
                 screenshotDir,
@@ -80,9 +91,11 @@ class ScreenshotManifestReporter implements Reporter {
     async onEnd(_result: FullResult): Promise<void> {
         const lines = [
             "# Directories covered by this test run",
-            ...[...this.coveredDirs].sort().map((d) => `dir:${d}`),
+            ...[...this.coveredDirs]
+                .sort((a, b) => a.localeCompare(b))
+                .map((d) => `dir:${d}`),
             "# Screenshots referenced by tests",
-            ...[...this.usedScreenshots].sort(),
+            ...[...this.usedScreenshots].sort((a, b) => a.localeCompare(b)),
         ];
         fs.writeFileSync(this.outputFile, lines.join("\n") + "\n", "utf-8");
         console.log(

--- a/e2e/screenshot-manifest-reporter.ts
+++ b/e2e/screenshot-manifest-reporter.ts
@@ -15,17 +15,6 @@
  * In CI the config registers this reporter with a shard-specific output file
  * (e.g. .screenshot-manifest-1.txt) so parallel shards don't overwrite each other.
  * The stale checker then reads all manifest files matching the glob pattern.
- *
- * ⚠️  Playwright coupling — verified against @playwright/test ^1.58.2:
- *   - sanitizeForFilePath, trimLongString, sanitizeFilePathBeforeExtension mirror
- *     Playwright's internal path utilities (playwright/lib/util.js and
- *     playwright-core/lib/utils). These are not public API. Verify they still
- *     match after upgrading Playwright; a mismatch causes silent false positives
- *     in the stale checker (real screenshots flagged as orphaned).
- *   - titlePath().slice(3) assumes the title array is structured as
- *     [root, projectName, filePath, ...testTitles]. Verify this still holds
- *     after a Playwright upgrade by checking _fsSanitizedTestName in
- *     playwright/lib/worker/testInfo.js.
  */
 
 import type {
@@ -36,45 +25,8 @@ import type {
     TestCase,
     TestResult,
 } from "@playwright/test/reporter";
-import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
-
-/**
- * Mirrors Playwright's internal sanitizeForFilePath utility.
- * Replaces characters that are unsafe in file paths with hyphens.
- */
-function sanitizeForFilePath(s: string): string {
-    return s.replace(/[\x00-\x2C\x2E-\x2F\x3A-\x40\x5B-\x60\x7B-\x7F]+/g, "-");
-}
-
-/**
- * Mirrors Playwright's internal trimLongString utility.
- * Truncates strings that exceed `length` characters by replacing the middle
- * section with a short SHA-1 hash to avoid filesystem path-length limits while
- * keeping the result deterministic.
- */
-function trimLongString(s: string, length = 100): string {
-    if (s.length <= length) return s;
-    const hash = createHash("sha1").update(s).digest("hex");
-    const middle = `-${hash.substring(0, 5)}-`;
-    const start = Math.floor((length - middle.length) / 2);
-    const end = length - middle.length - start;
-    return s.substring(0, start) + middle + s.slice(-end);
-}
-
-/**
- * Mirrors Playwright's internal sanitizeFilePathBeforeExtension utility.
- * Sanitizes only the base name portion of a filename, preserving the extension
- * so that e.g. "non-sticky open.png" becomes "non-sticky-open.png".
- */
-function sanitizeFilePathBeforeExtension(
-    filePath: string,
-    ext: string
-): string {
-    const base = filePath.substring(0, filePath.length - ext.length);
-    return sanitizeForFilePath(base) + ext;
-}
 
 interface ReporterOptions {
     outputFile?: string;
@@ -101,58 +53,22 @@ class ScreenshotManifestReporter implements Reporter {
     /**
      * Called by Playwright after every test completes (pass or fail).
      *
-     * Reconstructs the absolute path of each screenshot the test declared it
-     * used via the "screenshot-used" annotation, using the same path-building
-     * logic as Playwright's snapshotPathTemplate resolution:
+     * Reads "screenshot-used" annotations written by compareScreenshot()
+     * (e2e/tests/utils.ts). Each annotation carries the absolute snapshot path
+     * already resolved by testInfo.snapshotPath(), so no path reconstruction
+     * is needed here.
      *
-     *   {testDir}/{testFileDir}/__screenshots__/{projectName}/{testName}--{arg}{ext}
-     *
-     * The path components are sanitized and truncated in exactly the same way
-     * as Playwright does internally, so the reconstructed paths match the real
-     * files on disk.
+     * The directory of each resolved path is also recorded so the stale checker
+     * knows which __screenshots__ directories were exercised by this run.
      */
-    onTestEnd(test: TestCase, result: TestResult): void {
-        const project = test.parent.project()!;
-        const testDir = project.testDir;
-        const testFilePath = test.location.file;
-        const relativeTestFileDir = path.dirname(
-            path.relative(testDir, testFilePath)
-        );
-        const projectName = sanitizeForFilePath(project.name);
-        // slice(3) skips [root, projectName, filePath] to match Playwright's
-        // internal _fsSanitizedTestName which also starts from index 1 of titlePath.
-        const fullTitleWithoutSpec = test.titlePath().slice(3).join(" ");
-        const testName = sanitizeForFilePath(
-            trimLongString(fullTitleWithoutSpec)
-        );
-
-        const screenshotDir = path.resolve(
-            testDir,
-            relativeTestFileDir,
-            "__screenshots__",
-            projectName
-        );
-        // Track this directory so the stale checker knows to inspect it even if
-        // a particular test ends up taking no screenshots.
-        this.coveredDirs.add(screenshotDir);
-
+    onTestEnd(_test: TestCase, result: TestResult): void {
         for (const annotation of result.annotations) {
             if (annotation.type !== "_screenshot-used") continue;
-            const screenshotFileName = annotation.description;
-            if (!screenshotFileName) continue;
-
-            const ext = path.extname(screenshotFileName);
-            const arg = sanitizeFilePathBeforeExtension(
-                screenshotFileName,
-                ext
-            ).replace(ext, "");
-
-            const snapshotPath = path.join(
-                screenshotDir,
-                `${testName}--${arg}${ext}`
-            );
+            const snapshotPath = annotation.description;
+            if (!snapshotPath) continue;
 
             this.usedScreenshots.add(snapshotPath);
+            this.coveredDirs.add(path.dirname(snapshotPath));
         }
     }
 

--- a/e2e/tests/components/button/button.e2e.spec.ts
+++ b/e2e/tests/components/button/button.e2e.spec.ts
@@ -30,7 +30,7 @@ test.describe("Button", () => {
     // -------------------------------------------------------------------------
     // Base variants
     // -------------------------------------------------------------------------
-    test.describe(() => {
+    test.describe.skip(() => {
         test.beforeEach(async ({ story }) => {
             await story.init("base-variants");
         });

--- a/e2e/tests/components/button/button.e2e.spec.ts
+++ b/e2e/tests/components/button/button.e2e.spec.ts
@@ -30,7 +30,7 @@ test.describe("Button", () => {
     // -------------------------------------------------------------------------
     // Base variants
     // -------------------------------------------------------------------------
-    test.describe.skip(() => {
+    test.describe(() => {
         test.beforeEach(async ({ story }) => {
             await story.init("base-variants");
         });

--- a/e2e/tests/utils.ts
+++ b/e2e/tests/utils.ts
@@ -1,4 +1,10 @@
-import { expect, Locator, Page } from "@playwright/test";
+import {
+    expect,
+    Locator,
+    Page,
+    PageAssertionsToHaveScreenshotOptions,
+    test,
+} from "@playwright/test";
 import { viewport } from "./consts";
 
 export abstract class AbstractStoryPage {
@@ -158,6 +164,15 @@ export const compareScreenshot = async (
         scrollIntoView?: boolean;
     }
 ) => {
+    let screenshotOptions: PageAssertionsToHaveScreenshotOptions = {
+        fullPage: false,
+        threshold: 0.01, // Strict colour matching
+        maxDiffPixelRatio: 0.01, // Allow a small percentage of pixels to differ
+        maxDiffPixels: 50,
+        mask: options?.mask,
+    };
+    let target: Page | Locator = storyPage.page;
+
     if (options?.locator) {
         if (options.scrollIntoView) {
             await options.locator.evaluate((el) => {
@@ -169,8 +184,7 @@ export const compareScreenshot = async (
         if (!box) {
             throw new Error("Could not get bounding box for locator");
         }
-
-        await expect.soft(storyPage.page).toHaveScreenshot(`${name}.png`, {
+        screenshotOptions = {
             // Adding a 10px boundary around the element to capture any shadows or outlines
             clip: {
                 x: Math.max(0, box.x - 10),
@@ -182,20 +196,20 @@ export const compareScreenshot = async (
             maxDiffPixelRatio: 0.01, // Allow a small percentage of pixels to differ
             maxDiffPixels: 50,
             mask: options.mask,
-        });
-        return;
+        };
     }
 
-    const target = options?.fullscreen
-        ? storyPage.page
-        : storyPage.page.locator("body");
+    if (!options?.locator && !options?.fullscreen) {
+        target = storyPage.page.locator("body");
+    }
 
-    await expect.soft(target).toHaveScreenshot(`${name}.png`, {
-        fullPage: false,
-        threshold: 0.01, // Strict colour matching
-        maxDiffPixelRatio: 0.01, // Allow a small percentage of pixels to differ
-        maxDiffPixels: 50,
-        mask: options?.mask,
+    await expect
+        .soft(target)
+        .toHaveScreenshot(`${name}.png`, screenshotOptions);
+
+    test.info().annotations.push({
+        type: "screenshot-used",
+        description: `${name}.png`,
     });
 };
 

--- a/e2e/tests/utils.ts
+++ b/e2e/tests/utils.ts
@@ -208,7 +208,7 @@ export const compareScreenshot = async (
         .toHaveScreenshot(`${name}.png`, screenshotOptions);
 
     test.info().annotations.push({
-        type: "screenshot-used",
+        type: "_screenshot-used",
         description: `${name}.png`,
     });
 };

--- a/e2e/tests/utils.ts
+++ b/e2e/tests/utils.ts
@@ -209,7 +209,7 @@ export const compareScreenshot = async (
 
     test.info().annotations.push({
         type: "_screenshot-used",
-        description: `${name}.png`,
+        description: test.info().snapshotPath(`${name}.png`),
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "test-e2e:setup": "./scripts/e2e-setup.sh",
         "test-e2e-ci": "npm run test-e2e:setup && ./scripts/e2e-ci-build.sh && ./scripts/e2e-ci-test.sh",
         "test-e2e:changed": "npm run test-e2e:setup && playwright test --only-changed",
-        "check-stale-screenshots": "tsx scripts/check-stale-screenshots.ts",
+        "test-e2e:check-stale-screenshots": "tsx scripts/check-stale-screenshots.ts",
         "prepare": "(test -d ./.git && npx husky install) || true",
         "postinstall": "patch-package",
         "storybook": "concurrently -k -n types,storybook \"npm run storybook:argtypes -- --watch\" \"storybook dev -p 6006\"",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
         "test-e2e:docker": "docker compose up --build",
         "test-e2e:setup": "./scripts/e2e-setup.sh",
         "test-e2e-ci": "npm run test-e2e:setup && ./scripts/e2e-ci-build.sh && ./scripts/e2e-ci-test.sh",
+        "test-e2e:changed": "npm run test-e2e:setup && playwright test --only-changed",
+        "check-stale-screenshots": "tsx scripts/check-stale-screenshots.ts",
         "prepare": "(test -d ./.git && npx husky install) || true",
         "postinstall": "patch-package",
         "storybook": "concurrently -k -n types,storybook \"npm run storybook:argtypes -- --watch\" \"storybook dev -p 6006\"",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
                   "./e2e/screenshot-manifest-reporter.ts",
                   {
                       outputFile: `.screenshot-manifest-${
-                          (process.env.SHARD || "full").replace(/\//g, "-")
+                          (process.env.SHARD || "full").split("/")[0]
                       }.txt`,
                   },
               ],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
                   "./e2e/screenshot-manifest-reporter.ts",
                   {
                       outputFile: `.screenshot-manifest-${
-                          process.env.SHARD || "full"
+                          (process.env.SHARD || "full").replace(/\//g, "-")
                       }.txt`,
                   },
               ],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,8 +15,27 @@ export default defineConfig({
     workers: process.env.CI ? "50%" : undefined,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: process.env.CI
-        ? [["github"], ["html"], ["blob"]]
-        : [["list"], ["html"]],
+        ? [
+              ["github"],
+              ["html"],
+              ["blob"],
+              [
+                  "./e2e/screenshot-manifest-reporter.ts",
+                  {
+                      outputFile: `.screenshot-manifest-${
+                          process.env.SHARD || "full"
+                      }.txt`,
+                  },
+              ],
+          ]
+        : [
+              ["list"],
+              ["html"],
+              [
+                  "./e2e/screenshot-manifest-reporter.ts",
+                  { outputFile: ".screenshot-manifest.txt" },
+              ],
+          ],
     /* Location of screenshots */
     snapshotPathTemplate:
         "{testDir}/{testFileDir}/__screenshots__/{projectName}/{testName}--{arg}{ext}",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -70,6 +70,7 @@ const plugins = [
             // which happened after tsconfig.json includes scripts/**/*.ts
             exclude: [
                 "tests",
+                "scripts",
                 "**/stories/**",
                 "**/__mocks__/**",
                 "**/custom-types/css.d.ts",

--- a/scripts/check-stale-screenshots.ts
+++ b/scripts/check-stale-screenshots.ts
@@ -1,0 +1,118 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const DEFAULT_MANIFEST_GLOB = ".screenshot-manifest*.txt";
+
+function findManifestFiles(pattern: string): string[] {
+    const dir = path.dirname(pattern) || ".";
+    const base = path.basename(pattern);
+    const regex = new RegExp(
+        "^" + base.replace(/\./g, "\\.").replace(/\*/g, ".*") + "$"
+    );
+
+    const resolvedDir = path.resolve(dir);
+    if (!fs.existsSync(resolvedDir)) return [];
+
+    return fs
+        .readdirSync(resolvedDir)
+        .filter((f) => regex.test(f))
+        .map((f) => path.resolve(resolvedDir, f));
+}
+
+interface ManifestData {
+    coveredDirs: Set<string>;
+    usedScreenshots: Set<string>;
+}
+
+function readManifests(files: string[]): ManifestData {
+    const coveredDirs = new Set<string>();
+    const usedScreenshots = new Set<string>();
+
+    for (const file of files) {
+        const content = fs.readFileSync(file, "utf-8");
+        for (const line of content.split("\n")) {
+            const trimmed = line.trim();
+            if (!trimmed || trimmed.startsWith("#")) continue;
+            if (trimmed.startsWith("dir:")) {
+                coveredDirs.add(trimmed.slice(4));
+            } else {
+                usedScreenshots.add(trimmed);
+            }
+        }
+    }
+
+    return { coveredDirs, usedScreenshots };
+}
+
+function findScreenshotsInDirs(dirs: Set<string>): string[] {
+    const results: string[] = [];
+
+    for (const dir of dirs) {
+        if (!fs.existsSync(dir)) continue;
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+            if (entry.isFile() && entry.name.endsWith(".png")) {
+                results.push(path.join(dir, entry.name));
+            }
+        }
+    }
+
+    return results;
+}
+
+function main() {
+    const args = process.argv.slice(2);
+    const deleteMode = args.includes("--delete");
+    const manifestArg = args
+        .find((a) => a.startsWith("--manifest="))
+        ?.split("=")[1];
+    const manifestPattern = manifestArg || DEFAULT_MANIFEST_GLOB;
+
+    const manifestFiles = findManifestFiles(manifestPattern);
+    if (manifestFiles.length === 0) {
+        console.error(
+            `No manifest files found matching "${manifestPattern}".` +
+                "\nRun the full test suite first to generate the manifest."
+        );
+        process.exit(1);
+    }
+
+    console.log(
+        `Reading ${manifestFiles.length} manifest file(s):` +
+            manifestFiles
+                .map((f) => `\n  ${path.relative(process.cwd(), f)}`)
+                .join("")
+    );
+
+    const { coveredDirs, usedScreenshots } = readManifests(manifestFiles);
+    console.log(`Directories covered: ${coveredDirs.size}`);
+    console.log(`Screenshots referenced in tests: ${usedScreenshots.size}`);
+
+    const allScreenshots = findScreenshotsInDirs(coveredDirs);
+    console.log(
+        `Screenshots on disk (in covered dirs): ${allScreenshots.length}`
+    );
+
+    const staleFiles = allScreenshots.filter((f) => !usedScreenshots.has(f));
+
+    if (staleFiles.length === 0) {
+        console.log("\nNo stale screenshots found.");
+        process.exit(0);
+    }
+
+    console.log(`\nFound ${staleFiles.length} stale screenshot(s):`);
+    for (const f of staleFiles) {
+        console.log(`  ${path.relative(process.cwd(), f)}`);
+    }
+
+    if (deleteMode) {
+        for (const f of staleFiles) {
+            fs.unlinkSync(f);
+        }
+        console.log(`\nDeleted ${staleFiles.length} stale screenshot(s).`);
+    } else {
+        console.log("\nRun with --delete to remove these files.");
+        process.exit(1);
+    }
+}
+
+main();

--- a/scripts/e2e/pre-push.sh
+++ b/scripts/e2e/pre-push.sh
@@ -28,6 +28,5 @@ if ! REMOTE_REF=$(resolve_changed_ref); then
 fi
 
 echo "[e2e] Running changed-file E2E between HEAD and $REMOTE_REF"
-npm run test-e2e:setup
-CI=true npx playwright test --only-changed="$REMOTE_REF"
-npx tsx scripts/check-stale-screenshots.ts
+npm run test-e2e:changed -- "$REMOTE_REF"
+npm run check-stale-screenshots

--- a/scripts/e2e/pre-push.sh
+++ b/scripts/e2e/pre-push.sh
@@ -1,4 +1,4 @@
-# scripts/e2e-prepush.sh
+#!/bin/bash
 
 # Pre-push e2e validation script.
 #

--- a/scripts/e2e/pre-push.sh
+++ b/scripts/e2e/pre-push.sh
@@ -1,0 +1,33 @@
+# scripts/e2e-prepush.sh
+
+# Pre-push e2e validation script.
+#
+# 1. Determines whether a valid upstream ref exists.
+# 2. Runs Playwright's --only-changed to execute tests affected by the diff.
+#    This detects changes in test files and their imports (e.g., shared utils).
+# 3. After the run, the screenshot-manifest-reporter writes a manifest of all
+#    screenshot paths that were referenced and which directories were covered.
+# 4. Runs check-stale-screenshots.ts to detect orphaned .png files within
+#    those covered directories. Exits with error if any are found.
+
+resolve_changed_ref() {
+	if git rev-parse --abbrev-ref --symbolic-full-name @{u} >/dev/null 2>&1; then
+		upstream_ref=$(git rev-parse --abbrev-ref --symbolic-full-name @{u})
+		if git rev-parse --verify --quiet "$upstream_ref" >/dev/null; then
+			printf '%s\n' "$upstream_ref"
+			return 0
+		fi
+	fi
+
+	return 1
+}
+
+if ! REMOTE_REF=$(resolve_changed_ref); then
+	echo "[e2e] No upstream ref found — skipping E2E. Set an upstream with: git branch --set-upstream-to=<remote>/<branch>"
+	exit 0
+fi
+
+echo "[e2e] Running changed-file E2E between HEAD and $REMOTE_REF"
+npm run test-e2e:setup
+CI=true npx playwright test --only-changed="$REMOTE_REF"
+npx tsx scripts/check-stale-screenshots.ts

--- a/scripts/e2e/pre-push.sh
+++ b/scripts/e2e/pre-push.sh
@@ -29,4 +29,4 @@ fi
 
 echo "[e2e] Running changed-file E2E between HEAD and $REMOTE_REF"
 npm run test-e2e:changed -- "$REMOTE_REF"
-npm run check-stale-screenshots
+npm run test-e2e:check-stale-screenshots

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
     },
     "include": [
         "src/**/*",
+        "scripts/**/*",
         "tests/**/*",
         "custom-types/*",
         "stories",


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)
-   [ ] Documentation (change to documentation, comments or API descriptions)
-   [ ] Tests (improvements to unit tests or E2E tests)
-   [X] Other (technical improvements, refactoring, or changes that don't fall into the above categories)

**Description of changes**
 Link to [ticket](https://sgtechstack.atlassian.net/browse/CCUBE-2180)

Adding a script to check for any stale snapshots. The approach is:
- Add annotation for each snapshot
- Add a custom reporter to generate a manifest based on annotation
- Add a script to check for any snapshot not present in the manifest, marked those as stale
- Include e2e run for changed only on pre-push for local guard

When any stale snapshots is present, the pre-push and CI pipeline would be stopped, and marked as failed.
> [!CAUTION]
> Pre-push check only works when the branch has an upstream branch reference. When it is not present, the checker won't run. This is due to playwright need the branch to compare the changes diff, otherwise it will run the whole suite which is not ideal.

**Checklist**

<!-- Put an `x` in items that apply -->

-   [X] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [ ] Looks good on mobile and tablet
-   [ ] Updated documentation
-   [ ] Added/updated unit tests
-   [ ] Added/updated E2E tests

**Screenshots** 

Pipeline https://github.com/LifeSG/react-design-system/actions/runs/30613329864/job/91102159301?pr=1304. 

---

Prepush Guard
<img width="854" height="302" alt="image" src="https://github.com/user-attachments/assets/e875eed3-eb8e-4e31-8783-eb4c41cc3fbe" />

