### PR TITLE
[CCUBE-2182][GZ] component jsdocs batch 6

### DIFF
--- a/JSDOC_CONVENTIONS.md
+++ b/JSDOC_CONVENTIONS.md
@@ -250,7 +250,12 @@ Avoid:
 
 ### Defaults
 
-Use `@default` only when the default value is stable and enforced by the component.
+Use `@default` for:
+
+-   A default value assigned in the destructuring or function body
+-   A direct/simple fallback: a literal value (`200`, `"border"`), a named
+    token (`Colour["border"]`), or a simple computation (`50% of container
+height`)
 
 ```tsx
 export interface ExampleProps {
@@ -260,8 +265,18 @@ export interface ExampleProps {
      * @default false
      */
     fixed?: boolean | undefined;
+
+    /**
+     * Stroke colour for the border.
+     *
+     * @default Colour["border"]
+     */
+    colour?: string | undefined;
 }
 ```
+
+For complex fallback logic (conditional, multi-step, or computed), use
+`@remarks` instead of `@default`.
 
 Do not document a default when the value is only assumed by convention.
 

--- a/src/form/index.ts
+++ b/src/form/index.ts
@@ -25,29 +25,109 @@ import { FormUnitNumberInput } from "./form-unit-number-input";
 
 export * from "./types";
 
+/**
+ * A collection of form field components that each combine a label, input
+ * control, and inline error message with consistent ARIA wiring.
+ *
+ * Use `Form.*` sub-components to build accessible forms. Use `Form.CustomField` to wrap any
+ * bespoke input element in the same layout.
+ *
+ * Sub-components:
+ * - `Form.CustomField` — layout shell for wrapping custom input elements.
+ * - `Form.DateInput` — single date picker.
+ * - `Form.DateRangeInput` — date range picker.
+ * - `Form.ESignature` — e-signature capture field.
+ * - `Form.HistogramSlider` — range slider with histogram overlay.
+ * - `Form.Input` — single-line text input field.
+ * - `Form.InputGroup` — grouped inputs with shared label and error state.
+ * - `Form.Label` — standalone label for use outside a `Form.*` field.
+ * - `Form.MaskedInput` — text input with a character-level input mask.
+ * - `Form.MultiSelect` — multi-value dropdown select.
+ * - `Form.NestedMultiSelect` — hierarchical multi-value select.
+ * - `Form.NestedSelect` — hierarchical single-value select.
+ * - `Form.OtpVerification` — OTP send-and-verify flow.
+ * - `Form.PhoneNumberInput` — phone number input with country code selection.
+ * - `Form.PredictiveTextInput` — text input with predictive suggestions.
+ * - `Form.RangeSelect` — dual-value range dropdown select.
+ * - `Form.RangeSlider` — dual-handle range slider.
+ * - `Form.Select` — single-value dropdown select.
+ * - `Form.SelectHistogram` — select control with histogram.
+ * - `Form.Slider` — single-value range slider.
+ * - `Form.Textarea` — multi-line text area.
+ * - `Form.Timepicker` — time picker.
+ * - `Form.TimeRangePicker` — time range picker.
+ * - `Form.UnitNumberInput` — structured unit number input.
+ */
 export const Form = {
-    DateInput: FormDateInput,
-    DateRangeInput: FormDateRangeInput,
-    ESignature: FormESignature,
-    HistogramSlider: FormHistogramSlider,
-    Input: FormInput,
-    InputGroup: FormInputGroup,
-    MaskedInput: FormMaskedInput,
-    Label: FormLabel,
-    MultiSelect: FormMultiSelect,
-    NestedSelect: FormNestedSelect,
-    NestedMultiSelect: FormNestedMultiSelect,
-    Select: FormSelect,
-    SelectHistogram: FormSelectHistogram,
-    Slider: FormSlider,
-    RangeSlider: FormRangeSlider,
-    RangeSelect: FormRangeSelect,
-    Textarea: FormTextarea,
-    Timepicker: FormTimepicker,
-    TimeRangePicker: FormTimeRangePicker,
+    /** Layout shell that wraps any custom input element with label, subtitle, and error message. */
     CustomField: FormCustomField,
-    UnitNumberInput: FormUnitNumberInput,
-    PhoneNumberInput: FormPhoneNumberInput,
-    PredictiveTextInput: FormPredictiveTextInput,
+
+    /** Single date picker with form layout. */
+    DateInput: FormDateInput,
+
+    /** Date range picker with form layout. */
+    DateRangeInput: FormDateRangeInput,
+
+    /** E-signature capture field with form layout. */
+    ESignature: FormESignature,
+
+    /** Range slider with histogram overlay and form layout. */
+    HistogramSlider: FormHistogramSlider,
+
+    /** Single-line text input field with form layout. */
+    Input: FormInput,
+
+    /** Grouped inputs with shared label, error state, and form layout. */
+    InputGroup: FormInputGroup,
+
+    /** Standalone label element for use outside a `Form.*` field with optional subtitle and addon icon. */
+    Label: FormLabel,
+
+    /** Text input with a character-level input mask and form layout. */
+    MaskedInput: FormMaskedInput,
+
+    /** Multi-value dropdown select with form layout. */
+    MultiSelect: FormMultiSelect,
+
+    /** Hierarchical multi-value select with form layout. */
+    NestedMultiSelect: FormNestedMultiSelect,
+
+    /** Hierarchical single-value select with form layout. */
+    NestedSelect: FormNestedSelect,
+
+    /** OTP send-and-verify flow with form layout. */
     OtpVerification: FormOtpVerification,
+
+    /** Phone number input with country code selection and form layout. */
+    PhoneNumberInput: FormPhoneNumberInput,
+
+    /** Text input with predictive suggestions and form layout. */
+    PredictiveTextInput: FormPredictiveTextInput,
+
+    /** Dual-value range dropdown select with form layout. */
+    RangeSelect: FormRangeSelect,
+
+    /** Dual-handle range slider with form layout. */
+    RangeSlider: FormRangeSlider,
+
+    /** Single-value dropdown select with form layout. */
+    Select: FormSelect,
+
+    /** Select control with histogram and form layout. */
+    SelectHistogram: FormSelectHistogram,
+
+    /** Single-value range slider with form layout. */
+    Slider: FormSlider,
+
+    /** Multi-line text area with form layout. */
+    Textarea: FormTextarea,
+
+    /** Time picker with form layout. */
+    Timepicker: FormTimepicker,
+
+    /** Time range picker with form layout. */
+    TimeRangePicker: FormTimeRangePicker,
+
+    /** Structured unit number input with form layout. */
+    UnitNumberInput: FormUnitNumberInput,
 };

