### PR TITLE
[CCUBE-2278][RYN] add control mode for accordion item

### DIFF
--- a/src/accordion/accordion-item.tsx
+++ b/src/accordion/accordion-item.tsx
@@ -31,6 +31,7 @@ function Component(
         className,
         id,
         expanded: expandedControlled,
+        onExpandChange,
         "data-testid": testId = "accordion-item",
     }: AccordionItemProps,
     ref: React.Ref<AccordionItemHandle>
@@ -50,9 +51,13 @@ function Component(
     const internalId = useId();
     const contentId = `${internalId}-content`;
     const { height, ref: resizeDetectorRef } = useResizeDetector();
-    const expanded =
-        itemState[internalId] ??
-        (collapsible ? expandedControlled ?? expandAll : true); // the initial value
+    const isControlled = onExpandChange !== undefined;
+    const expanded = isControlled
+        ? collapsible
+            ? expandedControlled ?? false
+            : true
+        : itemState[internalId] ??
+          (collapsible ? expandedControlled ?? expandAll : true);
 
     useImperativeHandle(
         ref,
@@ -61,10 +66,18 @@ function Component(
                 elementRef.current!,
                 {
                     expand(): void {
-                        onItemStateChange(internalId, true);
+                        if (isControlled) {
+                            onExpandChange?.(true);
+                        } else {
+                            onItemStateChange(internalId, true);
+                        }
                     },
                     collapse(): void {
-                        onItemStateChange(internalId, false);
+                        if (isControlled) {
+                            onExpandChange?.(false);
+                        } else {
+                            onItemStateChange(internalId, false);
+                        }
                     },
                     isExpanded() {
                         return expanded;
@@ -85,13 +98,35 @@ function Component(
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
+    // Controlled mode: keep parent itemState in sync so "Show all"/"Hide all" label stays accurate
     useEffect(() => {
-        onItemStateChange(
-            internalId,
-            collapsible ? expandedControlled ?? expandAll : true
-        );
+        if (isControlled) {
+            onItemStateChange(
+                internalId,
+                collapsible ? expandedControlled ?? false : true
+            );
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [expandedControlled, collapsible]);
+
+    // Uncontrolled mode: sync state when expandAll button or the hint prop changes
+    useEffect(() => {
+        if (!isControlled) {
+            onItemStateChange(
+                internalId,
+                collapsible ? expandedControlled ?? expandAll : true
+            );
+        }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [expandAll, expandedControlled, collapsible]);
+
+    // Controlled mode: forward expandAll button changes to the caller
+    useEffect(() => {
+        if (isControlled && hasFirstLoad) {
+            onExpandChange?.(collapsible ? expandAll : true);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [expandAll]);
 
     // =========================================================================
     // EVENT HANDLERS
@@ -99,7 +134,11 @@ function Component(
 
     const handleExpandCollapseClick = (event: React.MouseEvent) => {
         event.preventDefault();
-        onItemStateChange(internalId, !expanded);
+        if (isControlled) {
+            onExpandChange?.(!expanded);
+        } else {
+            onItemStateChange(internalId, !expanded);
+        }
     };
 
     // =========================================================================

--- a/src/accordion/accordion-item.tsx
+++ b/src/accordion/accordion-item.tsx
@@ -122,8 +122,10 @@ function Component(
 
     // Controlled mode: forward expandAll button changes to the caller
     useEffect(() => {
-        if (isControlled && hasFirstLoad) {
-            onExpandChange?.(collapsible ? expandAll : true);
+        if (!isControlled || !hasFirstLoad) return;
+        const next = collapsible ? expandAll : true;
+        if (next !== expandedControlled) {
+            onExpandChange?.(next);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [expandAll]);

--- a/src/accordion/types.ts
+++ b/src/accordion/types.ts
@@ -67,6 +67,13 @@ export interface AccordionItemProps {
      * @default true
      */
     collapsible?: boolean | undefined;
+    /**
+     * Called when the user toggles this item or the parent "Show all" / "Hide all"
+     * button fires. When provided, the item enters **controlled mode** — the caller
+     * must update the `expanded` prop in response. Without this prop, the item
+     * manages its own state internally (uncontrolled mode).
+     */
+    onExpandChange?: ((expanded: boolean) => void) | undefined;
 }
 
 // @storybookSection Accordion.Item

--- a/stories/accordion/accordion.mdx
+++ b/stories/accordion/accordion.mdx
@@ -41,6 +41,14 @@ If you do not require a expand/collapse all button in the `Accordion`, use `enab
 
 <Canvas of={AccordionStories.NoExpandCollapseAll} />
 
+## Control Mode
+
+Pass `expanded` and `onExpandChange` together to put an `Accordion.Item` in controlled mode.
+The item will call `onExpandChange` on user interaction and when the parent "Show all" / "Hide all"
+button fires — the caller is responsible for updating `expanded` in response.
+
+<Canvas of={AccordionStories.ControlMode} />
+
 ## Accessibility
 
 Depending on where the `Accordion` is used, set a custom `headingLevel` to

--- a/stories/accordion/accordion.mdx
+++ b/stories/accordion/accordion.mdx
@@ -41,13 +41,13 @@ If you do not require a expand/collapse all button in the `Accordion`, use `enab
 
 <Canvas of={AccordionStories.NoExpandCollapseAll} />
 
-## Control Mode
+## Controlled mode
 
-Pass `expanded` and `onExpandChange` together to put an `Accordion.Item` in controlled mode.
-The item will call `onExpandChange` on user interaction and when the parent "Show all" / "Hide all"
-button fires — the caller is responsible for updating `expanded` in response.
+Pass `expanded` and `onExpandChange` to an `Accordion.Item` to fully control its
+expanded state. The caller is responsible for updating the state when
+`onExpandChange` is invoked.
 
-<Canvas of={AccordionStories.ControlMode} />
+<Canvas of={AccordionStories.ControlledMode} />
 
 ## Accessibility
 

--- a/stories/accordion/accordion.stories.tsx
+++ b/stories/accordion/accordion.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-webpack5";
+import { useState } from "react";
 import { Accordion } from "src/accordion";
 import { Typography } from "src/typography";
 
@@ -193,6 +194,58 @@ export const Accessibility: StoryObj<Component> = {
                         Lorem ipsum dolor sit amet, consectetur adipiscing elit.
                     </Typography.BodyBL>
                 </Accordion.Item>
+            </Accordion>
+        );
+    },
+};
+
+export const ControlMode: StoryObj<Component> = {
+    render: (_args) => {
+        const items = [
+            {
+                title: "This is the first item",
+                detail: (
+                    <Typography.BodyBL>
+                        Lorem ipsum dolor sit amet
+                    </Typography.BodyBL>
+                ),
+            },
+            {
+                title: "This is the second item",
+                detail: (
+                    <Typography.BodyBL>
+                        Lorem ipsum dolor sit amet
+                    </Typography.BodyBL>
+                ),
+            },
+            {
+                title: "This is the third item",
+                detail: (
+                    <Typography.BodyBL>
+                        Lorem ipsum dolor sit amet
+                    </Typography.BodyBL>
+                ),
+            },
+        ];
+        const [expandedStates, setExpandedStates] = useState(() =>
+            items.map((_, index) => index === 0)
+        );
+        return (
+            <Accordion enableExpandAll={false} initialDisplay="collapse-all">
+                {items.map((item, index) => (
+                    <Accordion.Item
+                        key={`${item.title}-${index}`}
+                        title={item.title}
+                        expanded={expandedStates[index]}
+                        onExpandChange={(val) =>
+                            setExpandedStates((prev) =>
+                                prev.map((v, i) => (i === index ? val : v))
+                            )
+                        }
+                    >
+                        {item.detail}
+                    </Accordion.Item>
+                ))}
             </Accordion>
         );
     },

--- a/stories/accordion/accordion.stories.tsx
+++ b/stories/accordion/accordion.stories.tsx
@@ -174,32 +174,7 @@ export const NoExpandCollapseAll: StoryObj<Component> = {
     },
 };
 
-export const Accessibility: StoryObj<Component> = {
-    render: (_args) => {
-        return (
-            <Accordion title="Heading" headingLevel={3}>
-                <Accordion.Item title="Title as string">
-                    <Typography.BodyBL>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                    </Typography.BodyBL>
-                </Accordion.Item>
-                <Accordion.Item
-                    title={
-                        <Typography.HeadingXS inline weight="semibold">
-                            Title as JSX element
-                        </Typography.HeadingXS>
-                    }
-                >
-                    <Typography.BodyBL>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                    </Typography.BodyBL>
-                </Accordion.Item>
-            </Accordion>
-        );
-    },
-};
-
-export const ControlMode: StoryObj<Component> = {
+export const ControlledMode: StoryObj<Component> = {
     render: (_args) => {
         const items = [
             {
@@ -231,7 +206,7 @@ export const ControlMode: StoryObj<Component> = {
             items.map((_, index) => index === 0)
         );
         return (
-            <Accordion enableExpandAll={false} initialDisplay="collapse-all">
+            <Accordion initialDisplay="collapse-all">
                 {items.map((item, index) => (
                     <Accordion.Item
                         key={`${item.title}-${index}`}
@@ -246,6 +221,31 @@ export const ControlMode: StoryObj<Component> = {
                         {item.detail}
                     </Accordion.Item>
                 ))}
+            </Accordion>
+        );
+    },
+};
+
+export const Accessibility: StoryObj<Component> = {
+    render: (_args) => {
+        return (
+            <Accordion title="Heading" headingLevel={3}>
+                <Accordion.Item title="Title as string">
+                    <Typography.BodyBL>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                    </Typography.BodyBL>
+                </Accordion.Item>
+                <Accordion.Item
+                    title={
+                        <Typography.HeadingXS inline weight="semibold">
+                            Title as JSX element
+                        </Typography.HeadingXS>
+                    }
+                >
+                    <Typography.BodyBL>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                    </Typography.BodyBL>
+                </Accordion.Item>
             </Accordion>
         );
     },

--- a/tests/accordion/accordion.spec.tsx
+++ b/tests/accordion/accordion.spec.tsx
@@ -5,6 +5,7 @@ import {
     screen,
     waitFor,
 } from "@testing-library/react";
+import { useState } from "react";
 import { Accordion } from "src/accordion";
 import { Typography } from "src/typography";
 
@@ -401,6 +402,212 @@ describe("Accordion", () => {
             expect(
                 screen.queryByTestId("item1-expand-collapse-icon")
             ).not.toBeInTheDocument();
+        });
+    });
+
+    describe("Accordion.Item controlled mode (onExpandChange)", () => {
+        it("should call onExpandChange with the toggled value when item is clicked", () => {
+            const onExpandChange = jest.fn();
+
+            function TestComponent() {
+                const [isExpanded, setIsExpanded] = useState(false);
+                return (
+                    <Accordion>
+                        <Accordion.Item
+                            data-testid="item1"
+                            title="Item title"
+                            expanded={isExpanded}
+                            onExpandChange={(val) => {
+                                onExpandChange(val);
+                                setIsExpanded(val);
+                            }}
+                        >
+                            <Typography.BodyBL>
+                                {DEFAULT_TEXT_CONTENT}
+                            </Typography.BodyBL>
+                        </Accordion.Item>
+                    </Accordion>
+                );
+            }
+
+            render(<TestComponent />);
+
+            act(() => {
+                fireEvent.click(
+                    screen.getByTestId("item1-expand-collapse-button")
+                );
+            });
+
+            expect(onExpandChange).toHaveBeenCalledWith(true);
+
+            act(() => {
+                fireEvent.click(
+                    screen.getByTestId("item1-expand-collapse-button")
+                );
+            });
+
+            expect(onExpandChange).toHaveBeenCalledWith(false);
+        });
+
+        it("should not expand the item without the caller updating the expanded prop", async () => {
+            const onExpandChange = jest.fn();
+
+            render(
+                <Accordion>
+                    <Accordion.Item
+                        data-testid="item1"
+                        title="Item title"
+                        expanded={false}
+                        onExpandChange={onExpandChange}
+                    >
+                        <Typography.BodyBL>
+                            {DEFAULT_TEXT_CONTENT}
+                        </Typography.BodyBL>
+                    </Accordion.Item>
+                </Accordion>
+            );
+
+            const expandableContainer = screen.getByTestId(
+                "item1-expandable-container"
+            );
+            await expectItemCollapsed(expandableContainer);
+
+            act(() => {
+                fireEvent.click(
+                    screen.getByTestId("item1-expand-collapse-button")
+                );
+            });
+
+            await expectItemCollapsed(expandableContainer);
+        });
+
+        it("should keep all items expanded when all are manually opened", async () => {
+            // Regression: expandAll auto-detection must not reset controlled items
+            function TestComponent() {
+                const [states, setStates] = useState([true, false, false]);
+                return (
+                    <Accordion
+                        enableExpandAll={false}
+                        initialDisplay="collapse-all"
+                    >
+                        {states.map((isExpanded, index) => (
+                            <Accordion.Item
+                                key={index}
+                                data-testid={`item${index + 1}`}
+                                title={`Item ${index + 1}`}
+                                expanded={isExpanded}
+                                onExpandChange={(val) =>
+                                    setStates((prev) =>
+                                        prev.map((v, i) =>
+                                            i === index ? val : v
+                                        )
+                                    )
+                                }
+                            >
+                                <Typography.BodyBL>
+                                    {DEFAULT_TEXT_CONTENT}
+                                </Typography.BodyBL>
+                            </Accordion.Item>
+                        ))}
+                    </Accordion>
+                );
+            }
+
+            render(<TestComponent />);
+
+            await expectItemExpanded(
+                screen.getByTestId("item1-expandable-container")
+            );
+            await expectItemCollapsed(
+                screen.getByTestId("item2-expandable-container")
+            );
+            await expectItemCollapsed(
+                screen.getByTestId("item3-expandable-container")
+            );
+
+            act(() => {
+                fireEvent.click(
+                    screen.getByTestId("item2-expand-collapse-button")
+                );
+            });
+            act(() => {
+                fireEvent.click(
+                    screen.getByTestId("item3-expand-collapse-button")
+                );
+            });
+
+            await expectItemExpanded(
+                screen.getByTestId("item1-expandable-container")
+            );
+            await expectItemExpanded(
+                screen.getByTestId("item2-expandable-container")
+            );
+            await expectItemExpanded(
+                screen.getByTestId("item3-expandable-container")
+            );
+        });
+
+        it("should call onExpandChange when Show all / Hide all is clicked", () => {
+            const onExpandChange1 = jest.fn();
+            const onExpandChange2 = jest.fn();
+
+            function TestComponent() {
+                const [states, setStates] = useState([false, false]);
+                return (
+                    <Accordion initialDisplay="collapse-all">
+                        <Accordion.Item
+                            data-testid="item1"
+                            title="Item 1"
+                            expanded={states[0]}
+                            onExpandChange={(val) => {
+                                onExpandChange1(val);
+                                setStates((prev) => [val, prev[1]]);
+                            }}
+                        >
+                            <Typography.BodyBL>
+                                {DEFAULT_TEXT_CONTENT}
+                            </Typography.BodyBL>
+                        </Accordion.Item>
+                        <Accordion.Item
+                            data-testid="item2"
+                            title="Item 2"
+                            expanded={states[1]}
+                            onExpandChange={(val) => {
+                                onExpandChange2(val);
+                                setStates((prev) => [prev[0], val]);
+                            }}
+                        >
+                            <Typography.BodyBL>
+                                {DEFAULT_TEXT_CONTENT}
+                            </Typography.BodyBL>
+                        </Accordion.Item>
+                    </Accordion>
+                );
+            }
+
+            render(<TestComponent />);
+
+            act(() => {
+                fireEvent.click(
+                    screen.getByRole("button", {
+                        name: ACCORDION_EXPAND_ALL_BUTTON_LABEL,
+                    })
+                );
+            });
+
+            expect(onExpandChange1).toHaveBeenCalledWith(true);
+            expect(onExpandChange2).toHaveBeenCalledWith(true);
+
+            act(() => {
+                fireEvent.click(
+                    screen.getByRole("button", {
+                        name: ACCORDION_HIDE_ALL_BUTTON_LABEL,
+                    })
+                );
+            });
+
+            expect(onExpandChange1).toHaveBeenCalledWith(false);
+            expect(onExpandChange2).toHaveBeenCalledWith(false);
         });
     });
 


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)
-   [ ] Documentation (change to documentation, comments or API descriptions)
-   [ ] Tests (improvements to unit tests or E2E tests)
-   [ ] Other (technical improvements, refactoring, or changes that don't fall into the above categories)

**Description of changes**

-   Link to [ticket](https://sgtechstack.atlassian.net/browse/CCUBE-2278)
-   Description of changes:
     - Expose a onExpandChange that lets the caller track the accordion state
     - If this is specified, the accordion should work in controlled mode 
     - If not specified, the accordion should continue to work in uncontrolled mode

**Checklist**

<!-- Put an `x` in items that apply -->

-   [ ] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [ ] Looks good on mobile and tablet
-   [x] Updated documentation
-   [ ] Added/updated unit tests
-   [ ] Added/updated E2E tests

