### PR TITLE
[CCUBE-2268][GZ] wait for filter checkbox item animation

### DIFF
--- a/e2e/tests/components/filter-checkbox/filter-checkbox.e2e.spec.ts
+++ b/e2e/tests/components/filter-checkbox/filter-checkbox.e2e.spec.ts
@@ -73,6 +73,22 @@ class StoryPage extends AbstractStoryPage {
         for (let i = 0; i < count; i += 1) {
             await waitForAnimationEnd(filterItems.nth(i));
         }
+
+        // After initial stability, useEffect + ResizeObserver cascades
+        // can trigger secondary spring animations. Re-check stability.
+        await this.page.evaluate(() =>
+            new Promise<void>((resolve) => {
+                let frame = 0;
+                const wait = () => {
+                    if (++frame >= 5) resolve();
+                    else requestAnimationFrame(wait);
+                };
+                requestAnimationFrame(wait);
+            })
+        );
+        for (let i = 0; i < count; i += 1) {
+            await waitForAnimationEnd(filterItems.nth(i));
+        }
     }
 }
 


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)
-   [ ] Documentation (change to documentation, comments or API descriptions)
-   [X] Tests (improvements to unit tests or E2E tests)
-   [ ] Other (technical improvements, refactoring, or changes that don't fall into the above categories)

**Description of changes**

-   Link to [ticket](https://sgtechstack.atlassian.net/browse/CCUBE-2268)

The `FilterItem` component uses `react-spring` to animate expandable container height based on `useResizeDetector`. On mount in mobile mode, a cascade occurs. The current `waitForAnimationEnd` can pass before the cascade finishes. When this happens, the screenshot captures a mid-animation state, producing the pixel diffs.  

The fix is to wait until the cascades flushed, then recheck the element stability.

**Checklist**

<!-- Put an `x` in items that apply -->

-   [X] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [ ] Looks good on mobile and tablet
-   [ ] Updated documentation
-   [ ] Added/updated unit tests
-   [X] Added/updated E2E tests

**Screenshots**

<!-- Include a screenshot or video recording of visual changes -->