--- a/src/form/types.ts
+++ b/src/form/types.ts
@@ -21,130 +21,278 @@ import type { TimeRangePickerProps } from "../time-range-picker/types";
 import type { TimepickerProps } from "../timepicker/types";
 import type { UnitNumberInputProps } from "../unit-number/types";
 
+/**
+ * Determines whether a label addon renders as a tooltip or a popover overlay.
+ */
 export type FormLabelAddonType = "tooltip" | "popover";
 
-export interface FormLabelAddonTriggerProps {
-    addonType?: FormLabelAddonType | undefined /* For informational purposes */;
-    icon?: JSX.Element | undefined;
-    "data-testid"?: string | undefined;
-}
-
+/**
+ * Configuration for an informational icon rendered inline with a form label.
+ */
 export interface FormLabelAddonProps {
+    /** Text or element displayed inside the popover overlay. */
     content: string | JSX.Element;
+    /**
+     * Display mechanism for the addon.
+     *
+     * - `"popover"` - renders an icon that triggers a popover
+     * - `"tooltip"` - currently unsupported
+     * - omitted - renders nothing
+     */
     type?: FormLabelAddonType | undefined;
+    /**
+     * Custom icon element.
+     *
+     * @default `i-circle-fill` icon.
+     */
     icon?: JSX.Element | undefined;
     id?: string | undefined;
+    /** Stacking order of the popover overlay. */
     zIndex?: number | undefined;
     "data-testid"?: string | undefined;
 }
 
+/**
+ * Props for a form field label or `Form.Label` component.
+ */
 export interface FormLabelProps
     extends React.LabelHTMLAttributes<HTMLLabelElement> {
+    /** Informational icon and popover rendered inline with the label text. */
     addon?: FormLabelAddonProps | undefined;
+    /** Supporting description rendered below the label. */
     subtitle?: string | JSX.Element | undefined;
     "data-testid"?: string | undefined;
 }
 
