### PR TITLE
[G2CA-136][AN] Change time picker and time range picker disabled valu…

### DIFF
--- a/src/time-range-picker/combobox-picker/combobox-picker.tsx
+++ b/src/time-range-picker/combobox-picker/combobox-picker.tsx
@@ -420,7 +420,7 @@ export const ComboboxPicker = ({
                     }
                     onChange={(e) => setStartTimeVal(e.target.value)}
                     value={startTimeVal}
-                    readOnly={readOnly}
+                    readOnly={readOnly || disabled}
                     data-testid={
                         otherProps["data-testid"]
                             ? `${otherProps["data-testid"]}-timepicker-selector-start`
@@ -441,6 +441,7 @@ export const ComboboxPicker = ({
                     aria-invalid={error || ariaInvalid || !!validationError}
                     aria-disabled={disabled}
                     aria-readonly={readOnly}
+                    $disabled={disabled}
                 />
                 {/* To */}
                 <SelectorInput
@@ -449,7 +450,7 @@ export const ComboboxPicker = ({
                     placeholder={activeTimeSelector === "end" ? "hh:mm" : "To"}
                     onChange={(e) => setEndTimeVal(e.target.value)}
                     value={endTimeVal}
-                    readOnly={readOnly}
+                    readOnly={readOnly || disabled}
                     data-testid={
                         otherProps["data-testid"]
                             ? `${otherProps["data-testid"]}-timepicker-selector-end`
@@ -470,6 +471,7 @@ export const ComboboxPicker = ({
                     }
                     aria-disabled={disabled || undefined}
                     aria-readonly={readOnly || undefined}
+                    $disabled={disabled}
                 />
             </RangeInputInnerContainer>
             {renderClearButton()}

--- a/src/time-range-picker/common.styles.tsx
+++ b/src/time-range-picker/common.styles.tsx
@@ -1,9 +1,9 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import {
     BasicInput,
     InputWrapper,
 } from "../shared/input-wrapper/input-wrapper";
-import { Spacing } from "../theme";
+import { Colour, Spacing } from "../theme";
 
 // =============================================================================
 // STYLING
@@ -17,8 +17,16 @@ export const TimeContainer = styled(InputWrapper)`
     gap: ${Spacing["spacing-8"]};
 `;
 
-export const SelectorInput = styled(BasicInput)`
+export const SelectorInput = styled(BasicInput)<{
+    $disabled?: boolean | undefined;
+}>`
     display: block;
     width: 100%;
     flex: 1;
+    ${(props) =>
+        props.$disabled &&
+        css`
+            color: ${Colour["text-subtler"]};
+            cursor: not-allowed;
+        `}
 `;

--- a/src/time-range-picker/dial-picker/dial-picker.tsx
+++ b/src/time-range-picker/dial-picker/dial-picker.tsx
@@ -179,6 +179,7 @@ export const DialPicker = ({
                     aria-readonly={readOnly}
                     aria-labelledby={getInputLabelledBy("start")}
                     aria-describedby={getInputDescribedBy()}
+                    $disabled={disabled}
                 />
                 <SelectorInput
                     onClick={() => handleOpen("end")}
@@ -197,6 +198,7 @@ export const DialPicker = ({
                     aria-readonly={readOnly || undefined}
                     aria-labelledby={getInputLabelledBy("end")}
                     aria-describedby={getInputDescribedBy()}
+                    $disabled={disabled}
                 />
             </RangeInputInnerContainer>
         </TimeContainer>

--- a/src/timepicker/timepicker.styles.tsx
+++ b/src/timepicker/timepicker.styles.tsx
@@ -1,5 +1,6 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { BasicInput } from "../shared/input-wrapper/input-wrapper";
+import { Colour } from "../theme";
 
 // =============================================================================
 // STYLING
@@ -13,4 +14,10 @@ export const InputSelectorElement = styled(BasicInput)<{
 }>`
     height: calc(3rem - 2px); // exclude top and bottom borders
     cursor: inherit;
+    ${(props) =>
+        props.$disabled &&
+        css`
+            color: ${Colour["text-subtler"]};
+            cursor: not-allowed;
+        `}
 `;

--- a/tests/time-range-picker/time-range-picker.spec.tsx
+++ b/tests/time-range-picker/time-range-picker.spec.tsx
@@ -722,6 +722,8 @@ describe("TimeRangePicker", () => {
                 expect(end).toHaveAttribute("aria-disabled", "true");
                 expect(start).not.toHaveAttribute("disabled");
                 expect(end).not.toHaveAttribute("disabled");
+                expect(start).toHaveAttribute("readonly");
+                expect(end).toHaveAttribute("readonly");
 
                 await user.click(start);
                 expect(


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)
-   [ ] Documentation (change to documentation, comments or API descriptions)
-   [ ] Tests (improvements to unit tests or E2E tests)
-   [ ] Other (technical improvements, refactoring, or changes that don't fall into the above categories)

**Description of changes**

-   Link to [ticket](https://sgtechstack.atlassian.net/browse/G2CA-136)
-   Link to [Figma](https://www.figma.com/design/Rk9kGbW523VwV0vnyUtFiG/MOM-Events?node-id=4001-24120&t=j8lf5LAHypirpdBb-0)
-   Description of changes: Change the color of time picker and time range picker to "text-subtler" when the input is disabled to synchronize with color of disabled date picker input.

**Checklist**

<!-- Put an `x` in items that apply -->

-   [x] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [x] Looks good on mobile and tablet
-   [ ] Updated documentation
-   [ ] Added/updated unit tests
-   [ ] Added/updated E2E tests

**Screenshots**

<!-- Include a screenshot or video recording of visual changes -->
<img width="516" height="727" alt="image" src="https://github.com/user-attachments/assets/a315d4c6-f12e-4104-ac44-1879cc074253" />
<img width="875" height="727" alt="image" src="https://github.com/user-attachments/assets/ede5bd1a-2af5-4381-9f0f-cf5cbf8f4064" />
<img width="531" height="764" alt="image" src="https://github.com/user-attachments/assets/54f0fe0a-ec77-4d17-8451-d3ed40329b65" />
<img width="937" height="802" alt="image" src="https://github.com/user-attachments/assets/0bfa76e4-7a21-4de5-98ae-be7a07d793fd" />
