### PR TITLE
[CCUBE-2278][V3] add control mode for accordion item

### DIFF
--- a/src/accordion/accordion-item.tsx
+++ b/src/accordion/accordion-item.tsx
@@ -35,6 +35,7 @@ function Component(
         className,
         id,
         expanded: expandedControlled,
+        onExpandChange,
         "data-testid": testId = "accordion-item",
     }: AccordionItemProps,
     ref: React.Ref<AccordionItemHandle>
@@ -53,10 +54,14 @@ function Component(
     const [hasFirstLoad, setHasFirstLoad] = useState<boolean>(false);
     const internalId = useId();
     const contentId = `${internalId}-content`;
-    const resizeDetector = useResizeDetector();
-    const expanded =
-        itemState[internalId] ??
-        (collapsible ? expandedControlled ?? expandAll : true); // the initial value
+    const { height, ref: resizeDetectorRef } = useResizeDetector();
+    const isControlled = onExpandChange !== undefined;
+    const expanded = isControlled
+        ? collapsible
+            ? expandedControlled ?? false
+            : true
+        : itemState[internalId] ??
+          (collapsible ? expandedControlled ?? expandAll : true);
 
     useImperativeHandle(
         ref,
@@ -65,10 +70,18 @@ function Component(
                 elementRef.current!,
                 {
                     expand(): void {
-                        onItemStateChange(internalId, true);
+                        if (isControlled) {
+                            onExpandChange?.(true);
+                        } else {
+                            onItemStateChange(internalId, true);
+                        }
                     },
                     collapse(): void {
-                        onItemStateChange(internalId, false);
+                        if (isControlled) {
+                            onExpandChange?.(false);
+                        } else {
+                            onItemStateChange(internalId, false);
+                        }
                     },
                     isExpanded() {
                         return expanded;
@@ -87,12 +100,34 @@ function Component(
         return () => onItemDeregister?.(internalId);
     }, []);
 
+    // Controlled mode: keep parent itemState in sync so "Show all"/"Hide all" label stays accurate
     useEffect(() => {
-        onItemStateChange(
-            internalId,
-            collapsible ? expandedControlled ?? expandAll : true
-        );
+        if (isControlled) {
+            onItemStateChange(
+                internalId,
+                collapsible ? expandedControlled ?? false : true
+            );
+        }
+    }, [expandedControlled, collapsible]);
+
+    // Uncontrolled mode: sync state when expandAll button or the hint prop changes
+    useEffect(() => {
+        if (!isControlled) {
+            onItemStateChange(
+                internalId,
+                collapsible ? expandedControlled ?? expandAll : true
+            );
+        }
     }, [expandAll, expandedControlled, collapsible]);
+
+    // Controlled mode: forward expandAll button changes to the caller
+    useEffect(() => {
+        if (!isControlled || !hasFirstLoad) return;
+        const next = collapsible ? expandAll : true;
+        if (next !== expandedControlled) {
+            onExpandChange?.(next);
+        }
+    }, [expandAll]);
 
     // =========================================================================
     // EVENT HANDLERS
@@ -100,7 +135,11 @@ function Component(
 
     const handleExpandCollapseClick = (event: React.MouseEvent) => {
         event.preventDefault();
-        onItemStateChange(internalId, !expanded);
+        if (isControlled) {
+            onExpandChange?.(!expanded);
+        } else {
+            onItemStateChange(internalId, !expanded);
+        }
     };
 
     // =========================================================================
@@ -108,7 +147,7 @@ function Component(
     // =========================================================================
     // React spring animation configuration
     const resizeHeight = {
-        height: expanded ? resizeDetector.height : 0,
+        height: expanded ? height : 0,
     };
     const expandableStyles = useSpring(resizeHeight);
 
@@ -121,7 +160,7 @@ function Component(
                 inert={inertValue(!expanded)}
             >
                 <ContentContainer
-                    ref={resizeDetector.ref}
+                    ref={resizeDetectorRef}
                     data-testid="content-container"
                 >
                     {children}

--- a/src/accordion/types.ts
+++ b/src/accordion/types.ts
@@ -32,6 +32,13 @@ export interface AccordionItemProps {
     className?: string | undefined;
     type?: AccordionItemType | undefined;
     collapsible?: boolean | undefined;
+    /**
+     * Called when the user toggles this item or the parent "Show all" / "Hide all"
+     * button fires. When provided, the item enters **controlled mode** — the caller
+     * must update the `expanded` prop in response. Without this prop, the item
+     * manages its own state internally (uncontrolled mode).
+     */
+    onExpandChange?: ((expanded: boolean) => void) | undefined;
 }
 
 export interface AccordionItemApi {

--- a/stories/accordion/accordion.mdx
+++ b/stories/accordion/accordion.mdx
@@ -41,6 +41,14 @@ If you do not require a expand/collapse all button in the `Accordion`, use `enab
 
 <Canvas of={AccordionStories.NoExpandCollapseAll} />
 
+## Controlled mode
+
+Pass `expanded` and `onExpandChange` to an `Accordion.Item` to fully control its
+expanded state. The caller is responsible for updating the state when
+`onExpandChange` is invoked.
+
+<Canvas of={AccordionStories.ControlledMode} />
+
 ## Accessibility
 
 Depending on where the `Accordion` is used, set a custom `headingLevel` to

--- a/stories/accordion/accordion.stories.tsx
+++ b/stories/accordion/accordion.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-webpack5";
+import { useState } from "react";
 import { Accordion } from "src/accordion";
 import { Typography } from "src/typography";
 
@@ -168,6 +169,58 @@ export const NoExpandCollapseAll: StoryObj<Component> = {
                         .
                     </Typography.BodyBL>
                 </Accordion.Item>
+            </Accordion>
+        );
+    },
+};
+
+export const ControlledMode: StoryObj<Component> = {
+    render: (_args) => {
+        const items = [
+            {
+                title: "This is the first item",
+                detail: (
+                    <Typography.BodyBL>
+                        Lorem ipsum dolor sit amet
+                    </Typography.BodyBL>
+                ),
+            },
+            {
+                title: "This is the second item",
+                detail: (
+                    <Typography.BodyBL>
+                        Lorem ipsum dolor sit amet
+                    </Typography.BodyBL>
+                ),
+            },
+            {
+                title: "This is the third item",
+                detail: (
+                    <Typography.BodyBL>
+                        Lorem ipsum dolor sit amet
+                    </Typography.BodyBL>
+                ),
+            },
+        ];
+        const [expandedStates, setExpandedStates] = useState(() =>
+            items.map((_, index) => index === 0)
+        );
+        return (
+            <Accordion initialDisplay="collapse-all">
+                {items.map((item, index) => (
+                    <Accordion.Item
+                        key={`${item.title}-${index}`}
+                        title={item.title}
+                        expanded={expandedStates[index]}
+                        onExpandChange={(val) =>
+                            setExpandedStates((prev) =>
+                                prev.map((v, i) => (i === index ? val : v))
+                            )
+                        }
+                    >
+                        {item.detail}
+                    </Accordion.Item>
+                ))}
             </Accordion>
         );
     },

--- a/stories/accordion/props-table.tsx
+++ b/stories/accordion/props-table.tsx
@@ -133,6 +133,12 @@ const ACCORDION_ITEM_DATA: ApiTableSectionProps[] = [
                 propTypes: ["boolean"],
                 defaultValue: "true",
             },
+            {
+                name: "onExpandChange",
+                description:
+                    "Callback fired when the expanded state changes. When provided, the component operates in controlled mode.",
+                propTypes: ["(expanded: boolean) => void"],
+            },
         ],
     },
 ];

--- a/tests/accordion/accordion.spec.tsx
+++ b/tests/accordion/accordion.spec.tsx
@@ -1,4 +1,12 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import {
+    act,
+    fireEvent,
+    render,
+    screen,
+    waitFor,
+    within,
+} from "@testing-library/react";
+import { useState } from "react";
 import { Accordion } from "src/accordion";
 import { Typography } from "src/typography";
 
@@ -29,7 +37,9 @@ describe("Accordion", () => {
         expect(screen.getByTestId("item1")).toBeInTheDocument();
         expect(screen.getByTestId("item1-content")).toBeInTheDocument();
         expect(
-            screen.getByRole("button", { name: "Hide all" })
+            screen.getByRole("button", {
+                name: ACCORDION_HIDE_ALL_BUTTON_LABEL,
+            })
         ).toBeInTheDocument();
     });
 
@@ -79,7 +89,9 @@ describe("Accordion", () => {
                     </Accordion>
                 );
 
-                expect(getAccordionButton("Hide all")).toBeInTheDocument();
+                expect(
+                    getAccordionButton(ACCORDION_HIDE_ALL_BUTTON_LABEL)
+                ).toBeInTheDocument();
             });
 
             it("should render the button label as 'Show all' if it has been clicked", () => {
@@ -105,7 +117,7 @@ describe("Accordion", () => {
                 expect(button.innerHTML).toBe("<span>Show all</span>");
             });
 
-            it("should minimise all the children items if the button has been clicked", () => {
+            it("should minimise all the children items if the button has been clicked", async () => {
                 render(
                     <Accordion>
                         <Accordion.Item data-testid="item1" title="Item title">
@@ -121,22 +133,16 @@ describe("Accordion", () => {
                     </Accordion>
                 );
 
-                const button = getAccordionButton("Hide all");
+                const button = getAccordionButton(
+                    ACCORDION_HIDE_ALL_BUTTON_LABEL
+                );
 
                 act(() => {
                     fireEvent.click(button);
                 });
 
-                expect(
-                    screen.queryByTestId("item1-expandable-container")
-                ).toHaveStyle({
-                    height: 0,
-                });
-                expect(
-                    screen.queryByTestId("item2-expandable-container")
-                ).toHaveStyle({
-                    height: 0,
-                });
+                await expectItemCollapsed("item1");
+                await expectItemCollapsed("item2");
             });
         });
 
@@ -226,11 +232,7 @@ describe("Accordion", () => {
                 fireEvent.click(button);
             });
 
-            expect(
-                screen.getByTestId("item1-expandable-container")
-            ).toHaveStyle({
-                height: 0,
-            });
+            await expectItemCollapsed("item1");
         });
 
         it("should disable expand/collapse functionality if collapsible=false specified", () => {
@@ -257,6 +259,201 @@ describe("Accordion", () => {
             expect(
                 screen.queryByTestId("item1-expand-collapse-icon")
             ).not.toBeInTheDocument();
+        });
+    });
+
+    describe("Accordion.Item controlled mode (onExpandChange)", () => {
+        it("should call onExpandChange with the toggled value when item is clicked", () => {
+            const onExpandChange = jest.fn();
+
+            function TestComponent() {
+                const [isExpanded, setIsExpanded] = useState(false);
+                return (
+                    <Accordion>
+                        <Accordion.Item
+                            data-testid="item1"
+                            title="Item title"
+                            expanded={isExpanded}
+                            onExpandChange={(val) => {
+                                onExpandChange(val);
+                                setIsExpanded(val);
+                            }}
+                        >
+                            <Typography.BodyBL>
+                                {DEFAULT_TEXT_CONTENT}
+                            </Typography.BodyBL>
+                        </Accordion.Item>
+                    </Accordion>
+                );
+            }
+
+            render(<TestComponent />);
+
+            act(() => {
+                fireEvent.click(
+                    screen.getByTestId("item1-expand-collapse-button")
+                );
+            });
+
+            expect(onExpandChange).toHaveBeenCalledWith(true);
+
+            act(() => {
+                fireEvent.click(
+                    screen.getByTestId("item1-expand-collapse-button")
+                );
+            });
+
+            expect(onExpandChange).toHaveBeenCalledWith(false);
+        });
+
+        it("should not expand the item without the caller updating the expanded prop", async () => {
+            const onExpandChange = jest.fn();
+
+            render(
+                <Accordion>
+                    <Accordion.Item
+                        data-testid="item1"
+                        title="Item title"
+                        expanded={false}
+                        onExpandChange={onExpandChange}
+                    >
+                        <Typography.BodyBL>
+                            {DEFAULT_TEXT_CONTENT}
+                        </Typography.BodyBL>
+                    </Accordion.Item>
+                </Accordion>
+            );
+
+            await expectItemCollapsed("item1");
+
+            act(() => {
+                fireEvent.click(
+                    screen.getByTestId("item1-expand-collapse-button")
+                );
+            });
+
+            await expectItemCollapsed("item1");
+        });
+
+        it("should keep all items expanded when all are manually opened", async () => {
+            // Regression: expandAll auto-detection must not reset controlled items
+            function TestComponent() {
+                const [states, setStates] = useState([true, false, false]);
+                return (
+                    <Accordion
+                        enableExpandAll={false}
+                        initialDisplay="collapse-all"
+                    >
+                        {states.map((isExpanded, index) => (
+                            <Accordion.Item
+                                key={index}
+                                data-testid={`item${index + 1}`}
+                                title={`Item ${index + 1}`}
+                                expanded={isExpanded}
+                                onExpandChange={(val) =>
+                                    setStates((prev) =>
+                                        prev.map((v, i) =>
+                                            i === index ? val : v
+                                        )
+                                    )
+                                }
+                            >
+                                <Typography.BodyBL>
+                                    {DEFAULT_TEXT_CONTENT}
+                                </Typography.BodyBL>
+                            </Accordion.Item>
+                        ))}
+                    </Accordion>
+                );
+            }
+
+            render(<TestComponent />);
+
+            await expectItemExpanded("item1");
+            await expectItemCollapsed("item2");
+            await expectItemCollapsed("item3");
+
+            act(() => {
+                fireEvent.click(
+                    screen.getByTestId("item2-expand-collapse-button")
+                );
+            });
+            act(() => {
+                fireEvent.click(
+                    screen.getByTestId("item3-expand-collapse-button")
+                );
+            });
+
+            await expectItemExpanded("item1");
+            await expectItemExpanded("item2");
+            await expectItemExpanded("item3");
+        });
+
+        it("should call onExpandChange when Show all / Hide all is clicked", async () => {
+            const onExpandChange1 = jest.fn();
+            const onExpandChange2 = jest.fn();
+
+            function TestComponent() {
+                const [states, setStates] = useState([false, false]);
+                return (
+                    <Accordion initialDisplay="collapse-all">
+                        <Accordion.Item
+                            data-testid="item1"
+                            title="Item 1"
+                            expanded={states[0]}
+                            onExpandChange={(val) => {
+                                onExpandChange1(val);
+                                setStates((prev) => [val, prev[1]]);
+                            }}
+                        >
+                            <Typography.BodyBL>
+                                {DEFAULT_TEXT_CONTENT}
+                            </Typography.BodyBL>
+                        </Accordion.Item>
+                        <Accordion.Item
+                            data-testid="item2"
+                            title="Item 2"
+                            expanded={states[1]}
+                            onExpandChange={(val) => {
+                                onExpandChange2(val);
+                                setStates((prev) => [prev[0], val]);
+                            }}
+                        >
+                            <Typography.BodyBL>
+                                {DEFAULT_TEXT_CONTENT}
+                            </Typography.BodyBL>
+                        </Accordion.Item>
+                    </Accordion>
+                );
+            }
+
+            render(<TestComponent />);
+
+            act(() => {
+                fireEvent.click(
+                    screen.getByRole("button", {
+                        name: ACCORDION_EXPAND_ALL_BUTTON_LABEL,
+                    })
+                );
+            });
+
+            await waitFor(() => {
+                expect(onExpandChange1).toHaveBeenCalledWith(true);
+                expect(onExpandChange2).toHaveBeenCalledWith(true);
+            });
+
+            act(() => {
+                fireEvent.click(
+                    screen.getByRole("button", {
+                        name: ACCORDION_HIDE_ALL_BUTTON_LABEL,
+                    })
+                );
+            });
+
+            await waitFor(() => {
+                expect(onExpandChange1).toHaveBeenCalledWith(false);
+                expect(onExpandChange2).toHaveBeenCalledWith(false);
+            });
         });
     });
 
@@ -310,8 +507,30 @@ const getAccordionButton = (label: string) => {
     return screen.getByRole("button", { name: label });
 };
 
+const expectItemExpanded = async (testId: string) => {
+    const item = screen.getByTestId(testId);
+    const heading = within(item).getByTestId(
+        `${testId}-expand-collapse-button`
+    );
+    await waitFor(() => {
+        expect(heading).toHaveAttribute("aria-expanded", "true");
+    });
+};
+
+const expectItemCollapsed = async (testId: string) => {
+    const item = screen.getByTestId(testId);
+    const heading = within(item).getByTestId(
+        `${testId}-expand-collapse-button`
+    );
+    await waitFor(() => {
+        expect(heading).toHaveAttribute("aria-expanded", "false");
+    });
+};
+
 // =============================================================================
 // CONSTANTS
 // =============================================================================
 const DEFAULT_TEXT_CONTENT = "This is some default text";
 const ACCORDION_BUTTON_ID = "accordion-expand-collapse-button";
+const ACCORDION_HIDE_ALL_BUTTON_LABEL = "Hide all";
+const ACCORDION_EXPAND_ALL_BUTTON_LABEL = "Show all";


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)
-   [ ] Documentation (change to documentation, comments or API descriptions)
-   [ ] Tests (improvements to unit tests or E2E tests)
-   [ ] Other (technical improvements, refactoring, or changes that don't fall into the above categories)

**Description of changes**

-   Link to [ticket](https://sgtechstack.atlassian.net/browse/CCUBE-2278)
-   Cherry picks https://github.com/LifeSG/react-design-system/pull/1444 to v3
- Tweaked detection of item collapse/expand state in unit tests as the actual style is not computed

**Checklist**

<!-- Put an `x` in items that apply -->

-   [x] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md) and [CONVENTIONS.md](https://github.com/LifeSG/react-design-system/blob/master/CONVENTIONS.md)
-   [x] Looks good on mobile and tablet
-   [x] Updated documentation
-   [x] Added/updated unit tests
-   [ ] ~~Added/updated E2E tests~~