+/**
+ * Controls how a form field's outer container is rendered.
+ *
+ * - `"flex"` — plain `div` with no column constraints.
+ * - `"grid"` — `ColDiv` that accepts responsive column span props from `ColProps`.
+ */
 export type FormElementLayoutType = "flex" | "grid";
 
+/**
+ * Common props shared by all `Form.*` field components.
+ */
 export interface BaseFormElementProps extends ColProps {
+    /**
+     * Label rendered above the input. Accepts a plain string or a
+     * `FormLabelProps` object to provide additional configuration.
+     */
     label?: FormLabelProps | string | undefined;
+    /**
+     * Inline error text rendered below the input.
+     */
     errorMessage?: string | React.ReactNode | undefined;
     "data-testid"?: string | undefined;
     "data-error-testid"?: string | undefined;
-    /** The layout type. Values: "flex" | "grid" */
+    /**
+     * Controls whether the container uses flex layout or a responsive column grid.
+     */
     layoutType?: FormElementLayoutType | undefined;
 }
 
+/**
+ * Props for the `FormWrapper` layout container.
+ */
 export interface FormWrapperProps extends BaseFormElementProps {
     children: JSX.Element | JSX.Element[];
+    /**
+     * Base ID used to derive ARIA label, subtitle, and error-message element
+     * IDs. A generated ID is used when omitted.
+     */
     id?: string | undefined;
 }
 
+/**
+ * Props for `Form.Input`, combining text input props with the shared form
+ * field layout.
+ */
 export interface FormInputProps
     extends InputPartialProps,
         BaseFormElementProps {}
 
+/**
+ * Props for `Form.InputGroup`, combining input group props with the shared
+ * form field layout.
+ *
+ * `T` is the option item type. `V` is the selected value type.
+ */
 export interface FormInputGroupProps<T, V>
     extends InputGroupPartialProps<T, V>,
         BaseFormElementProps {}
 
+/**
+ * Props for `Form.MaskedInput`, combining masked input props with the shared
+ * form field layout.
+ */
 export interface FormMaskedInputProps
     extends MaskedInputPartialProps,
         BaseFormElementProps {}
 
+/**
+ * Props for `Form.Textarea`, combining textarea props with the shared form
+ * field layout.
+ */
 export interface FormTextareaProps
     extends TextareaPartialProps,
         BaseFormElementProps {}
 
+/**
+ * Props for `Form.CustomField`, which wraps any custom input element with a
+ * shared label, subtitle, and inline error message layout.
+ */
 export interface FormCustomFieldProps
     extends FormWrapperProps,
         BaseFormElementProps {}
 
+/**
+ * Props for `Form.Select`, combining single-select input props with the shared
+ * form field layout.
+ *
+ * `T` is the option item type. `V` is the selected value type.
+ */
 export interface FormInputSelectProps<T, V>
     extends InputSelectPartialProps<T, V>,
         BaseFormElementProps {}
 
+/**
+ * Props for `Form.RangeSelect`, combining range-select input props with the
+ * shared form field layout.
+ *
+ * `T` is the option item type. `V` is the selected value type.
+ */
 export interface FormInputRangeSelectProps<T, V>
     extends InputRangeSelectPartialProps<T, V>,
         BaseFormElementProps {}
 
+/**
+ * Props for `Form.MultiSelect`, combining multi-select input props with the
+ * shared form field layout.
+ *
+ * `T` is the option item type. `V` is the selected value type.
+ */
 export interface FormMultiSelectProps<T, V>
     extends InputMultiSelectPartialProps<T, V>,
         BaseFormElementProps {}
 
+/**
+ * Props for `Form.NestedSelect`, combining nested single-select input props
+ * with the shared form field layout.
+ *
+ * `V1`, `V2`, and `V3` are the value types for the first, second, and third
+ * nesting levels respectively.
+ */
 export interface FormNestedSelectProps<V1, V2, V3>
     extends InputNestedSelectPartialProps<V1, V2, V3>,
         BaseFormElementProps {}
 
