### PR TITLE
[CCUBE-2241] Fix flash of "No results found" in PredictiveTextInput

### DIFF
--- a/src/predictive-text-input/predictive-text-input.tsx
+++ b/src/predictive-text-input/predictive-text-input.tsx
@@ -143,7 +143,6 @@ export const PredictiveTextInput = <T, V>({
         setInput(selectedOption ? getDisplayValue(selectedOption) : "");
         setSearchedInput(selectedOption ? getDisplayValue(selectedOption) : "");
         setPrevOptionSelected(selectedOption);
-        setOptions([]);
         setIsOptionSelected(!!selectedOption);
     }, [selectedOption]);
 
@@ -235,9 +234,15 @@ export const PredictiveTextInput = <T, V>({
         selectorRef.current?.focus();
     };
 
+    const handleHide = () => {
+        // reset dropdown state once it fully closes
+        setOptions([]);
+        setIsLoading(true);
+        setIsError(false);
+    };
+
     const handleOnClear = () => {
         setInput("");
-        setOptions([]);
         setIsOptionSelected(false);
         setIsOpen(false);
         onSelectOption?.(undefined, undefined);
@@ -263,7 +268,6 @@ export const PredictiveTextInput = <T, V>({
     const handleDropdownDismiss = (item?: T) => {
         setSearchedInput(item ? getDisplayValue(item) : "");
         setIsOptionSelected(!!item);
-        setOptions([]);
         setIsLoading(true);
     };
 
@@ -332,24 +336,22 @@ export const PredictiveTextInput = <T, V>({
 
     const renderDropdown = () => {
         return (
-            <>
-                <DropdownList
-                    listboxId={internalId}
-                    listItems={options}
-                    onSelectItem={handleListItemClick}
-                    onDismiss={handleListDismiss}
-                    valueExtractor={valueExtractor}
-                    listExtractor={listExtractor}
-                    itemsLoadState={getItemsLoadState()}
-                    itemTruncationType={"end"}
-                    itemMaxLines={1}
-                    labelDisplayType={"next-line"}
-                    disableItemFocus
-                    onRetry={() => handleFetchOptions(input)}
-                    width={dropdownWidth}
-                    matchElementWidth
-                />
-            </>
+            <DropdownList
+                listboxId={internalId}
+                listItems={options}
+                onSelectItem={handleListItemClick}
+                onDismiss={handleListDismiss}
+                valueExtractor={valueExtractor}
+                listExtractor={listExtractor}
+                itemsLoadState={getItemsLoadState()}
+                itemTruncationType={"end"}
+                itemMaxLines={1}
+                labelDisplayType={"next-line"}
+                disableItemFocus
+                onRetry={() => handleFetchOptions(input)}
+                width={dropdownWidth}
+                matchElementWidth
+            />
         );
     };
 
@@ -363,6 +365,7 @@ export const PredictiveTextInput = <T, V>({
                 onOpen={handleOpen}
                 onClose={handleClose}
                 onDismiss={handleDismiss}
+                onHide={handleHide}
                 clickToToggle={false}
                 offset={8}
                 alignment={alignment}

--- a/src/shared/dropdown-wrapper/element-with-dropdown.tsx
+++ b/src/shared/dropdown-wrapper/element-with-dropdown.tsx
@@ -19,11 +19,12 @@ import {
     useTransitionStyles,
 } from "@floating-ui/react";
 import type { CSSProperties, RefObject } from "react";
-import { createContext, useContext, useRef } from "react";
+import { createContext, useContext, useEffect, useRef } from "react";
 import { useResizeDetector } from "react-resize-detector";
 
 import { useFloatingChild } from "../../overlay/use-floating-context";
 import { useInheritedThemeScope, useMaxWidthMediaQuery } from "../../theme";
+import { useEvent, usePrevious } from "../../util";
 import * as elementWithDropdownStyles from "./element-with-dropdown.styles";
 import type { DropdownAlignmentType } from "./types";
 
@@ -39,9 +40,10 @@ export interface DropdownRenderProps {
 interface ElementWithDropdownProps {
     enabled: boolean;
     isOpen: boolean;
-    onOpen?: () => void | undefined;
-    onClose?: (reason: OpenChangeReason | undefined) => void | undefined;
-    onDismiss?: () => void | undefined;
+    onOpen?: (() => void) | undefined;
+    onClose?: ((reason: OpenChangeReason | undefined) => void) | undefined;
+    onDismiss?: (() => void) | undefined;
+    onHide?: (() => void) | undefined;
     renderElement: () => React.ReactNode;
     renderDropdown: (props: DropdownRenderProps) => React.ReactNode;
     customZIndex?: number | undefined;
@@ -123,6 +125,7 @@ export const ElementWithDropdown = ({
     onOpen,
     onClose,
     onDismiss,
+    onHide,
     renderElement,
     renderDropdown,
     customZIndex,
@@ -219,9 +222,21 @@ export const ElementWithDropdown = ({
         dismiss,
     ]);
 
-    // =============================================================================
+    // =========================================================================
+    // ON HIDE EFFECT
+    // =========================================================================
+    const prevIsMounted = usePrevious(isMounted);
+    const onHideEvent = useEvent(() => onHide?.());
+
+    useEffect(() => {
+        if (prevIsMounted && !isMounted) {
+            onHideEvent();
+        }
+    }, [prevIsMounted, isMounted, onHideEvent]);
+
+    // =========================================================================
     // RENDER FUNCTIONS
-    // =============================================================================
+    // =========================================================================
     const dropdownRenderProps = {
         elementWidth: referenceWidth,
         styles: {


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)
-   [ ] Documentation (change to documentation, comments or API descriptions)
-   [ ] Tests (improvements to unit tests or E2E tests)
-   [ ] Other (technical improvements, refactoring, or changes that don't fall into the above categories)

**Description of changes**

-   Closes #1333
-   We need to reset the dropdown state to the default (no options fetched and in loading state) when the dropdown closes
- Previously this reset was triggering too early when the dropdown was closed but still animating out of view, resulting in the `No results found` (empty options + `itemsLoadState`= "success") display
- Introduced a `onHide` to ElementWithDropdown to detect when the dropdown is fully gone (when the animation completes, `isMounted`=false), and only trigger the reset in this callback

**Checklist**

<!-- Put an `x` in items that apply -->

-   [x] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [ ] ~~Looks good on mobile and tablet~~
-   [ ] ~~Updated documentation~~
-   [ ] ~~Added/updated unit tests~~
-   [ ] ~~Added/updated E2E tests~~

**Screenshots**

https://github.com/user-attachments/assets/ce28ed7a-3cc7-4ae2-bf4f-ed7614b2f7f6


https://github.com/user-attachments/assets/4de2dde9-c4d6-45c4-97db-8e15aa6ce401

