### PR TITLE
Fix breakpoint detection on mobile with content overflow

### DIFF
--- a/e2e/nextjs-app/src/app/components/theme/media-query-content-overflow.e2e.tsx
+++ b/e2e/nextjs-app/src/app/components/theme/media-query-content-overflow.e2e.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useMinWidthMediaQuery } from "@lifesg/react-design-system";
+import { useEffect, useState } from "react";
+
+import styles from "./media-query-content-overflow.module.css";
+
+export default function Story() {
+    const [isMounted, setIsMounted] = useState(false);
+    const [breakpoint, setBreakpoint] = useState<string>("");
+    const isSm = useMinWidthMediaQuery("sm");
+    const isMd = useMinWidthMediaQuery("md");
+
+    useEffect(() => {
+        setIsMounted(true);
+    }, []);
+
+    useEffect(() => {
+        const observer = new MutationObserver(() => {
+            const body = document.body;
+            const breakpointClass = [...body.classList].find((cls) =>
+                /^fds-breakpoint-[a-z]+$/.test(cls)
+            );
+            if (breakpointClass) {
+                setBreakpoint(breakpointClass);
+            }
+        });
+        observer.observe(document.body, {
+            attributes: true,
+            attributeFilter: ["class"],
+        });
+
+        return () => {
+            observer.disconnect();
+        };
+    }, []);
+
+    return (
+        <div className="story-column-container">
+            {isMounted && (
+                <>
+                    <div>isSm: {isSm ? "true" : "false"}</div>
+                    <div>isMd: {isMd ? "true" : "false"}</div>
+                    <div>breakpoint: {breakpoint}</div>
+                </>
+            )}
+            <div className={styles["overflow-content"]}>
+                <div>Overflow content</div>
+                <div>Overflow content</div>
+                <div>Overflow content</div>
+            </div>
+        </div>
+    );
+}

--- a/e2e/nextjs-app/src/app/components/theme/media-query-content-overflow.module.css
+++ b/e2e/nextjs-app/src/app/components/theme/media-query-content-overflow.module.css
@@ -1,0 +1,5 @@
+.overflow-content {
+    width: 720px;
+    padding: 16px;
+    background: #BFDBFE;
+}

--- a/e2e/tests/components/theme/media-query.e2e.spec.ts
+++ b/e2e/tests/components/theme/media-query.e2e.spec.ts
@@ -119,6 +119,21 @@ test.describe("Theme media query", () => {
                 "false"
             );
         });