+/**
+ * Props for `Form.NestedMultiSelect`, combining nested multi-select input
+ * props with the shared form field layout.
+ *
+ * `V1`, `V2`, and `V3` are the value types for the first, second, and third
+ * nesting levels respectively.
+ */
 export interface FormNestedMultiSelectProps<V1, V2, V3>
     extends InputNestedMultiSelectPartialProps<V1, V2, V3>,
         BaseFormElementProps {}
 
+/**
+ * Props for `Form.DateInput`, combining date input props with the shared form
+ * field layout.
+ */
 export interface FormDateInputProps
     extends DateInputProps,
         BaseFormElementProps {}
 
+/**
+ * Props for `Form.DateRangeInput`, combining date-range input props with the
+ * shared form field layout.
+ */
 export interface FormDateRangeInputProps
     extends DateRangeInputProps,
         BaseFormElementProps {}
 
+/**
+ * Props for `Form.Timepicker`, combining time picker props with the shared
+ * form field layout.
+ */
 export interface FormTimepickerProps
     extends TimepickerProps,
         BaseFormElementProps {}
 
+/**
+ * Props for `Form.UnitNumberInput`, combining unit-number input props with the
+ * shared form field layout.
+ */
 export interface FormUnitNumberInputProps
     extends UnitNumberInputProps,
         BaseFormElementProps {}
 
+/**
+ * Props for `Form.PhoneNumberInput`, combining phone-number input props with
+ * the shared form field layout.
+ */
 export interface FormPhoneNumberInputProps
     extends PhoneNumberInputProps,
         BaseFormElementProps {}
 
+/**
+ * Props for `Form.TimeRangePicker`, combining time-range picker props with the
+ * shared form field layout.
+ */
 export interface FormTimeRangePickerProps
     extends TimeRangePickerProps,
         BaseFormElementProps {}
 
+/**
+ * Props for `Form.PredictiveTextInput`, combining predictive text input props
+ * with the shared form field layout.
+ *
+ * `T` is the suggestion item type. `V` is the selected value type.
+ */
 export interface FormPredictiveTextInputProps<T, V>
     extends PredictiveTextInputProps<T, V>,
         BaseFormElementProps {}
 
+/**
+ * Props for `Form.Slider`, combining single-value slider props with the shared
+ * form field layout.
+ */
 export interface FormSliderProps
     extends InputSliderProps,
         BaseFormElementProps {}
 
+/**
+ * Props for `Form.RangeSlider`, combining range slider props with the shared
+ * form field layout.
+ */
 export interface FormRangeSliderProps
     extends InputRangeSliderProps,
         BaseFormElementProps {}
 
+/**
+ * Props for `Form.HistogramSlider`, combining histogram slider props with the
+ * shared form field layout.
+ */
 export interface FormHistogramSliderProps
     extends HistogramSliderProps,
         BaseFormElementProps {}
 
+/**
+ * Props for `Form.ESignature`, combining e-signature props with the shared
+ * form field layout.
+ */
 export interface FormESignatureProps
     extends EsignatureProps,
         BaseFormElementProps {}
 
+/**
+ * Props for `Form.SelectHistogram`, combining select-histogram props with the
+ * shared form field layout.
+ */
 export interface FormSelectHistogramProps
     extends SelectHistogramProps,
         BaseFormElementProps {}

--- a/src/fullscreen-image-carousel/fullscreen-image-carousel.tsx
+++ b/src/fullscreen-image-carousel/fullscreen-image-carousel.tsx
@@ -603,6 +603,13 @@ export const Component = (
     );
 };
 
+/**
+ * A fullscreen modal carousel for browsing images and custom media items.
+ *
+ * Use to present a collection of images or custom content in an overlay with
+ * navigation controls, zoom support, and an optional thumbnail strip.
+ * The top info bar is rendered only when at least one item provides some file metadata.
+ */
 export const FullscreenImageCarousel = forwardRef<
     FullscreenImageCarouselRef,
     FullscreenImageCarouselProps

--- a/src/fullscreen-image-carousel/types.ts
+++ b/src/fullscreen-image-carousel/types.ts
@@ -1,42 +1,109 @@
 import type { ModalProps } from "../modal";
 import type { Insets } from "../shared/types";
 
