### PR TITLE
[CCUBE-2244][GZ] add jsdoc to theme

### DIFF
--- a/JSDOC_CONVENTIONS.md
+++ b/JSDOC_CONVENTIONS.md
@@ -2,7 +2,8 @@
 
 ## Purpose
 
-JSDoc should explain the public behavior of component APIs that TypeScript types alone cannot describe. We're using it for:
+JSDoc should explain the public behavior of component APIs that TypeScript types
+alone cannot describe. We're using it for:
 
 -   IntelliSense hover information
 -   Generated props documentation
@@ -99,7 +100,12 @@ export const Accordion = Object.assign(AccordionBase, {
 
 ## Type-level comments
 
-The first sentence should be understandable on its own, because it may be the only text shown in IntelliSense or generated documentation.
+The first sentence should be understandable on its own, because it may be the
+only text shown in IntelliSense or generated documentation.
+
+Write from the consumer's perspective. Describe what the type represents or
+what the consumer can do with it. Do not reference internal constant names,
+helper functions, or implementation details that are not part of the public API.
 
 ```tsx
 /**
@@ -155,7 +161,8 @@ and is not generally true for all usages of the underlying type.
 
 ## Prop-level comments
 
-Add prop-level JSDoc only when the prop has behavior, fallback rules, accessibility meaning, or relationships with other props.
+Add prop-level JSDoc only when the prop has behavior, fallback rules,
+accessibility meaning, or relationships with other props.
 
 ```tsx
 export interface NavbarProps<T = void> {

--- a/JSDOC_CONVENTIONS.md
+++ b/JSDOC_CONVENTIONS.md
@@ -271,12 +271,44 @@ Recommended:
 -   `@default` when the default is enforced by code
 -   `@deprecated` with a migration path
 -   `@remarks` for important caveats or relationships
+-   `@returns` on hooks and utility functions when the return value needs
+    explanation beyond what the TypeScript signature conveys (e.g. `undefined`
+    edge cases, fallback behaviour).
 
 Avoid:
 
 -   `@returns` on interface properties
--   Tags that only repeat the type
+-   Tags that only restate the type or name
 -   Long explanations of internal implementation details
+
+### Returns
+
+Use `@returns` on hooks and utility functions when the return value needs
+explanation beyond what the TypeScript signature conveys.
+
+Good use cases:
+
+-   `undefined` or `null` edge cases (e.g. "returns `undefined` until the
+    provider mounts")
+-   Fallback behaviour (e.g. "defaults to `"lifesg"` when outside a provider")
+-   Non-obvious return shape (e.g. describing object properties returned by a
+    hook)
+
+Do not use `@returns` on interface properties or when it would only restate the
+return type.
+
+```tsx
+/**
+ * Resolves a design-token CSS variable to its computed string value.
+ *
+ * @param tokenName A `CSSVariableString` token, or `undefined` to skip.
+ * @returns The computed CSS value, or `undefined` when the provider has not
+ * yet mounted or `tokenName` is `undefined`.
+ */
+export const useDesignToken = (
+    tokenName: CSSVariableString | undefined
+): string | undefined => { ... };
+```
 
 ### Defaults
 

--- a/src/theme/theme-provider/breakpoint.ts
+++ b/src/theme/theme-provider/breakpoint.ts
@@ -55,7 +55,7 @@ function getBreakpointRanges(sourceElement: HTMLElement) {
 
 const BREAKPOINT_CLASS_PREFIX = "fds-breakpoint-";
 
-export function applyBreakpointClasses(sourceElement: HTMLElement) {
+function applyBreakpointClasses(sourceElement: HTMLElement) {
     const body = document.body;
     const width = window.innerWidth;
 

--- a/src/theme/theme-provider/hooks.tsx
+++ b/src/theme/theme-provider/hooks.tsx
@@ -13,6 +13,12 @@ type InheritedThemeScope = {
     themeStyle: CSSProperties;
 };
 
+/**
+ * Returns the theme context from the nearest `ThemeProvider`.
+ *
+ * @returns The active `ThemeContextValue`. When called outside a provider,
+ * returns defaults: `theme: "lifesg"`, `mode: "light"`, `themeElement: null`.
+ */
 export const useTheme = (): ThemeContextValue => {
     const context = useContext(ThemeContext);
 
@@ -27,6 +33,16 @@ export const useTheme = (): ThemeContextValue => {
     return context;
 };
 
+/**
+ * Builds `data-fds-theme*` attributes and inline CSS variables for re-stamping
+ * the current theme onto a detached DOM element (e.g. a portal or floating
+ * overlay).
+ *
+ * @param enabled When `false`, returns empty objects — useful to conditionally
+ * skip the attribute injection.
+ * @returns `themeProps` (spread onto the root element) and `themeStyle` (inline
+ * CSS variables to apply).
+ */
 export const useInheritedThemeScope = (
     enabled: boolean
 ): InheritedThemeScope => {

--- a/src/theme/theme-provider/index.tsx
+++ b/src/theme/theme-provider/index.tsx
@@ -69,6 +69,13 @@ const InnerThemeProvider = (
     );
 };
 
+/**
+ * Establishes a themed scope for its subtree.
+ *
+ * Wrap a section of the tree in `ThemeProvider` to activate a design-token set
+ * and colour mode. Components below it read tokens via CSS variables or the
+ * `useTheme` hook. Providers can be nested to override a subtree's theme.
+ */
 export const ThemeProvider = forwardRef<HTMLDivElement, ThemeProviderProps>(
     InnerThemeProvider
 );

--- a/src/theme/theme-provider/types.ts
+++ b/src/theme/theme-provider/types.ts
@@ -2,8 +2,11 @@ import type { CSSProperties } from "react";
 
 import type { ResolvedThemeMode, ThemeMode, ThemeType } from "../types";
 
+/** Value exposed by the `ThemeProvider` context. */
 export interface ThemeContextValue {
+    /** Active theme token set name. */
     theme: ThemeType;
+    /** Resolved colour mode. */
     mode: ResolvedThemeMode;
     /**
      * Element that hosts the current theme scope. Useful for scoped theming.
@@ -11,10 +14,21 @@ export interface ThemeContextValue {
     themeElement: HTMLElement | null;
 }
 
+/** Props for the `ThemeProvider` component. */
 export interface ThemeProviderProps {
     children: React.ReactNode;
     className?: string | undefined;
+    /**
+     * Colour mode applied to the themed subtree.
+     *
+     * @default "auto"
+     */
     mode?: ThemeMode | undefined;
     style?: CSSProperties | undefined;
+    /**
+     * Design token set to activate.
+     *
+     * @default "lifesg"
+     */
     theme?: ThemeType | undefined;
 }

--- a/src/theme/tokens/border.ts
+++ b/src/theme/tokens/border.ts
@@ -1,3 +1,4 @@
+/** Border width tokens. */
 export const BorderThickness = {
     "width-005": "var(--fds-border-width-005)",
     "width-010": "var(--fds-border-width-010)",
@@ -5,10 +6,12 @@ export const BorderThickness = {
     "width-040": "var(--fds-border-width-040)",
 } as const;
 
+/** Border style tokens. */
 export const BorderStyle = {
     solid: "var(--fds-border-style-solid)",
 } as const;
 
+/** Border tokens consisting of border width and border style. */
 export const Border = {
     ...BorderThickness,
     ...BorderStyle,

--- a/src/theme/tokens/breakpoint.ts
+++ b/src/theme/tokens/breakpoint.ts
@@ -1,3 +1,6 @@
+/**
+ * Responsive breakpoint tokens for each named breakpoint.
+ */
 export const Breakpoint = {
     "xxs-min": "var(--fds-breakpoint-xxs-min)",
     "xxs-max": "var(--fds-breakpoint-xxs-max)",

--- a/src/theme/tokens/colour.ts
+++ b/src/theme/tokens/colour.ts
@@ -1,3 +1,4 @@
+/** Base colour palette */
 export const PrimitiveColours = {
     "brand-10": "var(--fds-colour-brand-10)",
     "brand-20": "var(--fds-colour-brand-20)",
@@ -100,6 +101,7 @@ export const PrimitiveColours = {
     "primary-inverse": "var(--fds-colour-primary-inverse)",
 } as const;
 
+/** Purpose-driven colour tokens. */
 export const SemanticColours = {
     text: "var(--fds-colour-text)",
     "text-subtle": "var(--fds-colour-text-subtle)",
@@ -240,6 +242,7 @@ export const SemanticColours = {
     "focus-ring-inverse": "var(--fds-colour-focus-ring-inverse)",
 } as const;
 
+/** Combined colour token set. */
 export const Colour = {
     Primitive: PrimitiveColours,
     ...SemanticColours,

--- a/src/theme/tokens/component.ts
+++ b/src/theme/tokens/component.ts
@@ -40,6 +40,7 @@ const Footer = {
         "var(--fds-footer-disclaimer-link-colour-text-hover)",
 } as const;
 
+/** Component-scoped design tokens grouped by component. */
 export const ComponentToken = {
     Animation,
     Button,

--- a/src/theme/tokens/font.ts
+++ b/src/theme/tokens/font.ts
@@ -1,5 +1,6 @@
 import { generateFont } from "../utils/font";
 
+/** Raw font CSS variable tokens. */
 export const FontSpec = {
     "font-family-heading": "var(--fds-font-family-heading)",
     "font-family-body": "var(--fds-font-family-body)",
@@ -55,6 +56,7 @@ export const FontSpec = {
     "form-description-ls": "var(--fds-font-form-description-ls)",
 } as const;
 
+/** Pre-composed font declaration strings for all size & weight combinations. */
 export const Font = {
     "heading-xxl-light": generateFont("heading-xxl", "light"),
     "heading-xxl-regular": generateFont("heading-xxl", "regular"),

--- a/src/theme/tokens/media-query.ts
+++ b/src/theme/tokens/media-query.ts
@@ -23,6 +23,7 @@ const getPseudoMediaQuerySpec = <T extends readonly string[]>(
     return spec;
 };
 
+/** CSS class-based pseudo media-query selectors keyed by breakpoint name. */
 export const MediaQuery = {
     MaxWidth: getPseudoMediaQuerySpec(MAX_WIDTH_BREAKPOINTS, "max"),
     MinWidth: getPseudoMediaQuerySpec(MIN_WIDTH_BREAKPOINTS, "min"),

--- a/src/theme/tokens/motion.ts
+++ b/src/theme/tokens/motion.ts
@@ -1,3 +1,4 @@
+/** Animation tokens consisting of durations and easing functions. */
 export const Motion = {
     "duration-150": "var(--fds-motion-duration-150)",
     "duration-250": "var(--fds-motion-duration-250)",

--- a/src/theme/tokens/radius.ts
+++ b/src/theme/tokens/radius.ts
@@ -1,3 +1,4 @@
+/** Border radius tokens. */
 export const Radius = {
     none: "var(--fds-radius-none)",
     xs: "var(--fds-radius-xs)",

--- a/src/theme/tokens/shadow.ts
+++ b/src/theme/tokens/shadow.ts
@@ -1,3 +1,4 @@
+/** Box-shadow tokens. */
 export const Shadow = {
     "xs-subtle": "var(--fds-shadow-xs-subtle)",
     "xs-strong": "var(--fds-shadow-xs-strong)",

--- a/src/theme/tokens/spacing.ts
+++ b/src/theme/tokens/spacing.ts
@@ -1,3 +1,4 @@
+/** Spacing tokens consisting of component spacing and layout spacing. */
 export const Spacing = {
     "spacing-0": "var(--fds-spacing-0)",
     "spacing-4": "var(--fds-spacing-4)",

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -12,6 +12,7 @@ import type {
     Spacing,
 } from "./tokens";
 
+/** All available theme names. */
 export const THEME_TYPES = [
     "a11y-playground",
     "bookingsg",
@@ -29,11 +30,20 @@ export const THEME_TYPES = [
     "supportgowhere",
 ] as const;
 
+/** Union of all supported theme names. */
 export type ThemeType = (typeof THEME_TYPES)[number];
+/**
+ * Colour mode accepted by `ThemeProvider`.
+ * — `"auto"` follows OS preference.
+ * - `"light"` light mode.
+ * - `"dark"` dark mode.
+ */
 export type ThemeMode = "light" | "dark" | "auto";
 
+/** Resolved colour mode. */
 export type ResolvedThemeMode = "light" | "dark";
 
+/** Available typography size presets. */
 export type FontSize =
     | "heading-xxl"
     | "heading-xl"
@@ -48,26 +58,39 @@ export type FontSize =
     | "form-label"
     | "form-description";
 
+/** Available typography weight presets. */
 export type FontWeight = "light" | "regular" | "semibold" | "bold";
 
+/** Accepted breakpoint CSS variable strings. */
 export type BreakpointCSSVariableString = ValueOf<typeof Breakpoint>;
+/** Accepted border CSS variable strings. */
 export type BorderCSSVariableString = ValueOf<typeof Border>;
+/** Accepted component-scoped CSS variable strings. */
 export type ComponentTokenCSSVariableString =
     | ValueOf<typeof ComponentToken.Animation>
     | ValueOf<typeof ComponentToken.Button>
     | ValueOf<typeof ComponentToken.Footer>
     | ValueOf<typeof ComponentToken.Navbar>;
+/** Accepted font CSS variable strings. */
 export type FontSpecCSSVariableString = ValueOf<typeof FontSpec>;
+/** Accepted motion CSS variable strings. */
 export type MotionCSSVariableString = ValueOf<typeof Motion>;
+/** Accepted primitive colour CSS variable strings. */
 export type PrimitiveColourCSSVariableString = ValueOf<typeof PrimitiveColours>;
+/** Accepted radius CSS variable strings. */
 export type RadiusCSSVariableString = ValueOf<typeof Radius>;
+/** Accepted semantic colour CSS variable strings. */
 export type SemanticColourCSSVariableString = ValueOf<typeof SemanticColours>;
+/** Accepted colour CSS variable strings. */
 export type ColourCSSVariableString =
     | PrimitiveColourCSSVariableString
     | SemanticColourCSSVariableString;
+/** Accepted shadow CSS variable strings. */
 export type ShadowCSSVariableString = ValueOf<typeof Shadow>;
+/** Accepted spacing and layout CSS variable strings. */
 export type SpacingCSSVariableString = ValueOf<typeof Spacing>;
 
+/** Union of all design-token CSS variable string literals. */
 export type CSSVariableString =
     | BreakpointCSSVariableString
     | BorderCSSVariableString
@@ -78,7 +101,3 @@ export type CSSVariableString =
     | RadiusCSSVariableString
     | ShadowCSSVariableString
     | SpacingCSSVariableString;
-
-type ExtractCleanCSSVariableName<T extends string> =
-    T extends `var(${infer Name})` ? Name : never;
-export type CSSVariableKey = ExtractCleanCSSVariableName<CSSVariableString>;

--- a/src/theme/utils/css-variable.ts
+++ b/src/theme/utils/css-variable.ts
@@ -9,7 +9,10 @@ const CSS_PX_OR_REM_CAPTURE_PATTERN = /^(-?\d*\.?\d+)(px|rem)$/i;
 
 /**
  * Extracts an fds CSS variable name from raw token input.
- * Supports values like "var(--fds-breakpoint-sm-max)" and "--fds-breakpoint-sm-max".
+ * Supports values like `"var(--fds-breakpoint-sm-max)"` and `"--fds-breakpoint-sm-max"`.
+ *
+ * @returns The extracted `--fds-*` variable name, or `undefined` if the input
+ * does not contain a valid fds token.
  */
 export const extractFdsCssVariableName = (
     value: string | undefined
@@ -103,6 +106,9 @@ const mergeInlineCssVariables = (
 
 /**
  * Extracts inline token CSS custom properties from the theme element.
+ *
+ * @returns An object of `--fds-*` properties, or `{}` when the element is
+ * `null` or has no inline styles.
  */
 export const getInheritedInlineCssVariables = (
     themeElement: HTMLElement | null
@@ -116,7 +122,9 @@ export const getInheritedInlineCssVariables = (
 };
 
 /**
- * Convert a numeric value to a CSS unit string (e.g., 12 → "12px"). Returns null for non-numeric values.
+ * Convert a numeric value to a CSS unit string (e.g., `12` → `"12px"`).
+ *
+ * @returns The formatted string, or `null` for non-numeric values.
  */
 export const formatUnitValue = (
     value: unknown,

--- a/src/theme/utils/font.ts
+++ b/src/theme/utils/font.ts
@@ -1,6 +1,6 @@
 import type { FontSize, FontWeight } from "../types";
 
-export interface FontDeclarationProperties {
+interface FontDeclarationProperties {
     "font-family": string;
     "font-variant": string;
     "font-size": string;

--- a/src/theme/utils/use-apply-styles.ts
+++ b/src/theme/utils/use-apply-styles.ts
@@ -1,9 +1,13 @@
 import type { CSSProperties, RefObject } from "react";
 
 import { useIsomorphicLayoutEffect } from "../../util";
-import type { CSSVariableKey } from "../types";
+import type { CSSVariableString } from "../types";
 
 type StyleValue = string | number | null | undefined;
+
+type ExtractCleanCSSVariableName<T extends string> =
+    T extends `var(${infer Name})` ? Name : never;
+type CSSVariableKey = ExtractCleanCSSVariableName<CSSVariableString>;
 
 /**
  * Style map accepted by `useApplyStyle`. Supports camelCase CSS properties,

--- a/src/theme/utils/use-apply-styles.ts
+++ b/src/theme/utils/use-apply-styles.ts
@@ -5,6 +5,10 @@ import type { CSSVariableKey } from "../types";
 
 type StyleValue = string | number | null | undefined;
 
+/**
+ * Style map accepted by `useApplyStyle`. Supports camelCase CSS properties,
+ * theme CSS variable keys, and arbitrary `--custom-property` names.
+ */
 export type ApplyStyleMap =
     | ({
           [K in keyof CSSStyleDeclaration]?: StyleValue;
@@ -15,8 +19,11 @@ export type ApplyStyleMap =
       })
     | CSSProperties;
 
-/** list of properties that expect units but can be provided as numbers through React style prop */
-const numericCssStyleProperties: (keyof CSSStyleDeclaration)[] = [
+/**
+ * List of properties that expect units but can be provided as
+ * numbers through React style prop
+ */
+const numericCssStyleProperties: Set<keyof CSSStyleDeclaration> = new Set([
     "width",
     "height",
     "top",
@@ -33,7 +40,7 @@ const numericCssStyleProperties: (keyof CSSStyleDeclaration)[] = [
     "paddingLeft",
     "paddingRight",
     "paddingBottom",
-];
+]);
 
 /**
  * Normalises standard CSS property names from camelCase to kebab-case
@@ -59,7 +66,7 @@ function normaliseCssProperty(key: string): string {
 function normaliseCssValue(key: string, value: string | number): string {
     if (
         typeof value === "number" &&
-        numericCssStyleProperties.includes(key as keyof CSSStyleDeclaration)
+        numericCssStyleProperties.has(key as keyof CSSStyleDeclaration)
     ) {
         return `${value}px`;
     }
@@ -69,7 +76,7 @@ function normaliseCssValue(key: string, value: string | number): string {
 
 /**
  * Hook to apply styles to a HTML DOM element. Use when you need to apply inline
- * styles but cannot use the inline React `style` prop due to strict CSP rules
+ * styles but cannot use the inline React `style` prop due to strict CSP rules.
  *
  * @param ref The HTML element to receive the styles
  * @param styles The styles to apply, in the same format as the React `style`

--- a/src/theme/utils/use-design-token-override.ts
+++ b/src/theme/utils/use-design-token-override.ts
@@ -11,7 +11,15 @@ interface UseDesignTokenOverrideOptions {
 
 /**
  * Resolves a design token's value in a specific theme mode,
- * defaulting to light mode regardless of the current theme mode.
+ * regardless of the current active mode.
+ *
+ * @param options.token The CSS variable token to resolve.
+ * @param options.mode The mode to resolve in.
+ *
+ * @returns The computed CSS value, or `undefined` when the theme element has
+ * not yet mounted.
+ *
+ * @default options.mode "light"
  */
 export const useDesignTokenOverride = ({
     token,

--- a/src/theme/utils/use-design-token.ts
+++ b/src/theme/utils/use-design-token.ts
@@ -8,6 +8,15 @@ const isEmptyValue = (value: unknown) => {
     return value == null || value === "";
 };
 
+/**
+ * Resolves a design-token CSS variable to its computed string value within the
+ * nearest `ThemeProvider` scope.
+ *
+ * @param tokenName A `CSSVariableString` token (e.g. `Colour["text"]`), or
+ * `undefined` to skip resolution.
+ * @returns The computed CSS value, or `undefined` when the provider has not yet
+ * mounted or `tokenName` is `undefined`.
+ */
 export const useDesignToken = (
     tokenName: CSSVariableString | undefined
 ): string | undefined => {

--- a/src/theme/utils/use-media-query.ts
+++ b/src/theme/utils/use-media-query.ts
@@ -4,8 +4,9 @@ import { Breakpoint } from "../tokens/breakpoint";
 import { isTokenFromSet } from "./token-resolver";
 import { useResolvedTokenValue } from "./use-design-token";
 
-export type BreakpointName = "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl";
-export type MaxWidthBreakpointName = Exclude<BreakpointName, "xxl">;
+/** Named width breakpoint identifier used for responsive width comparisons. */
+type BreakpointName = "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl";
+type MaxWidthBreakpointName = Exclude<BreakpointName, "xxl">;
 type MinWidthBreakpointTokenKey = `${BreakpointName}-min`;
 type MaxWidthBreakpointTokenKey = `${MaxWidthBreakpointName}-max`;
 type WidthBreakpointTokenKey =
@@ -34,16 +35,28 @@ type MediaQueryFeature =
     | "scan"
     | "width";
 
-export type MediaQueryClauseValue = string | number | boolean;
+type MediaQueryClauseValue = string | number | boolean;
 
+/** A single media-query feature condition. */
 export interface MediaQueryClause {
     feature: MediaQueryFeature;
+    /**
+     * Value for the media-query feature.
+     *
+     * - A string or number emits `(feature: value)`.
+     * - `true` emits a bare feature clause (e.g. `(hover)`).
+     * - `false` or `undefined` omits the clause entirely.
+     */
     value: MediaQueryClauseValue | undefined;
 }
 
+/** Options for `useMediaQuery`. */
 export interface MediaQueryOptions {
+    /** Lower-bound breakpoint token. Viewport must be >= this width. */
     minWidth?: WidthBreakpointCSSVariableString;
+    /** Upper-bound breakpoint token. Viewport must be <= this width. */
     maxWidth?: WidthBreakpointCSSVariableString;
+    /** Extra feature conditions (e.g. `hover`, `orientation`) combined with `and`. */
     clauses?: MediaQueryClause[];
 }
 
@@ -103,11 +116,21 @@ const getMaxWidthBreakpointToken = (breakpoint: MaxWidthBreakpointName) => {
     return Breakpoint[`${breakpoint}-max`];
 };
 
+/**
+ * Returns `true` when the viewport width is at or above the named breakpoint.
+ *
+ * @param breakpoint Named breakpoint to compare against.
+ */
 export const useMinWidthMediaQuery = (breakpoint: BreakpointName) =>
     useMediaQuery({
         minWidth: getMinWidthBreakpointToken(breakpoint),
     });
 
+/**
+ * Returns `true` when the viewport width is at or below the named breakpoint.
+ *
+ * @param breakpoint Named breakpoint to compare against.
+ */
 export const useMaxWidthMediaQuery = (breakpoint: MaxWidthBreakpointName) =>
     useMediaQuery({
         maxWidth: getMaxWidthBreakpointToken(breakpoint),
@@ -172,6 +195,13 @@ const getCurrentMatch = (queryString: string, defaultMatch: boolean) => {
     return globalThis.window.matchMedia(queryString).matches;
 };
 
+/**
+ * Resolves a width breakpoint CSS variable token to its computed pixel string.
+ *
+ * @returns The resolved pixel value, falling back to default LifeSG breakpoint
+ * values when the theme element is not yet mounted, or `""` for unrecognised
+ * tokens.
+ */
 export const useResolvedBreakpointToken = (
     breakpointToken: WidthBreakpointCSSVariableString | undefined
 ): string => {
@@ -219,6 +249,14 @@ const useMatchMediaQuery = (
     return matches;
 };
 
+/**
+ * Reactive boolean hook that evaluates a media query built from width
+ * breakpoint tokens and optional custom feature clauses.
+ *
+ * @returns `true` when the query matches. When `window.matchMedia` is
+ * unavailable (SSR), defaults to `true` for min-width-only queries and
+ * `false` for max-width-only.
+ */
 export const useMediaQuery = (options: MediaQueryOptions): boolean => {
     const { minWidth, maxWidth, clauses = [] } = options;
     const normalizedMinWidth = useResolvedBreakpointToken(minWidth);


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)
-   [X] Documentation (change to documentation, comments or API descriptions)
-   [ ] Tests (improvements to unit tests or E2E tests)
-   [ ] Other (technical improvements, refactoring, or changes that don't fall into the above categories)

**Description of changes**

[Annotate theme utilities and design tokens](https://sgtechstack.atlassian.net/browse/CCUBE-2244)
- Add JSDoc to the theme's provider, utils, and types.
- Removed `export` declaration to internal-use only types.
- Update the JSDoc convention to better reflect the desired result.

**Checklist**

<!-- Put an `x` in items that apply -->

-   [X] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [ ] Looks good on mobile and tablet
-   [X] Updated documentation
-   [ ] Added/updated unit tests
-   [ ] Added/updated E2E tests

**Screenshots**

<!-- Include a screenshot or video recording of visual changes -->