+
+        test.describe(() => {
+            test.use({ isMobile: true });
+
+            test("content overflow behaviour", async ({ story }) => {
+                await story.init("media-query-content-overflow");
+                await story.page.setViewportSize({ width: 400, height: 720 });
+
+                await expect(story.layout).toContainText("isSm: true");
+                await expect(story.layout).toContainText("isMd: false");
+                await expect(story.layout).toContainText(
+                    "breakpoint: fds-breakpoint-sm"
+                );
+            });
+        });
     });
 
     test.describe("Specificity", () => {

--- a/src/theme/theme-provider/breakpoint.ts
+++ b/src/theme/theme-provider/breakpoint.ts
@@ -57,7 +57,10 @@ const BREAKPOINT_CLASS_PREFIX = "fds-breakpoint-";
 
 function applyBreakpointClasses(sourceElement: HTMLElement) {
     const body = document.body;
-    const width = window.innerWidth;
+
+    const width = window.visualViewport
+        ? window.visualViewport.width * window.visualViewport.scale
+        : window.innerWidth;
 
     [...body.classList].forEach((cls) => {
         if (cls.startsWith(BREAKPOINT_CLASS_PREFIX)) {

--- a/src/theme/theme-provider/breakpoint.ts
+++ b/src/theme/theme-provider/breakpoint.ts
@@ -1,6 +1,6 @@
 import { Breakpoint } from "../tokens/breakpoint";
 import type { CSSVariableString } from "../types";
-import { parseCSSVariableValue, parsePxOrRemValue } from "../utils";
+import { parseCSSVariableValue } from "../utils";
 
 function getBreakpointRanges(sourceElement: HTMLElement) {
     const getBreakpointValue = (token: CSSVariableString) => {
@@ -58,10 +58,6 @@ const BREAKPOINT_CLASS_PREFIX = "fds-breakpoint-";
 function applyBreakpointClasses(sourceElement: HTMLElement) {
     const body = document.body;
 
-    const width = window.visualViewport
-        ? window.visualViewport.width * window.visualViewport.scale
-        : window.innerWidth;
-
     [...body.classList].forEach((cls) => {
         if (cls.startsWith(BREAKPOINT_CLASS_PREFIX)) {
             body.classList.remove(cls);
@@ -71,16 +67,15 @@ function applyBreakpointClasses(sourceElement: HTMLElement) {
     const BREAKPOINT_RANGES = getBreakpointRanges(sourceElement);
 
     BREAKPOINT_RANGES.forEach((range) => {
-        const minValue = parsePxOrRemValue(range.min);
-        const maxValue =
+        const isMinMatched = window.matchMedia(
+            `(min-width: ${range.min})`
+        ).matches;
+        const isMaxMatched =
             range.max === Infinity
-                ? Infinity
-                : parsePxOrRemValue(range.max as string);
-
-        const isMinMatched = width >= minValue;
-        const isMaxMatched = maxValue === Infinity ? false : width <= maxValue;
+                ? false
+                : window.matchMedia(`(max-width: ${range.max})`).matches;
         const isWithinRange =
-            isMinMatched && (maxValue === Infinity || isMaxMatched);
+            isMinMatched && (range.max === Infinity || isMaxMatched);
 
         if (isWithinRange) {
             body.classList.add(`${BREAKPOINT_CLASS_PREFIX}${range.key}`);
@@ -97,7 +92,7 @@ function applyBreakpointClasses(sourceElement: HTMLElement) {
 }
 
 export function setupBreakpointListener(sourceElement: HTMLElement) {
-    if (!globalThis.window) return;
+    if (!globalThis.window || !globalThis.window.matchMedia) return;
 
     const handleBreakpointChange = () => {
         applyBreakpointClasses(sourceElement);

--- a/src/theme/theme-provider/index.tsx
+++ b/src/theme/theme-provider/index.tsx
@@ -1,5 +1,5 @@
 import type { Ref } from "react";
-import { forwardRef, useEffect, useMemo, useState } from "react";
+import { forwardRef, useContext, useEffect, useMemo, useState } from "react";
 
 import { mergeRefs, useIsomorphicLayoutEffect } from "../../util";
 import type { ResolvedThemeMode } from "../types";
@@ -27,14 +27,20 @@ const InnerThemeProvider = (
         null
     );
 
+    const themeContext = useContext(ThemeContext);
+    const isNestedThemeProvider = !!themeContext;
+
     // Re-subscribe when the source node or token set changes:
     // - `themeElement`: scoped breakpoint tokens may live on this element
     // - `theme` / `themeMode`: breakpoint token values can differ across theme/mode
     useIsomorphicLayoutEffect(() => {
+        // Only set up the breakpoint listener once in the root theme provider
+        if (isNestedThemeProvider) return;
+
         const sourceElement = themeElement ?? document.documentElement;
         const cleanup = setupBreakpointListener(sourceElement);
         return cleanup;
-    }, [themeElement, theme, computedMode]);
+    }, [themeElement, theme, computedMode, isNestedThemeProvider]);
 
     useEffect(() => {
         if (isModeControlled) {

--- a/tests/_common/match-media-mock.ts
+++ b/tests/_common/match-media-mock.ts
@@ -26,6 +26,7 @@ export type MatchMediaMockController = {
         mediaQueryLists: Map<string, MockMediaQueryList>;
     };
     restore: () => void;
+    setViewportWidth: (width: number) => void;
 };
 
 export const createMatchMediaMock = ({
@@ -38,6 +39,7 @@ export const createMatchMediaMock = ({
     let mediaQueryLists = new Map<string, MockMediaQueryList>();
     let matchMedia: jest.MockedFunction<(query: string) => MockMediaQueryList> =
         jest.fn<(query: string) => MockMediaQueryList>();
+    let viewportWidth: number | undefined;
 
     const mock: MatchMediaMockController["mock"] = (
         options: CreateMatchMediaMockOptions = {}
@@ -49,6 +51,10 @@ export const createMatchMediaMock = ({
             const existingMediaQueryList = mediaQueryLists.get(query);
 
             if (existingMediaQueryList) {
+                existingMediaQueryList.matches = resolveMediaQueryMatches(
+                    query,
+                    initialMatches
+                );
                 return existingMediaQueryList;
             }
 
@@ -71,7 +77,7 @@ export const createMatchMediaMock = ({
                     mediaQueryList.matches = matches;
                     changeListener?.({ matches } as MediaQueryListEvent);
                 },
-                matches: initialMatches,
+                matches: resolveMediaQueryMatches(query, initialMatches),
                 media: query,
                 removeEventListener: jest.fn(
                     (
@@ -102,7 +108,34 @@ export const createMatchMediaMock = ({
         return { matchMedia, mediaQueryLists };
     };
 
+    const resolveMediaQueryMatches = (
+        query: string,
+        initialMatches: boolean
+    ): boolean => {
+        if (viewportWidth === undefined) {
+            return initialMatches;
+        }
+
+        const minMatch = query.match(/min-width:\s*(\d+)/);
+        const maxMatch = query.match(/max-width:\s*(\d+)/);
+
+        if (minMatch && maxMatch) {
+            return (
+                viewportWidth >= parseInt(minMatch[1], 10) &&
+                viewportWidth <= parseInt(maxMatch[1], 10)
+            );
+        } else if (minMatch) {
+            return viewportWidth >= parseInt(minMatch[1], 10);
+        } else if (maxMatch) {
+            return viewportWidth <= parseInt(maxMatch[1], 10);
+        }
+
+        return false;
+    };
+
     const restore = () => {
+        viewportWidth = undefined;
+
         if (originalMatchMediaDescriptor) {
             Object.defineProperty(
                 globalThis.window,
@@ -113,6 +146,11 @@ export const createMatchMediaMock = ({
         }
 
         delete (globalThis.window as Partial<Window>).matchMedia;
+    };
+
+    const setViewportWidth = (width: number) => {
+        viewportWidth = width;
+        globalThis.window.dispatchEvent(new Event("resize"));
     };
 
     mock({ initialMatches });
@@ -126,5 +164,6 @@ export const createMatchMediaMock = ({
         },
         mock,
         restore,
+        setViewportWidth,
     };
 };

--- a/tests/e-signature/e-signature.spec.tsx
+++ b/tests/e-signature/e-signature.spec.tsx
@@ -3,29 +3,6 @@ import { ESignature } from "src/e-signature";
 
 import { createMatchMediaMock } from "../_common";
 
-jest.mock("../../src/theme", () => {
-    const actual = jest.requireActual("../../src/theme");
-    return {
-        ...actual,
-        useResolvedTokenValue: ({
-            value,
-            fallback,
-            isToken,
-            normalizeCustom,
-        }: {
-            value: unknown;
-            fallback: unknown;
-            isToken: (candidate: unknown) => boolean;
-            normalizeCustom: (candidate: unknown) => string;
-        }) => {
-            const effectiveValue =
-                value == null || value === "" ? fallback : value;
-            return isToken(effectiveValue)
-                ? String(effectiveValue)
-                : normalizeCustom(effectiveValue);
-        },
-    };
-});
 createMatchMediaMock();
 
 // =============================================================================

--- a/tests/theme/theme-provider.spec.tsx
+++ b/tests/theme/theme-provider.spec.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider, useTheme } from "src/theme";
 import * as breakpoint from "src/theme/theme-provider/breakpoint";
 import * as systemMode from "src/theme/theme-provider/system-colour-mode";
 
+import { createMatchMediaMock } from "../_common";
 import { setupThemeVariables } from "./setup";
 
 const TestComponent = () => {
@@ -16,16 +17,6 @@ const TestComponent = () => {
         </div>
     );
 };
-
-function setWindowWidth(width: number) {
-    Object.defineProperty(globalThis, "innerWidth", {
-        writable: true,
-        configurable: true,
-        value: width,
-    });
-
-    globalThis.dispatchEvent(new Event("resize"));
-}
 
 describe("ThemeProvider", () => {
     beforeEach(() => {
@@ -184,6 +175,16 @@ describe("ThemeProvider", () => {
     });
 
     describe("BREAKPOINT", () => {
+        let matchMediaMock: ReturnType<typeof createMatchMediaMock>;
+
+        beforeEach(() => {
+            matchMediaMock = createMatchMediaMock();
+        });
+
+        afterEach(() => {
+            matchMediaMock.restore();
+        });
+
         it("does not crash when breakpoint listener setup returns undefined", () => {
             jest.spyOn(
                 breakpoint,
@@ -200,7 +201,7 @@ describe("ThemeProvider", () => {
         });
 
         it("applies correct breakpoint classes on initial load", () => {
-            setWindowWidth(500); // md range (481–768)
+            matchMediaMock.setViewportWidth(500); // md range (481–768)
 
             render(
                 <ThemeProvider>
@@ -216,7 +217,7 @@ describe("ThemeProvider", () => {
         });
 
         it("updates breakpoint classes on resize", () => {
-            setWindowWidth(500); // md range (481–768)
+            matchMediaMock.setViewportWidth(500); // md range (481–768)
 
             render(
                 <ThemeProvider>
@@ -229,7 +230,7 @@ describe("ThemeProvider", () => {
             expect(body.classList.contains("fds-breakpoint-md")).toBe(true);
 
             // Resize to lg range (769–1200)
-            setWindowWidth(900);
+            matchMediaMock.setViewportWidth(900);
 
             expect(body.classList.contains("fds-breakpoint-lg")).toBe(true);
             expect(body.classList.contains("fds-breakpoint-lg-min")).toBe(true);
@@ -256,7 +257,7 @@ describe("ThemeProvider", () => {
         });
 
         it("applies only min and base class for xxl", () => {
-            setWindowWidth(1600); // xxl (1441+)
+            matchMediaMock.setViewportWidth(1600); // xxl (1441+)
 
             render(
                 <ThemeProvider>
@@ -276,7 +277,7 @@ describe("ThemeProvider", () => {
         });
 
         it("persist breakpoint when still within range", () => {
-            setWindowWidth(500); // md range (481–768)
+            matchMediaMock.setViewportWidth(500); // md range (481–768)
 
             render(
                 <ThemeProvider>
@@ -290,7 +291,7 @@ describe("ThemeProvider", () => {
             expect(body.classList.contains("fds-breakpoint-md-min")).toBe(true);
             expect(body.classList.contains("fds-breakpoint-md-max")).toBe(true);
 
-            setWindowWidth(600); // md range (481–768)
+            matchMediaMock.setViewportWidth(600); // md range (481–768)
 
             expect(body.classList.contains("fds-breakpoint-md")).toBe(true);
             expect(body.classList.contains("fds-breakpoint-md-min")).toBe(true);
@@ -298,7 +299,7 @@ describe("ThemeProvider", () => {
         });
 
         it("respects custom breakpoint overrides", () => {
-            setWindowWidth(1000);
+            matchMediaMock.setViewportWidth(1000);
 
             render(
                 <ThemeProvider
@@ -317,7 +318,7 @@ describe("ThemeProvider", () => {
             expect(body.classList.contains("fds-breakpoint-md")).toBe(true);
             expect(body.classList.contains("fds-breakpoint-md-max")).toBe(true);
 
-            setWindowWidth(1001);
+            matchMediaMock.setViewportWidth(1001);
             expect(body.classList.contains("fds-breakpoint-md")).toBe(false);
             expect(body.classList.contains("fds-breakpoint-md-max")).toBe(
                 false
@@ -329,7 +330,7 @@ describe("ThemeProvider", () => {
         it("does not remove non-breakpoint classes", () => {
             document.body.classList.add("random-class");
 
-            setWindowWidth(500);
+            matchMediaMock.setViewportWidth(500);
 
             render(
                 <ThemeProvider>


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)
-   [ ] Documentation (change to documentation, comments or API descriptions)
-   [ ] Tests (improvements to unit tests or E2E tests)
-   [ ] Other (technical improvements, refactoring, or changes that don't fall into the above categories)

**Description of changes**

-   Use the ~~visual viewport~~ `window.matchMedia` api to calculate the actual screen width instead of `window.innerWidth`, which could grow beyond the visible viewport when there is overflow content (without overflow hidden)
- Original issue reported:
  - a responsive element was rendered: on md, it's a flex row, on sm, it's a flex column
  - on page load, it renders as the flex row as expected
  - but when resizing the window to sm, it remains as flex row instead of switching to flex column. on inspection, the breakpoint class remains on `fds-breakpoint-md`
  - this was demonstrated with Chrome's Responsive Viewport Mode

**Checklist**

<!-- Put an `x` in items that apply -->

-   [x] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [ ] ~~Looks good on mobile and tablet~~
-   [ ] ~~Updated documentation~~
-   [ ] ~~Added/updated unit tests~~ - can't be verified in unit tests
-   [x] Added/updated E2E tests