+/**
+ * Imperative handle to read or change the active item programmatically.
+ */
 export interface FullscreenImageCarouselRef {
+    /** Zero-based index of the currently visible item. */
     currentItemIndex: number;
+    /**
+     * Navigates directly to the item at the given zero-based index.
+     *
+     * @param currentItemIndex Zero-based index of the target item.
+     */
     setCurrentItem: (currentItemIndex: number) => void;
+    /** Navigates to the previous item, wrapping from the first item to the last. */
     goToPrevItem: () => void;
+    /** Navigates to the next item, wrapping from the last item to the first. */
     goToNextItem: () => void;
 }
 
+/**
+ * Props for `FullscreenImageCarousel`.
+ */
 export interface FullscreenImageCarouselProps
     extends Pick<
         ModalProps,
         "show" | "rootComponentId" | "animationFrom" | "zIndex"
     > {
+    /** The list of items to display. Each item is either an image or a custom content item. */
     items: FullscreenImageCarouselItemProps[];
-    /** The index of the visible item, starts from 0 */
+    /**
+     * Zero-based index of the item that is active when the carousel first opens.
+     *
+     * @default 0
+     */
     initialActiveItemIndex?: number | undefined;
+    /**
+     * Hides the thumbnail strip below the main slide.
+     *
+     * @default false
+     */
     hideThumbnail?: boolean | undefined;
+    /**
+     * Hides the previous and next arrow navigation buttons.
+     *
+     * @default false
+     */
     hideNavigation?: boolean | undefined;
+    /**
+     * Hides the slide position counter chip (e.g. "2/5").
+     *
+     * @default false
+     */
     hideCounter?: boolean | undefined;
+    /**
+     * Hides the zoom in/out magnifier button. Has no effect on custom items, which
+     * never show the magnifier regardless of this prop.
+     *
+     * @default false
+     */
     hideMagnifier?: boolean | undefined;
+    /**
+     * Called when the delete button is activated for the current item.
+     *
+     * @param item The item that was deleted.
+     * @param index Zero-based index of the deleted item in the `items` array.
+     */
     onDelete?:
         | ((item: FullscreenImageCarouselItemProps, index: number) => void)
         | undefined;
+    /** Called when the close button is activated or the Escape key is pressed. */
     onClose?: (() => void) | undefined;
+    /**
+     * Additional pixel insets applied to keep content within a safe area
+     * of the viewport and avoid overlap with device UI elements.
+     */
     insets?: Insets | undefined;
 }
 
 interface FullscreenImageCarouselBaseItemProps {
+    /**
+     * Display name of the file shown in the top info bar.
+     */
     fileName?: string | undefined;
+    /**
+     * Human-readable file size shown alongside `fileName` in the top
+     * info bar (e.g. "2.4 MB").
+     */
     fileSize?: string | undefined;
 }
 
+/**
+ * A standard image item rendered inside the carousel slide.
+ */
 export interface FullscreenImageCarouselImageItemProps
     extends FullscreenImageCarouselBaseItemProps {
     type?: "image" | undefined;
+    /** URL of the full-resolution image shown in the slide. */
     src: string;
+    /** Accessible label for the image. */
     alt?: string | undefined;
+    /**
+     * URL of the image shown in the thumbnail strip.
+     * Falls back to `src` when omitted.
+     */
     thumbnailSrc?: string | undefined;
     renderContent?: never;
 }
@@ -44,21 +111,42 @@ export interface FullscreenImageCarouselImageItemProps
 /** @deprecated Use FullscreenImageCarouselImageItemProps instead */
 export type FullscreenCarouselItemProps = FullscreenImageCarouselImageItemProps;
 
+/**
+ * A custom-content item for the carousel slide.
+ *
+ * Use when the slide content is not a plain image — for example an iframe,
+ * PDF embed, or any arbitrary React element. The zoom magnifier is not shown
+ * for custom items regardless of the `hideMagnifier` prop.
+ */
 export interface FullscreenImageCarouselCustomItemProps
     extends FullscreenImageCarouselBaseItemProps {
     type: "custom";
     /** The thumbnail image src. If omitted, a placeholder is shown in the thumbnail strip. */
     thumbnailSrc?: string | undefined;
-    /** Label for this item used in aria-labels (e.g. "PDF"). Defaults to "image". When any item sets this, carousel-level aria-labels use generic "item" wording. */
+    /**
+     * Label for this item used in aria-labels (e.g. "PDF").
+     *
+     * @default "image"
+     */
     itemLabel?: string | undefined;
-    /** Render prop for the full slide area. Consumer is responsible for the entire slide content (e.g. an iframe, embed, or custom viewer). */
+    /**
+     * Render prop for the full slide area. Consumer is responsible
+     * for the entire slide content (e.g. an iframe, embed, or custom viewer).
+     */
     renderContent: () => React.ReactNode;
 }
 
