### PR TITLE
[CCUBE-2274][RYN] remove underlineStyle and weight from navbar-items Link

### DIFF
--- a/src/navbar/navbar-items.styles.tsx
+++ b/src/navbar/navbar-items.styles.tsx
@@ -70,8 +70,8 @@ export const LinkItem = styled.li<ItemStyleProps>`
     }
 `;
 
-const linkCss = css<{ $selected: boolean; weight: TypographyWeight }>`
-    ${(props) => Font[`body-md-${props.weight}`]}
+const linkCss = css<{ $selected: boolean; $weight: TypographyWeight }>`
+    ${(props) => Font[`body-md-${props.$weight}`]}
 
     display: flex;
     position: relative;
@@ -97,13 +97,13 @@ const linkCss = css<{ $selected: boolean; weight: TypographyWeight }>`
         text-align: left;
     }
 `;
-export const Link = styled.a<{ $selected: boolean; weight: TypographyWeight }>`
+export const Link = styled.a<{ $selected: boolean; $weight: TypographyWeight }>`
     ${linkCss}
 `;
 
 export const LinkButton = styled.button<{
     $selected: boolean;
-    weight: TypographyWeight;
+    $weight: TypographyWeight;
 }>`
     ${linkCss}
     background: none;

--- a/src/navbar/navbar-items.tsx
+++ b/src/navbar/navbar-items.tsx
@@ -203,9 +203,8 @@ export const NavbarItems = <T,>({
             <Link
                 tabIndex={0}
                 data-testid={testId}
-                weight={textWeight}
+                $weight={textWeight}
                 $selected={selected}
-                underlineStyle="none"
                 {...otherItemAttrs}
                 aria-current={isRouteSelected ? "page" : undefined}
                 onClick={handleLinkClick(item, index)}
@@ -224,9 +223,8 @@ export const NavbarItems = <T,>({
                     <>
                         <Link
                             data-testid={testId}
-                            weight={textWeight}
+                            $weight={textWeight}
                             $selected={selected}
-                            underlineStyle="none"
                             {...otherItemAttrs}
                             aria-current={isRouteSelected ? "page" : undefined}
                             aria-haspopup="menu"
@@ -262,7 +260,7 @@ export const NavbarItems = <T,>({
                         type="button"
                         tabIndex={0}
                         data-testid={testId}
-                        weight={textWeight}
+                        $weight={textWeight}
                         $selected={selected}
                         aria-haspopup="menu"
                         aria-expanded={isExpanded}


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)
-   [ ] Documentation (change to documentation, comments or API descriptions)
-   [ ] Tests (improvements to unit tests or E2E tests)
-   [ ] Other (technical improvements, refactoring, or changes that don't fall into the above categories)

**Description of changes**

-   Link to [ticket](https://sgtechstack.atlassian.net/browse/CCUBE-2274)
-   Description of changes
- Remove underlineStyle
- Rename weight to a transiet prop with $ prefix



**Checklist**

<!-- Put an `x` in items that apply -->

-   [ ] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [ ] Looks good on mobile and tablet
-   [ ] Updated documentation
-   [ ] Added/updated unit tests
-   [ ] Added/updated E2E tests

