### PR TITLE
[CCUBE-2261][GZ] update assertion to check focus still trapped in dra…

### DIFF
--- a/e2e/tests/components/navbar/navbar.e2e.spec.ts
+++ b/e2e/tests/components/navbar/navbar.e2e.spec.ts
@@ -361,30 +361,24 @@ test.describe("Navbar", () => {
                     await closeButton.focus();
                     await expect(closeButton).toBeFocused();
 
-                    for (let i = 0; i < 10; i++) {
+                    for (let i = 0; i < 30; i++) {
                         await story.page.keyboard.press("Tab");
-                        await expect(outsideButton).not.toBeFocused();
-                        await expect(focusStart).not.toBeFocused();
+                        await expect(
+                            story.locators.internal.drawer.locator(":focus")
+                        ).toBeVisible();
                     }
-
-                    await expect(
-                        story.locators.internal.mobileNavLink(2)
-                    ).toBeFocused();
                 });
 
                 await test.step("Shift+Tab backward and verify focus does not escape", async () => {
                     await closeButton.focus();
                     await expect(closeButton).toBeFocused();
 
-                    for (let i = 0; i < 10; i++) {
+                    for (let i = 0; i < 30; i++) {
                         await story.page.keyboard.press("Shift+Tab");
-                        await expect(outsideButton).not.toBeFocused();
-                        await expect(focusStart).not.toBeFocused();
+                        await expect(
+                            story.locators.internal.drawer.locator(":focus")
+                        ).toBeVisible();
                     }
-
-                    await expect(
-                        story.locators.internal.playStoreButton
-                    ).toBeFocused();
                 });
 
                 await test.step("Escape closes the drawer", async () => {


### PR DESCRIPTION
…wer navbar

**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)
-   [ ] Documentation (change to documentation, comments or API descriptions)
-   [X] Tests (improvements to unit tests or E2E tests)
-   [ ] Other (technical improvements, refactoring, or changes that don't fall into the above categories)

**Description of changes**

-   Link to [ticket](https://sgtechstack.atlassian.net/browse/CCUBE-2261)
-   Update the assertion from checking exact focus position to making sure the focus still trapped in the drawer. The flakiness seems to be caused by non-syncing-state between the browser and the floating ui pkg.

**Checklist**

<!-- Put an `x` in items that apply -->

-   [X] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [ ] Looks good on mobile and tablet
-   [ ] Updated documentation
-   [ ] Added/updated unit tests
-   [X] Added/updated E2E tests

**Screenshots**

<!-- Include a screenshot or video recording of visual changes -->
