### PR TITLE
[CCUBE-2182][GZ] component jsdocs batch 8

### DIFF
--- a/src/input-range-slider/input-range-slider.tsx
+++ b/src/input-range-slider/input-range-slider.tsx
@@ -12,6 +12,13 @@ import * as styles from "./input-range-slider.styles";
 import { Thumb, Track } from "./slider-components";
 import type { InputRangeSliderProps } from "./types";
 
+/**
+ * A draggable track slider for selecting one or more numeric values within a
+ * bounded range.
+ *
+ * Use `InputRangeSlider` when the selection does not need to be precise;
+ * the user picks a value or a range by dragging thumb controls along a track.
+ */
 export const InputRangeSlider = ({
     id,
     value,

--- a/src/input-range-slider/types.ts
+++ b/src/input-range-slider/types.ts
@@ -1,37 +1,122 @@
+/**
+ * Shared configuration for `InputRangeSlider` covering track bounds,
+ * step interval, track colors, and label display.
+ */
 export interface BaseSliderProps {
     className?: string | undefined;
     id?: string | undefined;
     "data-testid"?: string | undefined;
+    /**
+     * The lower bound of the slider range.
+     *
+     * @default 0
+     */
     min?: number | undefined;
+    /**
+     * The upper bound of the slider range.
+     *
+     * @default 100
+     */
     max?: number | undefined;
-    /** The interval between the prev and next value */
+    /**
+     * The interval between selectable values.
+     *
+     * @default 1
+     */
     step?: number | undefined;
     disabled?: boolean | undefined;
     readOnly?: boolean | undefined;
-    /** Customise the color of each track segment. Expected length is (number of values + 1) */
+    /**
+     * Colours applied to each track segment in order. The array length should
+     * equal to `numOfThumbs + 1`.
+     */
     colors?: (string | undefined)[] | undefined;
+    /**
+     * Renders label text at the minimum and maximum ends of the track.
+     */
     showSliderLabels?: boolean | undefined;
+    /**
+     * Text prepended to each slider label value. Ignored when
+     * `renderSliderLabel` is provided.
+     */
     sliderLabelPrefix?: string | undefined;
+    /**
+     * Text appended to each slider label value. Ignored when
+     * `renderSliderLabel` is provided.
+     */
     sliderLabelSuffix?: string | undefined;
+    /**
+     * Renders a label above the slider showing the current selection.
+     */
     showIndicatorLabel?: boolean | undefined;
+    /**
+     * Text prepended to the indicator label value.
+     */
     indicatorLabelPrefix?: string | undefined;
+    /**
+     * Text appended to the indicator label value.
+     */
     indicatorLabelSuffix?: string | undefined;
+    /**
+     * Custom renderer for the slider labels shown at the min and max track
+     * ends. Takes precedence over `sliderLabelPrefix` and `sliderLabelSuffix`.
+     */
     renderSliderLabel?: ((value: number) => React.ReactNode) | undefined;
 }
 
+/**
+ * Props for `InputRangeSlider` component.
+ */
 export interface InputRangeSliderProps extends BaseSliderProps {
+    /**
+     * Controlled values for each thumb, indexed by position. Must have the
+     * same length as `numOfThumbs`; when the lengths differ or `value` is
+     * omitted, each thumb defaults to `min + step * index`.
+     */
     value?: number[] | undefined;
-    /** The number of thumb controls */
+    /**
+     * The number of thumb controls rendered on the track.
+     *
+     * @default 2
+     */
     numOfThumbs?: number | undefined;
-    /** The minimum difference between values */
+    /**
+     * The minimum allowed difference between adjacent thumb values.
+     *
+     * @default 0
+     */
     minRange?: number | undefined;
+    /**
+     * Accessible labels for each thumb.
+     */
     ariaLabels?: string[] | undefined;
+    /**
+     * Accessible description text for each thumb.
+     */
     ariaDescriptions?: string[] | undefined;
+    /**
+     * Marks each thumb's native range input as invalid for assistive
+     * technologies.
+     */
     "aria-invalid"?: boolean | undefined;
+    /**
+     * ID(s) of an element(s) that labels the slider group.
+     */
     "aria-labelledby"?: string | undefined;
+    /**
+     * ID(s) of an element(s) that provides additional information of the slider group.
+     */
     "aria-describedby"?: string | undefined;
-    /** Called on every selection change */
+    /**
+     * Called on every selection change.
+     *
+     * @param value The updated array of thumb values, in thumb order.
+     */
     onChange?: ((value: number[]) => void) | undefined;
-    /** Called when a thumb is released after selection is complete */
+    /**
+     * Called when a thumb is released after selection is complete.
+     *
+     * @param value The final array of thumb values, in thumb order.
+     */
     onChangeEnd?: ((value: number[]) => void) | undefined;
 }

--- a/src/input-select/input-select.tsx
+++ b/src/input-select/input-select.tsx
@@ -18,6 +18,11 @@ import { useId } from "../util";
 import { StringHelper } from "../util/string-helper";
 import type { InputSelectProps } from "./types";
 
+/**
+ * A single-selection dropdown input.
+ *
+ * Use `InputSelect` when the user must pick exactly one item from a list.
+ */
 export const InputSelect = <T, V>({
     selectedOption,
     placeholder = "Select",

--- a/src/input-select/types.ts
+++ b/src/input-select/types.ts
@@ -13,28 +13,46 @@ import type { DropdownAlignmentType } from "../shared/dropdown-wrapper";
 // =============================================================================
 // SHARED PROPS
 // =============================================================================
+/**
+ * Options configuration for `InputSelect`.
+ */
 export interface InputSelectOptionsProps<T> {
+    /** The list of selectable options rendered in the dropdown. */
     options: T[];
     /**
-     * Used when options are loaded from an api call.
-     * Values: "loading" | "fail" | "success"
+     * Indicates the load state of options fetched asynchronously.
+     * Renders a loading spinner, error retry, or the list depending on the state.
+     *
+     * @default "success"
      */
     optionsLoadState?: ItemsLoadStateType | undefined;
-    /** Specifies the truncation type. Truncated text will be replaced with ellipsis. Values: "middle" | "end" */
+    /**
+     * Controls how long option labels are truncated when they overflow.
+     * - `"middle"` trims the centre of the text
+     * - `"end"` trims from the right.
+     *
+     * @default "end"
+     */
     optionTruncationType?: TruncateType | undefined;
 
+    /** Called when the dropdown list becomes visible. */
     onShowOptions?: (() => void) | undefined;
+    /** Called when the dropdown list is hidden. */
     onHideOptions?: (() => void) | undefined;
+    /** Called when the user activates the retry action after a load failure. */
     onRetry?: (() => void) | undefined;
 }
 
+/** Common presentation and state props shared across select components. */
 export interface InputSelectSharedProps<T> {
-    /** HTML button props */
+    /** Name attribute forwarded to the underlying button element. */
     name?: string | undefined;
-    /** Component specific props */
+    /** The list of selectable options. */
     options: T[];
+    /** Placeholder text shown when no option is selected. */
     placeholder?: string | undefined;
     disabled?: boolean | undefined;
+    /** Renders the trigger in an error state. */
     error?: boolean | undefined;
     "data-testid"?: string | undefined;
 }
@@ -42,6 +60,12 @@ export interface InputSelectSharedProps<T> {
 // =============================================================================
 // INPUT SELECT PROPS
 // =============================================================================
+/**
+ * Props for `InputSelect`, a single-selection dropdown input.
+ *
+ * `T` is the option item type; `V` is the extracted value type returned by
+ * `valueExtractor`.
+ */
 export interface InputSelectProps<T, V>
     extends React.HTMLAttributes<HTMLElement>,
         InputSelectOptionsProps<T>,
@@ -50,34 +74,72 @@ export interface InputSelectProps<T, V>
         DropdownSearchProps<T> {
     // TODO: should be a common state once all variants implement this
     readOnly?: boolean | undefined;
+    /** The currently selected option. The component syncs to this value on each render. */
     selectedOption?: T | undefined;
+    /**
+     * Called when the user picks an item from the dropdown.
+     *
+     * @param option The full option object that was selected.
+     * @param extractedValue The value derived from the option via `valueExtractor`.
+     */
     onSelectOption?: ((option: T, extractedValue: V) => void) | undefined;
-    /** Function to derive display value for selected option */
+    /**
+     * Derives the display string shown in the trigger for the selected option.
+     * Takes precedence over `valueExtractor` + `valueToStringFunction`.
+     */
     displayValueExtractor?: ((option: T) => string) | undefined;
-    /** Function to convert value into a string */
+    /** Function to convert selected value into a display string */
     valueToStringFunction?: ((value: V) => string) | undefined;
-    /** Function to render selected custom component */
+    /**
+     * Renders a custom element for the currently selected option.
+     */
     renderCustomSelectedOption?: ((option: T) => JSX.Element) | undefined;
+    /**
+     * Called when focus leaves both the trigger and dropdown.
+     */
     onBlur?: (() => void) | undefined;
+    /**
+     * Visual size variant of the trigger and dropdown.
+     *
+     * @default "default"
+     */
     variant?: DropdownVariantType | undefined;
+    /**
+     * Aligns the dropdown relative to the trigger element.
+     * - `"left"` — dropdown left-aligns with the trigger
+     * - `"right"` — dropdown right-aligns with the trigger
+     */
     alignment?: DropdownAlignmentType | undefined;
+    /** CSS `z-index` applied to the dropdown overlay. */
     dropdownZIndex?: number | undefined;
     /**
-     * The root element that contains the dropdown element. Defaults to the document body.
+     * The root element that contains the dropdown element.
      *
-     * If the parent that contains the trigger element has a higher z-index than the dropdown,
-     * the dropdown may not be visible. Specify the parent element here instead
+     * @remarks Specify this if you need to change the parent of the
+     * dropdown in the HTML DOM.
+     * Possible use case: sharing a stacking context.
+     *
+     * Note: if a parent of the trigger has a higher `z-index` than the dropdown,
+     * the dropdown may be obscured.
+     *
+     * @default `document.body`
      */
     dropdownRootNode?: RefObject<HTMLElement> | undefined;
     /**
-     * Custom width for the dropdown. When specified, the dropdown will use this
-     * width instead of matching the input element width.
+     * Custom width for the dropdown. When specified, the dropdown uses this
+     * width instead of matching the trigger element width.
      */
     dropdownWidth?: string | undefined;
+    /**
+     * Overrides the default labels shown inside the dropdown and on the trigger.
+     */
     customLabels?: DropdownCustomLabelProps | undefined;
 }
 
-/** To be exposed for Form component inheritance */
+/**
+ * A subset of `InputSelectProps` used by form components that manage
+ * the `error` state themselves.
+ */
 export type InputSelectPartialProps<T, V> = Omit<
     InputSelectProps<T, V>,
     "error"

--- a/src/input-slider/input-slider.tsx
+++ b/src/input-slider/input-slider.tsx
@@ -3,6 +3,12 @@ import { useEffect, useState } from "react";
 import { InputRangeSlider } from "../input-range-slider";
 import type { InputSliderProps } from "./types";
 
+/**
+ * A single-thumb slider for selecting one numeric value within a range.
+ *
+ * Use `InputSlider` when a user needs to pick a single point on a continuous
+ * scale without a precise value. For selecting a range between two values, use `InputRangeSlider` instead.
+ */
 export const InputSlider = ({
     value,
     ariaLabel,

--- a/src/input-slider/types.ts
+++ b/src/input-slider/types.ts
@@ -1,10 +1,29 @@
 import type { BaseSliderProps } from "../input-range-slider/types";
 
+/**
+ * Props for `InputSlider` component.
+ */
 export interface InputSliderProps extends BaseSliderProps {
+    /**
+     * The controlled value of the thumb.
+     *
+     * @default `0`
+     */
     value?: number | undefined;
+    /**
+     * Accessible label for the thumb.
+     */
     ariaLabel?: string | undefined;
-    /** Called on every selection change */
+    /**
+     * Called on every selection change.
+     *
+     * @param value The updated thumb value.
+     */
     onChange?: ((value: number) => void) | undefined;
-    /** Called when the thumb is released after selection is complete */
+    /**
+     * Called when a thumb is released after selection is complete.
+     *
+     * @param value The final thumb value.
+     */
     onChangeEnd?: ((value: number) => void) | undefined;
 }

--- a/src/input-textarea/textarea.tsx
+++ b/src/input-textarea/textarea.tsx
@@ -209,4 +209,7 @@ const TextareaComponent = (
     );
 };
 
+/**
+ * A multi-line text input with an optional character counter and prefix.
+ */
 export const Textarea = React.forwardRef(TextareaComponent);

--- a/src/input-textarea/types.ts
+++ b/src/input-textarea/types.ts
@@ -1,17 +1,40 @@
 import type React from "react";
 
+/**
+ * Props for the `Textarea` component.
+ */
 export interface TextareaProps
     extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+    /** Renders the input in an error state. */
     error?: boolean | undefined;
     "data-testid"?: string | undefined;
+    /**
+     * Transforms user input on every change event.
+     */
     transformValue?: ((value: string) => string) | undefined;
+    /**
+     * A read-only string permanently displayed at the start of the textarea.
+     */
     prefix?: string | undefined;
+    /**
+     * Replaces the built-in character counter displayed below the textarea.
+     * Called only when `maxLength` is provided.
+     *
+     * @param maxLength The maximum number of user-input characters allowed.
+     * @param currentValueLength The current length of the user's input.
+     */
     renderCustomCounter?:
         | ((maxLength: number, currentValueLength: number) => JSX.Element)
         | undefined;
 }
 
-/** To be exposed for Form component inheritance */
+/**
+ * A subset of `TextareaProps` used by form components that manage
+ * the `error` state themselves.
+ */
 export type TextareaPartialProps = Omit<TextareaProps, "error">;
 
+/**
+ * Ref type for programmatic access to the underlying `HTMLTextAreaElement`.
+ */
 export type TextareaRef = React.Ref<HTMLTextAreaElement>;

--- a/src/language-switcher/language-switcher.tsx
+++ b/src/language-switcher/language-switcher.tsx
@@ -5,6 +5,12 @@ import { DropdownVariant } from "./dropdown-variant";
 import { LinkContainerVariant } from "./link-container-variant";
 import type { LanguageSwitcherCode, LanguageSwitcherProps } from "./types";
 
+/**
+ * A locale-switching control that lets users change the active display language.
+ *
+ * Use `LanguageSwitcher` to surface supported languages as either
+ * a compact dropdown or a set of inline links.
+ */
 export const LanguageSwitcher = ({
     variant = "dropdown",
     selectedLanguage = "en",

--- a/src/language-switcher/types.ts
+++ b/src/language-switcher/types.ts
@@ -1,16 +1,33 @@
 import type React from "react";
 
-// =============================================================================
-// TYPE DEFINITIONS
-// =============================================================================
+/** Code identifying a supported display language. */
 export type LanguageSwitcherCode = "en" | "zh" | "ms" | "ta";
 
+/** Presentation mode for the language switcher control. */
 export type LanguageSwitcherVariant = "dropdown" | "link-container";
 
+/** Props for `LanguageSwitcher` component. */
 export interface LanguageSwitcherProps
     extends React.HTMLAttributes<HTMLDivElement> {
+    /**
+     * Presentation mode
+     * - `"dropdown"` renders a compact select control
+     * - `"link-container"` renders languages as inline links
+     *
+     * @default "dropdown"
+     */
     variant?: LanguageSwitcherVariant | undefined;
+    /**
+     * The currently active language code.
+     *
+     * @default "en"
+     */
     selectedLanguage?: LanguageSwitcherCode | undefined;
+    /**
+     * Called when the user selects a language different from `selectedLanguage`.
+     *
+     * @param language The newly selected language code.
+     */
     onSelectLanguage?: ((language: LanguageSwitcherCode) => void) | undefined;
     "data-testid"?: string | undefined;
 }


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)
-   [X] Documentation (change to documentation, comments or API descriptions)
-   [ ] Tests (improvements to unit tests or E2E tests)
-   [ ] Other (technical improvements, refactoring, or changes that don't fall into the above categories)

**Description of changes**
[Annotate components and interfaces with JSDocs](urlhttps://sgtechstack.atlassian.net/browse/CCUBE-2182)
- Added JSDocs to these components
  - input-range-slider
  - input-select
  - input-slider
  - input-textarea
  - language-switcher

**Checklist**

<!-- Put an `x` in items that apply -->

-   [X] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [ ] Looks good on mobile and tablet
-   [X] Updated documentation
-   [ ] Added/updated unit tests
-   [ ] Added/updated E2E tests

~**Screenshots**~

<!-- Include a screenshot or video recording of visual changes -->