+/**
+ * A single item in the carousel.
+ *
+ * `type` discriminates between a standard image item (`"image"`)
+ * and a custom-content item (`"custom"`).
+ */
 export type FullscreenImageCarouselItemProps =
     | FullscreenImageCarouselImageItemProps
     | FullscreenImageCarouselCustomItemProps;
 
+/** Natural pixel dimensions of a carousel image, used for zoom calculations. */
 export interface ImageDimension {
     width: number;
     height: number;

--- a/src/histogram-slider/histogram-slider.tsx
+++ b/src/histogram-slider/histogram-slider.tsx
@@ -12,6 +12,12 @@ import type { HistogramBinProps, HistogramSliderProps } from "./types";
 
 const ANNOUNCEMENT_DEBOUNCE_MS = 500;
 
+/**
+ * A histogram with an overlaid two-thumb range slider for numeric filtering.
+ *
+ * Use `HistogramSlider` to let users narrow a dataset by selecting a numeric
+ * range while seeing how values are distributed across bins.
+ */
 export const HistogramSlider = ({
     bins = [],
     interval,

--- a/src/histogram-slider/types.ts
+++ b/src/histogram-slider/types.ts
@@ -1,28 +1,80 @@
+/**
+ * A single bin (bar) in the histogram, representing a value range and its
+ * item count.
+ *
+ * The upper bound of the bin's range is `minValue + interval`, where
+ * `interval` is provided separately via `HistogramSliderProps`.
+ */
 export interface HistogramBinProps {
+    /**
+     * Number of items that fall within this bin's value range.
+     */
     count: number;
+    /** Lower bound of this bin's value range. */
     minValue: number;
 }
 
+/** Props for `HistogramSlider`. */
 export interface HistogramSliderProps {
     className?: string | undefined;
     id?: string | undefined;
     "data-testid"?: string | undefined;
+    /**
+     * The set of bins to render as bars.
+     */
     bins: HistogramBinProps[];
+    /**
+     * Controls the slider's step increment and minimum selectable range.
+     */
     interval: number;
     disabled?: boolean | undefined;
     readOnly?: boolean | undefined;
-    /** The selected range, in the format `[start, end]` */
+    /**
+     * The selected range as `[start, end]`.
+     *
+     * When omitted, the selection is initialised to
+     * `[minValue, minValue + interval]` derived from the provided `bins`.
+     */
     value?: [number, number] | undefined;
+    /**
+     * When `true`, displays the current start and end values above the
+     * histogram.
+     */
     showRangeLabels?: boolean | undefined;
+    /**
+     * Text prepended to each range label value.
+     * Has no effect when `renderRangeLabel` is provided.
+     */
     rangeLabelPrefix?: string | undefined;
+    /**
+     * Text appended to each range label value.
+     * Has no effect when `renderRangeLabel` is provided.
+     */
     rangeLabelSuffix?: string | undefined;
+    /**
+     * Accessible labels for the two slider thumbs, as `[startLabel, endLabel]`.
+     */
     ariaLabels?: [string, string] | undefined;
+    /**
+     * ID of an element that labels the slider group.
+     */
     "aria-labelledby"?: string | undefined;
+    /**
+     * ID of an element that describes the slider group.
+     */
     "aria-describedby"?: string | undefined;
+    /**
+     * Custom renderer for each range label value. When provided, overrides the
+     * `rangeLabelPrefix` and `rangeLabelSuffix` combination.
+     */
     renderRangeLabel?: ((value: number) => React.ReactNode) | undefined;
     /** Called on every selection change. Returns the value in the format `[start, end]` */
     onChange?: ((value: [number, number]) => void) | undefined;
     /** Called when a thumb is released after selection is complete. Returns the value in the format `[start, end]` */
     onChangeEnd?: ((value: [number, number]) => void) | undefined;
+    /**
+     * Rendered in place of the histogram and slider when all bins have a count
+     * of zero.
+     */
     renderEmptyView?: (() => React.ReactNode) | undefined;
 }

--- a/src/image-button/image-button.tsx
+++ b/src/image-button/image-button.tsx
@@ -46,4 +46,10 @@ const Component = (
     );
 };
 
+/**
+ * A button that displays an image alongside optional label content.
+ *
+ * Use `ImageButton` for selectable image-based choices such as theme pickers or avatar
+ * selectors, where each option is represented visually.
+ */
 export const ImageButton = React.forwardRef(Component);

--- a/src/image-button/types.ts
+++ b/src/image-button/types.ts
@@ -1,9 +1,19 @@
+/**
+ * Props for `ImageButton`.
+ */
 export interface ImageButtonProps
     extends React.ButtonHTMLAttributes<HTMLButtonElement> {
     "data-testid"?: string | undefined;
-    /** The image source to be rendered */
+    /** URL of the image to display inside the button. */
     imgSrc: string;
+    /** Applies a selected visual style to indicate the button is the active choice. */
     selected?: boolean | undefined;
+    /** Applies an error visual style to indicate a validation or selection error. */
     error?: boolean | undefined;
+    /**
+     * Keeps the button reachable via keyboard focus when `disabled` is `true`.
+     *
+     * @default false
+     */
     focusableWhenDisabled?: boolean | undefined;
 }

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -177,4 +177,10 @@ const Component = (
     );
 };
 
+/**
+ * A single-line text input field.
+ *
+ * Use `Input` for free-form text entry. It supports controlled and uncontrolled
+ * usage.
+ */
 export const Input = React.forwardRef(Component);

--- a/src/input/types.ts
+++ b/src/input/types.ts
@@ -1,19 +1,54 @@
 import type React from "react";
 
+/**
+ * Visual style variant for the `Input` component.
+ */
 export type InputStyleType = "no-border" | "bordered";
 
+/**
+ * Props for the `Input` text field component.
+ */
 export interface InputProps
     extends React.InputHTMLAttributes<HTMLInputElement> {
-    /** Sets the number of characters before a space is added (works only with type `tel` input) */
+    /**
+     * Inserts a space after every `spacing` characters in the displayed value.
+     * Only applies when `type` is `"tel"`.
+     */
     spacing?: number | undefined;
+    /**
+     * Marks the input wrapper in an error state.
+     */
     error?: boolean | undefined;
+    /**
+     * Shows a clear button when the field has a value and is neither disabled
+     * nor read-only.
+     *
+     * @default false
+     */
     allowClear?: boolean | undefined;
+    /**
+     * Called when the user activates the clear button. Use this to clear the
+     * controlled value.
+     */
     onClear?: () => void | undefined;
     "data-testid"?: string | undefined;
+    /**
+     * Visual style variant.
+     * - `"bordered"` wraps the input in a styled border container
+     * - `"no-border"` omits the border wrapper.
+     *
+     * @default "bordered"
+     */
     styleType?: InputStyleType | undefined;
 }
 
-/** To be exposed for Form component inheritance */
+/**
+ * A subset of `InputProps` for use by form components that manage the `error`
+ * state themselves.
+ */
 export type InputPartialProps = Omit<InputProps, "error">;
 
+/**
+ * Ref type for programmatic access to the underlying `HTMLInputElement`.
+ */
 export type InputRef = React.Ref<HTMLInputElement>;


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)
-   [X] Documentation (change to documentation, comments or API descriptions)
-   [ ] Tests (improvements to unit tests or E2E tests)
-   [ ] Other (technical improvements, refactoring, or changes that don't fall into the above categories)

**Description of changes**
[Annotate components and interfaces with JSDocs](urlhttps://sgtechstack.atlassian.net/browse/CCUBE-2182)
- Added JSDocs to these components
  - form
  - fullscreen-image-carousel
  - histogram-slider
  - image-button
  - input
- Updated JSDoc Convention on the `@default` tag usage 

**Checklist**

<!-- Put an `x` in items that apply -->

-   [X] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [ ] Looks good on mobile and tablet
-   [X] Updated documentation
-   [ ] Added/updated unit tests
-   [ ] Added/updated E2E tests

~**Screenshots**~

<!-- Include a screenshot or video recording of visual changes -->
