### PR TITLE
[CCUBE-2104][IT] Expose ref on uneditable section component

### DIFF
--- a/src/uneditable-section/types.ts
+++ b/src/uneditable-section/types.ts
@@ -67,3 +67,5 @@ export interface UneditableSectionProps {
     /** The callback function when the "Try again" button is clicked in error state */
     onTryAgain?: ((item: UneditableSectionItemProps) => void) | undefined;
 }
+
+export type UneditableSectionRef = React.Ref<HTMLDivElement>;

--- a/src/uneditable-section/types.ts
+++ b/src/uneditable-section/types.ts
@@ -67,5 +67,3 @@ export interface UneditableSectionProps {
     /** The callback function when the "Try again" button is clicked in error state */
     onTryAgain?: ((item: UneditableSectionItemProps) => void) | undefined;
 }
-
-export type UneditableSectionRef = React.Ref<HTMLDivElement>;

--- a/src/uneditable-section/uneditable-section.tsx
+++ b/src/uneditable-section/uneditable-section.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx";
+import React from "react";
 
 import { Layout } from "../layout";
 import { Typography } from "../typography";
@@ -6,25 +7,29 @@ import { UneditableSectionItem } from "./section-item";
 import type {
     UneditableSectionItemProps,
     UneditableSectionProps,
+    UneditableSectionRef,
 } from "./types";
 import * as styles from "./uneditable-section.styles";
 
-export const UneditableSectionBase = ({
-    items,
-    title,
-    description,
-    topSection,
-    bottomSection,
-    children,
-    background = true,
-    stretch,
-    fullWidth,
-    onMask,
-    onUnmask,
-    onTryAgain,
-    className,
-    ...otherProps
-}: UneditableSectionProps) => {
+const Component = (
+    {
+        items,
+        title,
+        description,
+        topSection,
+        bottomSection,
+        children,
+        background = true,
+        stretch,
+        fullWidth,
+        onMask,
+        onUnmask,
+        onTryAgain,
+        className,
+        ...otherProps
+    }: UneditableSectionProps,
+    ref: UneditableSectionRef
+) => {
     // =============================================================================
     // EVENT HANDLERS
     // =============================================================================
@@ -133,6 +138,7 @@ export const UneditableSectionBase = ({
     if (fullWidth) {
         return (
             <div
+                ref={ref}
                 className={clsx(
                     background && styles.wrapperBackground,
                     className
@@ -145,6 +151,7 @@ export const UneditableSectionBase = ({
     }
     return (
         <Layout.Content
+            ref={ref}
             className={clsx(
                 styles.wrapper,
                 background && styles.wrapperBackground,
@@ -157,3 +164,7 @@ export const UneditableSectionBase = ({
         </Layout.Content>
     );
 };
+
+Component.displayName = "UneditableSection";
+
+export const UneditableSectionBase = React.forwardRef(Component);

--- a/src/uneditable-section/uneditable-section.tsx
+++ b/src/uneditable-section/uneditable-section.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx";
+import type { NamedExoticComponent } from "react";
 import React from "react";
 
 import { Layout } from "../layout";
@@ -7,7 +8,6 @@ import { UneditableSectionItem } from "./section-item";
 import type {
     UneditableSectionItemProps,
     UneditableSectionProps,
-    UneditableSectionRef,
 } from "./types";
 import * as styles from "./uneditable-section.styles";
 
@@ -28,7 +28,7 @@ const Component = (
         className,
         ...otherProps
     }: UneditableSectionProps,
-    ref: UneditableSectionRef
+    ref: React.Ref<HTMLDivElement>
 ) => {
     // =============================================================================
     // EVENT HANDLERS
@@ -165,6 +165,7 @@ const Component = (
     );
 };
 
-Component.displayName = "UneditableSection";
-
 export const UneditableSectionBase = React.forwardRef(Component);
+
+(UneditableSectionBase as NamedExoticComponent).displayName =
+    "UneditableSection";

--- a/tests/uneditable-section/uneditable-section.spec.tsx
+++ b/tests/uneditable-section/uneditable-section.spec.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
 import type { UneditableSectionItemProps } from "src/uneditable-section";
 import { UneditableSection } from "src/uneditable-section";
 
@@ -362,6 +363,31 @@ describe("UneditableSection", () => {
 
             render(<UneditableSection items={ITEMS} title="Test" />);
             expect(screen.getByText("This is an alert")).toBeInTheDocument();
+        });
+    });
+
+    describe("Ref forwarding", () => {
+        it("should forward ref to the wrapper element", () => {
+            const ref = React.createRef<HTMLDivElement>();
+            render(
+                <UneditableSection ref={ref} items={MOCK_ITEMS} title="Test" />
+            );
+
+            expect(ref.current).toBeInstanceOf(HTMLElement);
+        });
+
+        it("should forward ref when fullWidth is true", () => {
+            const ref = React.createRef<HTMLDivElement>();
+            render(
+                <UneditableSection
+                    ref={ref}
+                    items={MOCK_ITEMS}
+                    title="Test"
+                    fullWidth
+                />
+            );
+
+            expect(ref.current).toBeInstanceOf(HTMLDivElement);
         });
     });
 });


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)
-   [ ] Documentation (change to documentation, comments or API descriptions)
-   [ ] Tests (improvements to unit tests or E2E tests)
-   [ ] Other (technical improvements, refactoring, or changes that don't fall into the above categories)

**Description of changes**

-   Link to [ticket](https://sgtechstack.atlassian.net/browse/CCUBE-2104)
-   Exposed a ref for `UneditableSection` component 

**Checklist**

<!-- Put an `x` in items that apply -->

-   [x] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [ ] ~Looks good on mobile and tablet~
-   [ ] ~Updated documentation~
-   [x] Added/updated unit tests
-   [ ] ~Added/updated E2E tests~

